### PR TITLE
Put cava to sleep when no audio is playing

### DIFF
--- a/services/Cava.qml
+++ b/services/Cava.qml
@@ -12,7 +12,7 @@ Singleton {
 
     Process {
         running: true
-        command: ["sh", "-c", `printf '[general]\nframerate=60\nbars=${Config.dashboard.visualiserBars}\n[output]\nchannels=mono\nmethod=raw\nraw_target=/dev/stdout\ndata_format=ascii\nascii_max_range=100' | cava -p /dev/stdin`]
+        command: ["sh", "-c", `printf '[general]\nframerate=60\nbars=${Config.dashboard.visualiserBars}\nsleep_timer = 3\n[output]\nchannels=mono\nmethod=raw\nraw_target=/dev/stdout\ndata_format=ascii\nascii_max_range=100' | cava -p /dev/stdin`]
         stdout: SplitParser {
             onRead: data => {
                 if (root.refCount)


### PR DESCRIPTION
This pull requests lets cava sleep when audio has been silent for the last 3 seconds, using this option (snippet from example config found in cava github)
```
# Seconds with no input before cava goes to sleep mode. Cava will not perform FFT or drawing and
# only check for input once per second. Cava will wake up once input is detected. 0 = disable.
; sleep_timer = 0
```

Might not be a problem on modern systems, but for my old laptop its a must
