### PR TITLE
Support for high precision mouse scroll wheel

### DIFF
--- a/modules/bar/components/ActiveWindow.qml
+++ b/modules/bar/components/ActiveWindow.qml
@@ -21,12 +21,25 @@ Item {
         anchors.bottom: child.top
         anchors.left: parent.left
         anchors.right: parent.right
+        property int scrollAccumulatedY: 0
 
         onWheel: event => {
-            if (event.angleDelta.y > 0)
+            // Update accumulated scroll
+            if (Math.sign(event.angleDelta.y) !== Math.sign(scrollAccumulatedY)) {
+                scrollAccumulatedY = 0;
+            }
+            scrollAccumulatedY += event.angleDelta.y;
+
+            // Check for positive scroll (up)
+            if (scrollAccumulatedY >= 120 && event.angleDelta.y > 0) {
                 Audio.setVolume(Audio.volume + 0.1);
-            else if (event.angleDelta.y < 0)
+                scrollAccumulatedY = 0;
+            }
+            // Check for negative scroll (down)
+            else if (scrollAccumulatedY <= -120 && event.angleDelta.y < 0) {
                 Audio.setVolume(Audio.volume - 0.1);
+                scrollAccumulatedY = 0;
+            }
         }
     }
 
@@ -35,13 +48,25 @@ Item {
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.right: parent.right
+        property int scrollAccumulatedY: 0
 
         onWheel: event => {
-            const monitor = root.monitor;
-            if (event.angleDelta.y > 0)
+            // Update accumulated scroll
+            if (Math.sign(event.angleDelta.y) !== Math.sign(scrollAccumulatedY)) {
+                scrollAccumulatedY = 0;
+            }
+            scrollAccumulatedY += event.angleDelta.y;
+
+            // Check for positive scroll (up)
+            if (scrollAccumulatedY >= 120 && event.angleDelta.y > 0) {
                 monitor.setBrightness(monitor.brightness + 0.1);
-            else if (event.angleDelta.y < 0)
+                scrollAccumulatedY = 0;
+            }
+            // Check for negative scroll (down)
+            else if (scrollAccumulatedY <= -120 && event.angleDelta.y < 0) {
                 monitor.setBrightness(monitor.brightness - 0.1);
+                scrollAccumulatedY = 0;
+            }
         }
     }
 

--- a/modules/dashboard/Tabs.qml
+++ b/modules/dashboard/Tabs.qml
@@ -111,6 +111,8 @@ Item {
 
             cursorShape: Qt.PointingHandCursor
 
+            property int scrollAccumulatedY: 0
+
             onPressed: event => {
                 root.state.currentTab = tab.TabBar.index;
 
@@ -125,10 +127,21 @@ Item {
                 rippleAnim.restart();
             }
             onWheel: event => {
-                if (event.angleDelta.y < 0)
-                    root.state.currentTab = Math.min(root.state.currentTab + 1, bar.count - 1);
-                else if (event.angleDelta.y > 0)
+                // Update accumulated scroll
+                if (Math.sign(event.angleDelta.y) !== Math.sign(scrollAccumulatedY)) {
+                    scrollAccumulatedY = 0;
+                }
+                scrollAccumulatedY += event.angleDelta.y;
+                // Check for positive scroll (up)
+                if (scrollAccumulatedY >= 120 && event.angleDelta.y > 0) {
                     root.state.currentTab = Math.max(root.state.currentTab - 1, 0);
+                    scrollAccumulatedY = 0;
+                }
+                // Check for negative scroll (down)
+                else if (scrollAccumulatedY <= -120 && event.angleDelta.y < 0) {
+                    root.state.currentTab = Math.min(root.state.currentTab + 1, bar.count - 1);
+                    scrollAccumulatedY = 0;
+                }
             }
 
             SequentialAnimation {

--- a/widgets/StyledScrollBar.qml
+++ b/widgets/StyledScrollBar.qml
@@ -24,11 +24,24 @@ ScrollBar {
     MouseArea {
         z: -1
         anchors.fill: parent
+        property int scrollAccumulatedY: 0
         onWheel: event => {
-            if (event.angleDelta.y > 0)
+            // Update accumulated scroll
+            if (Math.sign(event.angleDelta.y) !== Math.sign(scrollAccumulatedY)) {
+                scrollAccumulatedY = 0;
+            }
+            scrollAccumulatedY += event.angleDelta.y;
+              
+            // Check for positive scroll (up)
+            if (scrollAccumulatedY >= 120 && event.angleDelta.y > 0) {
                 root.decrease();
-            else if (event.angleDelta.y < 0)
+                scrollAccumulatedY = 0;
+            }
+            // Check for negative scroll (down)
+            else if (scrollAccumulatedY <= -120 && event.angleDelta.y < 0) {
                 root.increase();
+                scrollAccumulatedY = 0;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR provides support for high resolution mouse scroll wheels which report less than 15 degree of change with each scroll wheel click (Regular mouse report 15 degrees). The current behavior on such high resolution scroll wheels is that scrolling is way too quick - jumping ahead by 4-5 steps (workspaces, tabs, etc) with each click.

More info in QT docs: https://doc.qt.io/qt-6/qwheelevent.html#angleDelta

This PR therefore fixes this too high wheel scroll speed on:
1. Scrolling through Tabs in the dashboard.
2. Scrolling on Vertical Scroll Bar in Launcher (not the actual list! - see below).
3. Scrolling through workspaces in the bar
    1. Scrolling is through the visible workspaces as indicated by `Config.bar.workspaces.shown` and wraps around both ends.
5. Scrolling up/down on ActiveWindow to get volume or brightness up/down.

For the 'native' QML Types like ListView and ScrollBar (wheel scrolling on OSD and Apps list in launcher) the current best workaround seem to be to set `QT_QUICK_FLICKABLE_WHEEL_DECELERATION` environment variable to something less that 15000.

Fixes #106 

References:
https://bugreports.qt.io/browse/QTBUG-120038
https://bugreports.qt.io/browse/QTBUG-129948
https://bugreports.qt.io/browse/QTBUG-116388