### PR TITLE
[typo] cpuTemp bad declaration

### DIFF
--- a/services/SystemUsage.qml
+++ b/services/SystemUsage.qml
@@ -160,10 +160,10 @@ Singleton {
             })
         stdout: StdioCollector {
             onStreamFinished: {
-		const cpuTemp = text.match(/(?:Package id [0-9]+|Tdie):\s+((\+|-)[0-9.]+)(°| )C/);
+		let cpuTemp = text.match(/(?:Package id [0-9]+|Tdie):\s+((\+|-)[0-9.]+)(°| )C/);
 		if (!cpuTemp) {
 		    // If AMD Tdie pattern failed, try fallback on Tctl
-		    const cpuTemp = text.match(/Tctl:\s+((\+|-)[0-9.]+)(°| )C/);
+		    cpuTemp = text.match(/Tctl:\s+((\+|-)[0-9.]+)(°| )C/);
 		}
                 if (cpuTemp)
                     root.cpuTemp = parseFloat(cpuTemp[1]);


### PR DESCRIPTION
As the variable cpuTemp can now be used later in the if block for the fallback, need to change the declaration so that the variable is unique and used in two different blocks.

Const will redeclare it.. My bad on this

Tested to be sure the fallback works, with setting a bad value in the previous block to get sure to use the fallback. Working

I need a coffee..