### PR TITLE
refactor: CPU temperature regex retrieval multivendor

### DIFF
--- a/services/SystemUsage.qml
+++ b/services/SystemUsage.qml
@@ -160,7 +160,11 @@ Singleton {
             })
         stdout: StdioCollector {
             onStreamFinished: {
-                const cpuTemp = text.match(/Package id [0-9]+: *((\+|-)[0-9.]+)(°| )C/);
+		const cpuTemp = text.match(/(?:Package id [0-9]+|Tdie):\s+((\+|-)[0-9.]+)(°| )C/);
+		if (!cpuTemp) {
+		    // If AMD Tdie pattern failed, try fallback on Tctl
+		    const cpuTemp = text.match(/Tctl:\s+((\+|-)[0-9.]+)(°| )C/);
+		}
                 if (cpuTemp)
                     root.cpuTemp = parseFloat(cpuTemp[1]);
 


### PR DESCRIPTION
### Multivendor CPU temperature retrieval

This PR enables the CPU temperature to be retrieved depending on the driver. Actually some CPUs are not supported from the code.

**Added**: k10temp-pci-00c3 driver family support

Using a simple non capturing group in regex to catch either `Package id` or `Tdie` line in sensors output.

As some AMD CPUs have no Tdie line in sensors output, depending on the model, we can fallback to Tctl instead. (see #138 for instance).

Use Tctl as a fallback only if Tdie not existing for AMD, as Tdie is preferred and more accurate. Tctl is using an offset on the temperature on some models.

Based on: https://www.hwinfo.com/forum/threads/cpu-temp-sensors-explanation.5597/

Tested on a fresh local installation, working.

sensors output:

```
◄ 0s ◎ sensors                                                                                   □ .config/caelestia 23:14
amdgpu-pci-2900
Adapter: PCI adapter
vddgfx:      950.00 mV 
fan1:        1232 RPM  (min =  300 RPM, max = 3300 RPM)
edge:         +52.0°C  (crit = +85.0°C, hyst = -273.1°C)
                       (emerg = +90.0°C)
junction:     +53.0°C  (crit = +105.0°C, hyst = -273.1°C)
                       (emerg = +110.0°C)
mem:          +53.0°C  (crit = +95.0°C, hyst = -273.1°C)
                       (emerg = +100.0°C)
PPT:          31.00 W  (cap = 240.00 W)
pwm1:              0%
sclk:         987 MHz 
mclk:         945 MHz 

nvme-pci-0100
Adapter: PCI adapter
Composite:    +45.9°C  (low  = -273.1°C, high = +81.8°C)
                       (crit = +84.8°C)
Sensor 1:     +45.9°C  (low  = -273.1°C, high = +65261.8°C)
Sensor 2:     +51.9°C  (low  = -273.1°C, high = +65261.8°C)

k10temp-pci-00c3
Adapter: PCI adapter
Tctl:         +57.2°C  
Tdie:         +47.2°C  
```

Result:

![swappy-20250623_233035](https://github.com/user-attachments/assets/e0f09d5f-23db-4212-960b-26dda4af0409)
