### PR TITLE
fix(logout): replace loginctl terminate-user by hyprctl dispatch exit

### DIFF
--- a/modules/launcher/Actions.qml
+++ b/modules/launcher/Actions.qml
@@ -109,7 +109,7 @@ Singleton {
 
             function onClicked(list: AppList): void {
                 list.visibilities.launcher = false;
-                Quickshell.execDetached(["loginctl", "terminate-user", ""]);
+                Quickshell.execDetached(["hyprctl", "dispatch", "exit"]);
             }
         },
         Action {

--- a/modules/lock/Buttons.qml
+++ b/modules/lock/Buttons.qml
@@ -56,7 +56,7 @@ WrapperItem {
 
         SessionButton {
             icon: "logout"
-            command: ["loginctl", "terminate-user", ""]
+            command: ["hyprctl", "dispatch", "exit"]
         }
 
         SessionButton {

--- a/modules/session/Content.qml
+++ b/modules/session/Content.qml
@@ -23,7 +23,7 @@ Column {
         id: logout
 
         icon: "logout"
-        command: ["loginctl", "terminate-user", ""]
+        command: ["hyprctl", "dispatch", "exit"]
 
         KeyNavigation.down: shutdown
 


### PR DESCRIPTION
Hyprland needs hyprctl to terminate a session "cleanly", without sddm crash.

https://github.com/hyprwm/Hyprland/issues/4399

Otherwise, sddm will crash, and user is not able to log back again graphically after logout.

Fixes #177 