### PR TITLE
drawers: fix exclusion zones deadzone

### DIFF
--- a/modules/drawers/Exclusions.qml
+++ b/modules/drawers/Exclusions.qml
@@ -15,21 +15,26 @@ Scope {
         anchors.left: true
         exclusiveZone: root.bar.implicitWidth
         implicitHeight: 0
+        implicitWidth: 10
     }
 
     ExclusionZone {
         anchors.top: true
         implicitWidth: 0
+        implicitHeight: 10
     }
 
     ExclusionZone {
         anchors.right: true
         implicitHeight: 0
+        implicitWidth: 10
     }
 
     ExclusionZone {
         anchors.bottom: true
         implicitWidth: 0
+        implicitHeight: 10
+
     }
 
     component ExclusionZone: StyledWindow {

--- a/modules/drawers/Exclusions.qml
+++ b/modules/drawers/Exclusions.qml
@@ -13,25 +13,29 @@ Scope {
 
     ExclusionZone {
         anchors.left: true
-        exclusiveZone: root.bar.implicitWidth - BorderConfig.thickness
+        exclusiveZone: root.bar.implicitWidth
+        implicitHeight: 0
     }
 
     ExclusionZone {
         anchors.top: true
+        implicitWidth: 0
     }
 
     ExclusionZone {
         anchors.right: true
+        implicitHeight: 0
     }
 
     ExclusionZone {
         anchors.bottom: true
+        implicitWidth: 0
+
     }
 
     component ExclusionZone: StyledWindow {
         screen: root.screen
-        implicitHeight: 0
-        implicitWidth: 0
         name: "border-exclusion"
+        exclusiveZone: BorderConfig.thickness
     }
 }

--- a/modules/drawers/Exclusions.qml
+++ b/modules/drawers/Exclusions.qml
@@ -30,7 +30,6 @@ Scope {
     ExclusionZone {
         anchors.bottom: true
         implicitWidth: 0
-
     }
 
     component ExclusionZone: StyledWindow {

--- a/modules/drawers/Exclusions.qml
+++ b/modules/drawers/Exclusions.qml
@@ -13,7 +13,7 @@ Scope {
 
     ExclusionZone {
         anchors.left: true
-        exclusiveZone: root.bar.implicitWidth
+        exclusiveZone: root.bar.implicitWidth - BorderConfig.thickness
     }
 
     ExclusionZone {

--- a/modules/drawers/Exclusions.qml
+++ b/modules/drawers/Exclusions.qml
@@ -30,7 +30,8 @@ Scope {
 
     component ExclusionZone: StyledWindow {
         screen: root.screen
+        width: 0
+        height: 0
         name: "border-exclusion"
-        exclusiveZone: BorderConfig.thickness
     }
 }

--- a/modules/drawers/Exclusions.qml
+++ b/modules/drawers/Exclusions.qml
@@ -30,8 +30,8 @@ Scope {
 
     component ExclusionZone: StyledWindow {
         screen: root.screen
-        width: 0
-        height: 0
+        implicitHeight: 0
+        implicitWidth: 0
         name: "border-exclusion"
     }
 }


### PR DESCRIPTION
This PR fixes the bug, where exclusion zones created a deadzone, by setting the width and height of the StyledWindow.

Tested on my own weird version, and a fresh, default copy.
Could not test [what happens on a config where this was not an issue to begin with](https://github.com/caelestia-dots/shell/issues/26#issuecomment-2973115876)

Fixes https://github.com/caelestia-dots/shell/issues/26