### PR TITLE
nix: install caelestia-cli via flake as it's a dependency

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,6 +20,29 @@
         "type": "github"
       }
     },
+    "caelestia-cli": {
+      "inputs": {
+        "app2unit": [
+          "app2unit"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1752566000,
+        "narHash": "sha256-xaSDZXvZtuM+88PsmfTDWv6+VxN5cOsT/5/czsk3xgI=",
+        "owner": "caelestia-dots",
+        "repo": "cli",
+        "rev": "b1019d11924d1bc9440f457ddf94fc0d8a230ff4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "caelestia-dots",
+        "repo": "cli",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1752480373,
@@ -59,6 +82,7 @@
     "root": {
       "inputs": {
         "app2unit": "app2unit",
+        "caelestia-cli": "caelestia-cli",
         "nixpkgs": "nixpkgs",
         "quickshell": "quickshell"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,12 @@
       url = "github:soramanew/app2unit";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    caelestia-cli = {
+      url = "github:caelestia-dots/cli";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.app2unit.follows = "app2unit";
+    };
   };
 
   outputs = {
@@ -36,7 +42,13 @@
         };
         app2unit = inputs.app2unit.packages.${pkgs.system}.default;
       };
-      default = caelestia-shell;
+        default = pkgs.buildEnv {
+          name = "caelestia-shell";
+          paths = [
+            self.packages.${pkgs.system}.caelestia-shell
+            inputs.caelestia-cli.packages.${pkgs.system}.default
+          ];
+        };
     });
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
       );
   in {
     formatter = forAllSystems (pkgs: pkgs.alejandra);
+    withCli = false;
 
     packages = forAllSystems (pkgs: rec {
       caelestia-shell = pkgs.callPackage ./default.nix {
@@ -42,13 +43,12 @@
         };
         app2unit = inputs.app2unit.packages.${pkgs.system}.default;
       };
-        default = pkgs.buildEnv {
-          name = "caelestia-shell";
-          paths = [
-            self.packages.${pkgs.system}.caelestia-shell
-            inputs.caelestia-cli.packages.${pkgs.system}.default
-          ];
-        };
+      default = pkgs.buildEnv {
+        name = "caelestia-shell";
+        paths = [
+          self.packages.${pkgs.system}.caelestia-shell 
+        ] ++ pkgs.lib.optional self.withCli inputs.caelestia-cli.packages.${pkgs.system}.default;
+      };
     });
   };
 }


### PR DESCRIPTION
caelestia-cli is considered a dependency, but isn't installed with the flake.nix, this PR adds caelestia-dots/cli as a flake input and changes the default package to install both the shell and cli. This allows users to use the full functionality with only one additional flake input.