### PR TITLE
Add custom shortcut for launcher, dashboard and osd all in one

### DIFF
--- a/modules/Shortcuts.qml
+++ b/modules/Shortcuts.qml
@@ -9,46 +9,20 @@ Scope {
     property bool launcherInterrupted
 
     CustomShortcut {
+        name: "showall"
+        description: "Toggle launcher, dashboard and osd"
+        onPressed: {
+            const v = Visibilities.getForActive();
+            v.launcher = v.dashboard = v.osd = !(v.launcher || v.dashboard || v.osd);
+        }
+    }
+
+    CustomShortcut {
         name: "session"
         description: "Toggle session menu"
         onPressed: {
             const visibilities = Visibilities.getForActive();
             visibilities.session = !visibilities.session;
-        }
-    }
-
-    CustomShortcut {
-        name: "showall"
-        description: "Toggle launcher & Dashboard & OSD"
-        onPressed: root.launcherInterrupted = false
-        onReleased: {
-            if (!root.launcherInterrupted) {
-                const visibilities = Visibilities.getForActive();
-                
-                const showLauncher = !visibilities.launcher;
-                visibilities.launcher = showLauncher;
-                
-                if (showLauncher) {
-                    // Show session first
-                    visibilities.session = false;
-                    
-                    // Then show dashboard and OSD with a tiny delay
-                    Qt.callLater(() => {
-                        visibilities.dashboard = true;
-                        visibilities.osd = true;
-                        
-                        // Force focus back to launcher after all panels are shown
-                        Qt.callLater(() => {
-                            visibilities.launcher = true; // Re-trigger launcher focus
-                        });
-                    });
-                } else {
-                    visibilities.session = false;
-                    visibilities.dashboard = false;
-                    visibilities.osd = false;
-                }
-            }
-            root.launcherInterrupted = false;
         }
     }
 

--- a/modules/drawers/Interactions.qml
+++ b/modules/drawers/Interactions.qml
@@ -16,8 +16,8 @@ MouseArea {
 
     property bool osdHovered
     property point dragStart
-    property bool dashboardShortcutActive: false
-    property bool osdShortcutActive: false
+    property bool dashboardShortcutActive
+    property bool osdShortcutActive
 
     function withinPanelHeight(panel: Item, x: real, y: real): bool {
         const panelY = BorderConfig.thickness + panel.y;
@@ -54,7 +54,7 @@ MouseArea {
     onPositionChanged: ({x, y}) => {
         // Show osd on hover
         const showOsd = inRightPanel(panels.osd, x, y);
-        
+
         // Always update visibility based on hover if not in shortcut mode
         if (!osdShortcutActive) {
             visibilities.osd = showOsd;
@@ -76,7 +76,7 @@ MouseArea {
 
         // Show dashboard on hover
         const showDashboard = inTopPanel(panels.dashboard, x, y);
-        
+
         // Always update visibility based on hover if not in shortcut mode
         if (!dashboardShortcutActive) {
             visibilities.dashboard = showDashboard;
@@ -100,51 +100,51 @@ MouseArea {
 
     // Monitor individual visibility changes
     Connections {
-        target: visibilities
-        
+        target: root.visibilities
+
         function onLauncherChanged() {
             // If launcher is hidden, clear shortcut flags for dashboard and OSD
-            if (!visibilities.launcher) {
-                dashboardShortcutActive = false;
-                osdShortcutActive = false;
-                
+            if (!root.visibilities.launcher) {
+                root.dashboardShortcutActive = false;
+                root.osdShortcutActive = false;
+
                 // Also hide dashboard and OSD if they're not being hovered
-                const inDashboardArea = inTopPanel(panels.dashboard, mouseX, mouseY);
-                const inOsdArea = inRightPanel(panels.osd, mouseX, mouseY);
-                
+                const inDashboardArea = root.inTopPanel(root.panels.dashboard, root.mouseX, root.mouseY);
+                const inOsdArea = root.inRightPanel(root.panels.osd, root.mouseX, root.mouseY);
+
                 if (!inDashboardArea) {
-                    visibilities.dashboard = false;
+                    root.visibilities.dashboard = false;
                 }
                 if (!inOsdArea) {
-                    visibilities.osd = false;
-                    osdHovered = false;
+                    root.visibilities.osd = false;
+                    root.osdHovered = false;
                 }
             }
         }
-        
+
         function onDashboardChanged() {
-            if (visibilities.dashboard) {
+            if (root.visibilities.dashboard) {
                 // Dashboard became visible, immediately check if this should be shortcut mode
-                const inDashboardArea = inTopPanel(panels.dashboard, mouseX, mouseY);
+                const inDashboardArea = root.inTopPanel(root.panels.dashboard, root.mouseX, root.mouseY);
                 if (!inDashboardArea) {
-                    dashboardShortcutActive = true;
+                    root.dashboardShortcutActive = true;
                 }
             } else {
                 // Dashboard hidden, clear shortcut flag
-                dashboardShortcutActive = false;
+                root.dashboardShortcutActive = false;
             }
         }
-        
+
         function onOsdChanged() {
-            if (visibilities.osd) {
+            if (root.visibilities.osd) {
                 // OSD became visible, immediately check if this should be shortcut mode
-                const inOsdArea = inRightPanel(panels.osd, mouseX, mouseY);
+                const inOsdArea = root.inRightPanel(root.panels.osd, root.mouseX, root.mouseY);
                 if (!inOsdArea) {
-                    osdShortcutActive = true;
+                    root.osdShortcutActive = true;
                 }
             } else {
                 // OSD hidden, clear shortcut flag
-                osdShortcutActive = false;
+                root.osdShortcutActive = false;
             }
         }
     }


### PR DESCRIPTION
This PR introduces a new global shortcut, that opens launcher, dashboard and osd simultaniously. The default hover-to-show is not affected, so this is merely an option.

Showcase:

https://github.com/user-attachments/assets/f0d335cf-0647-4e0b-9b2a-9831b5d4cbde