### PR TITLE
feat: toggle notifications

### DIFF
--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -22,6 +22,9 @@ Item {
         const th = tray.implicitHeight;
         const trayItems = tray.items;
 
+        const no = statusIconsInner.notificationsstatus;
+        const noy = statusIcons.y + statusIconsInner.y + no.y - spacing / 2;
+
         const n = statusIconsInner.network;
         const ny = statusIcons.y + statusIconsInner.y + n.y - spacing / 2;
 
@@ -41,6 +44,10 @@ Item {
 
             popouts.currentName = `traymenu${index}`;
             popouts.currentCenter = Qt.binding(() => tray.y + item.y + item.implicitHeight / 2);
+            popouts.hasCurrent = true;
+        } else if (y >= noy && y <= noy + no.implicitHeight + spacing) {
+            popouts.currentName = "notificationsstatus";
+            popouts.currentCenter = Qt.binding(() => statusIcons.y + statusIconsInner.y + no.y + no.implicitHeight / 2);
             popouts.hasCurrent = true;
         } else if (y >= ny && y <= ny + n.implicitHeight + spacing) {
             popouts.currentName = "network";

--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -11,23 +11,36 @@ Item {
 
     property color colour: Colours.palette.m3secondary
 
+    readonly property Item notificationsstatus: notificationsstatus
     readonly property Item network: network
     readonly property real bs: bluetooth.y
     readonly property real be: repeater.count > 0 ? devices.y + devices.implicitHeight : bluetooth.y + bluetooth.implicitHeight
     readonly property Item battery: battery
 
     clip: true
-    implicitWidth: Math.max(network.implicitWidth, bluetooth.implicitWidth, devices.implicitWidth, battery.implicitWidth)
-    implicitHeight: network.implicitHeight + bluetooth.implicitHeight + bluetooth.anchors.topMargin + (repeater.count > 0 ? devices.implicitHeight + devices.anchors.topMargin : 0) + battery.implicitHeight + battery.anchors.topMargin
+    implicitWidth: Math.max(notificationsstatus.implicitWidth, network.implicitWidth, bluetooth.implicitWidth, devices.implicitWidth, battery.implicitWidth)
+    implicitHeight: notificationsstatus.implicitHeight + network.implicitHeight + network.anchors.topMargin + bluetooth.implicitHeight + bluetooth.anchors.topMargin + (repeater.count > 0 ? devices.implicitHeight + devices.anchors.topMargin : 0) + battery.implicitHeight + battery.anchors.topMargin
+    
+    MaterialIcon {
+        id: notificationsstatus
+
+        animate: true
+        text: Notifs.notificationsEnabled ? "notifications" : "notifications_off"
+        color: root.colour
+
+        anchors.horizontalCenter: parent.horizontalCenter
+    }
 
     MaterialIcon {
         id: network
 
+        anchors.horizontalCenter: notificationsstatus.horizontalCenter
+        anchors.top: notificationsstatus.bottom
+        anchors.topMargin: Appearance.spacing.small
+
         animate: true
         text: Network.active ? Icons.getNetworkIcon(Network.active.strength ?? 0) : "wifi_off"
         color: root.colour
-
-        anchors.horizontalCenter: parent.horizontalCenter
     }
 
     MaterialIcon {

--- a/modules/bar/popouts/Content.qml
+++ b/modules/bar/popouts/Content.qml
@@ -34,6 +34,11 @@ Item {
         }
 
         Popout {
+            name: "notificationsstatus"
+            source: "NotificationsStatus.qml"
+        }
+
+        Popout {
             name: "network"
             source: "Network.qml"
         }

--- a/modules/bar/popouts/NotificationsStatus.qml
+++ b/modules/bar/popouts/NotificationsStatus.qml
@@ -1,0 +1,14 @@
+import "root:/widgets"
+import "root:/services"
+import "root:/config"
+import QtQuick
+
+Column {
+    id: root
+
+    spacing: Appearance.spacing.normal
+
+    StyledText {
+        text: Notifs.notificationsEnabled ? qsTr("Notifications are enabled") : qsTr("Notifications are disabled")
+    }
+}

--- a/services/Notifs.qml
+++ b/services/Notifs.qml
@@ -13,6 +13,8 @@ Singleton {
 
     readonly property list<Notif> list: []
     readonly property list<Notif> popups: list.filter(n => n.popup)
+    property var pending: []
+    property bool notificationsEnabled: true
 
     NotificationServer {
         id: server
@@ -26,11 +28,33 @@ Singleton {
 
         onNotification: notif => {
             notif.tracked = true;
+            if (root.notificationsEnabled) {
+                root.list.push(notifComp.createObject(root, {
+                    popup: true,
+                    notification: notif
+                }));
+            } else {
+                root.pending.push(notif);
+            }
+        }
+    }
 
-            root.list.push(notifComp.createObject(root, {
-                popup: true,
-                notification: notif
-            }));
+    function toggleNotifications(newState) {
+        if (root.notificationsEnabled === newState)
+            return;
+        if (!newState) {
+            for (const notif of root.list)
+                notif.popup = false;
+        }
+        root.notificationsEnabled = newState;
+        if (newState) {
+            for (const notif of root.pending) {
+                root.list.push(notifComp.createObject(root, {
+                    popup: true,
+                    notification: notif
+                }));
+            }
+            root.pending = [];
         }
     }
 
@@ -41,6 +65,12 @@ Singleton {
             for (const notif of root.list)
                 notif.popup = false;
         }
+    }
+
+    CustomShortcut {
+        name: "toggleNotifs"
+        description: "Toggle notifications enabled/disabled"
+        onPressed: root.toggleNotifications(!root.notificationsEnabled);
     }
 
     IpcHandler {


### PR DESCRIPTION
# Notification Toggle

This PR enables the user to temporarily toggle notifications on/off.

1. Turning notifications off will remove all currently visible notifications _forever_.
2. While notifications are turned off, they are added to a "pending" queue.
3. Turning notifications back on will release to pending notifications.

The status is displayed in the StatusIcons.

### Demo:
https://github.com/user-attachments/assets/c5cef7cb-920c-4f88-9bdc-cb4b5bf59ec8

Tested on personal & fresh copy, does not seem to break anything and usage is purely optional.