### PR TITLE
nix: add jetbrains-mono font to dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,7 @@
   findutils,
   file,
   material-symbols,
+  jetbrains-mono,
   gcc,
   quickshell,
   aubio,
@@ -54,7 +55,10 @@
     ++ lib.optional withCli caelestia-cli;
 
   fontconfig = makeFontsConf {
-    fontDirectories = [material-symbols];
+    fontDirectories = [
+      material-symbols
+      jetbrains-mono
+    ];
   };
 in
   stdenv.mkDerivation {

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
         };
         app2unit = inputs.app2unit.packages.${pkgs.system}.default;
         caelestia-cli = inputs.caelestia-cli.packages.${pkgs.system}.default;
+        jetbrains-mono = pkgs.nerd-fonts.jetbrains-mono;
       };
       default = caelestia-shell;
     });
@@ -53,7 +54,7 @@
       in
         pkgs.mkShellNoCC {
           inputsFrom = [shell];
-          packages = [pkgs.material-symbols];
+          packages = with pkgs; [material-symbols nerd-fonts.jetbrains-mono];
           CAELESTIA_BD_PATH = "${shell}/bin/beat_detector";
           QT_LOGGING_RULES = builtins.concatStringsSep ";" [
             "quickshell.dbus.properties.warning=false"


### PR DESCRIPTION
just few added lines to include jetbrains-mono font to package and shell dependencies

works fine on two nix machines

changed:
 - default.nix
 - flake.nix