### PR TITLE
feat: add nix support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,137 @@
+{
+  "nodes": {
+    "caelestia-cli": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1752343654,
+        "narHash": "sha256-BNepVUBwyoQoF8kEnMfbyYJATmh7JM2gg3n5YCvC4MI=",
+        "owner": "pinksteven",
+        "repo": "caelestia-cli",
+        "rev": "6ba8a212c1634a5e74b64ecfab5f29a17d136d81",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pinksteven",
+        "repo": "caelestia-cli",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "quickshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1752382953,
+        "narHash": "sha256-kx1kWu0/LILp/QvwL7Fsk28bOjDEfuhwgtnHwMhNyIU=",
+        "ref": "refs/heads/master",
+        "rev": "bb206e3a19b48af987977d86ad77822439f37360",
+        "revCount": 620,
+        "type": "git",
+        "url": "https://git.outfoxxed.me/outfoxxed/quickshell"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://git.outfoxxed.me/outfoxxed/quickshell"
+      }
+    },
+    "root": {
+      "inputs": {
+        "caelestia-cli": "caelestia-cli",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs",
+        "quickshell": "quickshell"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,135 @@
+{
+  description = "Caelstia Shell Packaged as flake";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    quickshell = {
+      # Apparently these dots track master branch not release
+      url = "git+https://git.outfoxxed.me/outfoxxed/quickshell";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    caelestia-cli = {
+      url = "github:pinksteven/caelestia-cli";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      quickshell,
+      caelestia-cli,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        qs = quickshell.packages.${system}.default;
+      in
+      {
+        packages = {
+          shell =
+            let
+              deps = with pkgs; [
+                app2unit
+                aubio
+                bluez
+                brightnessctl
+                cava
+                curl
+                ddcutil
+                fishMinimal
+                grim
+                inotify-tools
+                libqalculate
+                lm_sensors
+                material-symbols
+                networkmanager
+                pipewire
+                power-profiles-daemon
+                procps
+                kdePackages.qtdeclarative
+                qs
+                swappy
+              ];
+            in
+            pkgs.stdenv.mkDerivation {
+              pname = "caelestia-shell";
+              src = ./.;
+              version = "0.0.1+git.${self.shortRev or "dirty"}";
+
+              nativeBuildInputs = with pkgs; [
+                gcc
+                makeWrapper
+                qt6.wrapQtAppsHook
+              ];
+
+              propagatedBuildInputs = deps;
+
+              buildPhase = ''
+                runHook preBuild
+
+                mkdir -p bin
+                g++ -std=c++17 -Wall -Wextra \
+                -I${pkgs.pipewire.dev}/include/pipewire-0.3 \
+                -I${pkgs.pipewire.dev}/include/spa-0.2 \
+                -I${pkgs.aubio}/include/aubio \
+                assets/beat_detector.cpp \
+                -o bin/beat_detector \
+                -lpipewire-0.3 -laubio
+
+                runHook postBuild
+              '';
+
+              installPhase = ''
+                runHook preInstall
+
+                mkdir -p $out/bin
+                mkdir -p $out/share/quickshell/caelestia
+                mkdir -p $out/share/fonts
+
+                cp -r assets config modules services utils widgets $out/share/quickshell/caelestia/
+                cp -r ${pkgs.material-symbols}/share/fonts/* $out/share/fonts/
+                cp shell.qml $out/share/quickshell/caelestia/
+                cp bin/beat_detector $out/bin/
+
+                runHook postInstall
+              '';
+
+              patchPhase = ''
+                substituteInPlace shell.qml \
+                  --replace-fail "//@ pragma Env QS_NO_RELOAD_POPUP=1" "
+                  //@ pragma Env QS_NO_RELOAD_POPUP=1
+                  //@ pragma UseQApplication
+                  "
+
+                substituteInPlace run.fish \
+                  --replace-fail "(dirname (status filename))" "$out/share/quickshell/caelestia"
+              '';
+
+              postFixup = ''
+                makeWrapper ${qs}/bin/qs $out/bin/qs \
+                --unset QT_STYLE_OVERRIDE \
+                --set QT_QUICK_CONTROLS_STYLE Basic \
+                --set CAELESTIA_BD_PATH "$out/bin/beat_detector" \
+                --prefix XDG_CONFIG_DIRS : $out/share \
+                --prefix PATH : ${pkgs.lib.makeBinPath deps} \
+                --prefix FONTCONFIG_PATH : ${pkgs.fontconfig.out}/etc/fonts
+              '';
+            };
+          default = pkgs.buildEnv {
+            name = "caelestia";
+            paths = [
+              self.packages.${system}.shell
+              caelestia-cli.packages.${system}.default
+            ];
+          };
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -102,12 +102,6 @@
               '';
 
               patchPhase = ''
-                substituteInPlace shell.qml \
-                  --replace-fail "//@ pragma Env QS_NO_RELOAD_POPUP=1" "
-                  //@ pragma Env QS_NO_RELOAD_POPUP=1
-                  //@ pragma UseQApplication
-                  "
-
                 substituteInPlace run.fish \
                   --replace-fail "(dirname (status filename))" "$out/share/quickshell/caelestia"
               '';

--- a/flake.nix
+++ b/flake.nix
@@ -114,6 +114,18 @@
                 --prefix PATH : ${pkgs.lib.makeBinPath deps} \
                 --prefix FONTCONFIG_PATH : ${pkgs.fontconfig.out}/etc/fonts \
                 --add-flags "-p $out/share/quickshell/caelestia"
+
+
+                cat > $out/bin/caelestia-restart << 'EOF'
+                #!/usr/bin/env bash
+                if kill $(pgrep -f caelestia | grep -v ^$$\$); then
+                  echo "Restarting caelestia shell..."
+                  exec caelestia shell -d
+                else
+                  echo "Caelestia shell not running"
+                fi
+                EOF
+                chmod +x $out/bin/caelestia-restart
               '';
             };
           default = pkgs.buildEnv {

--- a/flake.nix
+++ b/flake.nix
@@ -107,13 +107,13 @@
               '';
 
               postFixup = ''
-                makeWrapper ${qs}/bin/qs $out/bin/qs \
+                makeWrapper ${qs}/bin/qs $out/bin/caelestia-shell \
                 --unset QT_STYLE_OVERRIDE \
                 --set QT_QUICK_CONTROLS_STYLE Basic \
                 --set CAELESTIA_BD_PATH "$out/bin/beat_detector" \
-                --prefix XDG_CONFIG_DIRS : $out/share \
                 --prefix PATH : ${pkgs.lib.makeBinPath deps} \
-                --prefix FONTCONFIG_PATH : ${pkgs.fontconfig.out}/etc/fonts
+                --prefix FONTCONFIG_PATH : ${pkgs.fontconfig.out}/etc/fonts \
+                --add-flags "-p $out/share/quickshell/caelestia"
               '';
             };
           default = pkgs.buildEnv {


### PR DESCRIPTION
Closes #133 
Adds a nix flake packaging the entire shell and wrapping quickshell's qs command to be able to run it. I'm going to keep it a draft until either [#26](https://github.com/caelestia-dots/cli/pull/26) or [#24](https://github.com/caelestia-dots/cli/pull/24) in the cli repo is merged and i can change the input from my own fork to the main repo. 