### PR TITLE
feat: Added Fahrenheit to Weather Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ All configuration options are in `~/.config/caelestia/shell.json`.
     "dashboard": {
         "mediaUpdateInterval": 500,
         "visualiserBars": 45,
-        "weatherLocation": "10,10"
+        "weatherLocation": "10,10",
+        "useFahrenheit": false,
     },
     "launcher": {
         "actionPrefix": ">",

--- a/config/DashboardConfig.qml
+++ b/config/DashboardConfig.qml
@@ -4,6 +4,7 @@ JsonObject {
     property int mediaUpdateInterval: 500
     property int visualiserBars: 45
     property string weatherLocation: "" // A lat,long pair, e.g. "37.8267,-122.4233"
+    property bool useFahrenheit: false
 
     property JsonObject sizes: JsonObject {
         readonly property int tabIndicatorHeight: 3

--- a/modules/dashboard/dash/Weather.qml
+++ b/modules/dashboard/dash/Weather.qml
@@ -38,7 +38,7 @@ Item {
             anchors.horizontalCenter: parent.horizontalCenter
 
             animate: true
-            text: `${Weather.temperature}°C`
+            text: Weather.temperature
             color: Colours.palette.m3primary
             font.pointSize: Appearance.font.size.extraLarge
             font.weight: 500

--- a/modules/dashboard/dash/Weather.qml
+++ b/modules/dashboard/dash/Weather.qml
@@ -38,7 +38,7 @@ Item {
             anchors.horizontalCenter: parent.horizontalCenter
 
             animate: true
-            text: Weather.temperature
+            text: Config.dashboard.useFahrenheit ? Weather.tempF : Weather.tempC
             color: Colours.palette.m3primary
             font.pointSize: Appearance.font.size.extraLarge
             font.weight: 500

--- a/modules/lock/WeatherInfo.qml
+++ b/modules/lock/WeatherInfo.qml
@@ -40,7 +40,7 @@ RowLayout {
             Layout.fillWidth: true
 
             animate: true
-            text: `${Weather.temperature}°C`
+            text: Weather.temperature
             color: Colours.palette.m3primary
             horizontalAlignment: Text.AlignHCenter
             font.pointSize: Appearance.font.size.extraLarge

--- a/modules/lock/WeatherInfo.qml
+++ b/modules/lock/WeatherInfo.qml
@@ -40,7 +40,7 @@ RowLayout {
             Layout.fillWidth: true
 
             animate: true
-            text: Weather.temperature
+            text: Config.dashboard.useFahrenheit ? Weather.tempF : Weather.tempC
             color: Colours.palette.m3primary
             horizontalAlignment: Text.AlignHCenter
             font.pointSize: Appearance.font.size.extraLarge

--- a/services/Weather.qml
+++ b/services/Weather.qml
@@ -9,13 +9,12 @@ Singleton {
     id: root
 
     property string loc
-    property bool useFahrenheit 
     property string icon
     property string description
-    property string temperature
+    property string tempC: "0°C"
+    property string tempF: "0°F"
 
     function reload(): void {
-        useFahrenheit = Config.dashboard.useFahrenheit
         if (Config.dashboard.weatherLocation)
             loc = Config.dashboard.weatherLocation;
         else if (!loc || timer.elapsed() > 900)
@@ -29,7 +28,8 @@ Singleton {
         const json = JSON.parse(text).current_condition[0];
         icon = Icons.getWeatherIcon(json.weatherCode);
         description = json.weatherDesc[0].value;
-        temperature = useFahrenheit ? `${parseFloat(json.temp_F)}°F` : `${parseFloat(json.temp_C)}°C`;
+        tempC = `${parseFloat(json.temp_C)}°C`;
+        tempF = `${parseFloat(json.temp_F)}°F`;
     })
 
     Component.onCompleted: reload()

--- a/services/Weather.qml
+++ b/services/Weather.qml
@@ -9,11 +9,13 @@ Singleton {
     id: root
 
     property string loc
+    property bool useFahrenheit 
     property string icon
     property string description
-    property real temperature
+    property string temperature
 
     function reload(): void {
+        useFahrenheit = Config.dashboard.useFahrenheit
         if (Config.dashboard.weatherLocation)
             loc = Config.dashboard.weatherLocation;
         else if (!loc || timer.elapsed() > 900)
@@ -27,7 +29,7 @@ Singleton {
         const json = JSON.parse(text).current_condition[0];
         icon = Icons.getWeatherIcon(json.weatherCode);
         description = json.weatherDesc[0].value;
-        temperature = parseFloat(json.temp_C);
+        temperature = useFahrenheit ? `${parseFloat(json.temp_F)}°F` : `${parseFloat(json.temp_C)}°C`;
     })
 
     Component.onCompleted: reload()


### PR DESCRIPTION
 ## Key Changes
 1. Added `useFahrenheit` setting to DashboardConfig.qml (I realize this also applies to the lockscreen, but the `weatherLocation` was here so I figured I'd keep it consistent)
 2. Changed Weather service to use the `useFahrenheit` config
 3. Changed Weather service's `temperature` to be a string including the unit
 4. Updated Modules to directly use Weather's `temperature` string

## Testing
I tested this locally, seems to be working great.

## Notes
I couldn't any info on making PRs to this repo, let me know if you want a different format or anything else.