### PR TITLE
feat: keyboard layout indicator

### DIFF
--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -25,6 +25,7 @@ JsonObject {
         property bool showNetwork: true
         property bool showBluetooth: true
         property bool showBattery: true
+        property bool showKeyboardLayout: true
     }
 
     component Sizes: JsonObject {

--- a/modules/bar/components/KeyboardLayout.qml
+++ b/modules/bar/components/KeyboardLayout.qml
@@ -1,0 +1,55 @@
+import QtQuick
+import QtQuick.Controls
+import Quickshell.Hyprland
+
+Item {
+    id: keyboardItem
+    implicitWidth: layoutText.implicitWidth
+    implicitHeight: layoutText.implicitHeight
+    
+    //Default string to show when shell started
+    //Didnt find any ways to get it from system
+    property string layout: "EN"
+    property color colour
+    
+    Connections {
+        target: Hyprland
+        
+        function onRawEvent(event) {
+            if (event.name === "activelayout") {
+                updateLayoutFromEvent(event.data)
+            }
+        }
+    }
+    
+    function transformLayout(layoutName) {
+        if (layoutName.includes("Russian")) return "RU"
+        if (layoutName.includes("English")) return "EN"
+        return layoutName.substring(0, 2).toLowerCase()
+    }
+    
+    function updateLayout(layoutName) {
+        const newLayout = transformLayout(layoutName)
+        if (newLayout !== keyboardItem.layout) {
+            keyboardItem.layout = newLayout
+        }
+    }
+    
+    function updateLayoutFromEvent(eventData) {
+        // Парсим данные события: activelayout,<keyboard>,<layout>
+        const parts = eventData.split(',')
+        if (parts.length > 1) {
+            updateLayout(parts[1])
+        }
+    }
+    
+    Text {
+        id: layoutText
+        anchors.centerIn: parent
+        text: parent.layout
+        font.family: "FiraCode Nerd Font"
+        font.pixelSize: 14
+        color: parent.colour
+        font.weight: Font.Medium
+    }
+}

--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -9,7 +9,7 @@ import Quickshell.Bluetooth
 import Quickshell.Services.UPower
 import QtQuick
 import QtQuick.Layouts
-
+import "components/KeyboardLayout"
 Item {
     id: root
 
@@ -163,6 +163,19 @@ Item {
                 }
                 color: !UPower.onBattery || UPower.displayDevice.percentage > 0.2 ? root.colour : Colours.palette.m3error
                 fill: 1
+            }
+        }
+
+        // Keyboard layout icon
+        Loader {
+            id: keyboardLayout
+
+            asynchronous: true
+            active: Config.bar.status.showKeyboardLayout
+            visible: active
+
+            sourceComponent: KeyboardLayout {
+                colour: root.colour
             }
         }
     }


### PR DESCRIPTION
Preview:
<img width="53" height="140" alt="image" src="https://github.com/user-attachments/assets/14624ce5-e87c-4741-ad20-74381b83a875" />

It's uses hyprland events to get current keyboard layout when it switched
Enabling/disabling compatible with shell.json config
Example:
```json
{
    "bar": {
        "status":{
            "showKeyboardLayout": true
        }
    }
}
```