### PR TITLE
Update Calendar.qml to fix localization

### DIFF
--- a/modules/dashboard/dash/Calendar.qml
+++ b/modules/dashboard/dash/Calendar.qml
@@ -63,7 +63,9 @@ Column {
                     anchors.centerIn: parent
 
                     horizontalAlignment: Text.AlignHCenter
-                    text: grid.locale.toString(day.model.date, "d")
+                    
+                     // locale-aware digits, no timezone headaches
+                    text: grid.locale.toString(model.day)
                     color: day.model.today ? Colours.palette.m3onPrimary : day.model.month === grid.month ? Colours.palette.m3onSurfaceVariant : Colours.palette.m3outline
                 }
             }


### PR DESCRIPTION
Calendar numbers were a day behind in negative UTC timezones. Fixed for localization purposes.

Fixes #20 