### PR TITLE
nix: fix typo in default.nix line 56

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -53,7 +53,7 @@ in
 
     nativeBuildInputs = [gcc makeWrapper];
     buildInputs = [quickshell aubio pipewire];
-    propogatedBuildInputs = runtimeDeps;
+    propagatedBuildInputs = runtimeDeps;
 
     buildPhase = ''
       mkdir -p bin


### PR DESCRIPTION
In default.nix line 56 there is misspelled propagatedBuildInputs as propogated. I am honestly surprised nix hasn't thrown any errors or warnings. I don't think the misspell broke anything but I haven't tested it extensively.