### PR TITLE
Battery Default Width Issue

### DIFF
--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -13,7 +13,7 @@ Singleton {
         property int innerHeight: 30
         property int windowPreviewSize: 400
         property int trayMenuWidth: 300
-        property int batteryWidth: 200
+        property int batteryWidth: 250
     }
 
     component Workspaces: QtObject {


### PR DESCRIPTION
Battery Width Property Being set to:
```
property int batteryWidth: 200`
```
is too cramped for the details to display properly.

![image](https://github.com/user-attachments/assets/8535f908-6533-4e42-b016-af015738f34d) ![image](https://github.com/user-attachments/assets/e66099b0-70c6-42c7-ba44-6b6e903c3a3c)


With Battery Width Adjusted to 250
```
property int batteryWidth: 250
```
now this will allow the contents to show properly while hovering in battery section.

![image](https://github.com/user-attachments/assets/de9e0ea5-ba98-4700-929c-336568c213a0) ![image](https://github.com/user-attachments/assets/6504dd16-473a-4db7-b42a-d9ddb678709e)