### PR TITLE
Fix keybaord layout text in Bar

### DIFF
--- a/assets/kb_brief_detector.cpp
+++ b/assets/kb_brief_detector.cpp
@@ -1,0 +1,29 @@
+#include <xkbcommon/xkbregistry.h>
+#include <string>
+#include <iostream>
+
+int main(int argc, char *argv[]) {
+    std::string description = argv[1];
+
+    auto* const context = rxkb_context_new(RXKB_CONTEXT_LOAD_EXOTIC_RULES);
+    rxkb_context_parse_default_ruleset(context);
+
+    rxkb_layout* layout = rxkb_layout_first(context);
+
+    std::string brief = "";
+    while (layout != nullptr) {
+        std::string kbDescription = rxkb_layout_get_description(layout);
+
+        if (kbDescription == description) {
+            auto kbBrief = std::string(rxkb_layout_get_brief(layout));
+            brief = kbBrief;
+            break;
+        } else
+            layout = rxkb_layout_next(layout);
+    }
+
+    std::cout << brief;
+    rxkb_context_unref(context);
+
+    return 0;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
           inputsFrom = [shell];
           packages = with pkgs; [material-symbols nerd-fonts.jetbrains-mono];
           CAELESTIA_BD_PATH = "${shell}/bin/beat_detector";
+          CAELESTIA_KBBD_PATH = "${shell}/bin/kb_brief_detector";
         };
     });
   };

--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -74,7 +74,7 @@ Item {
 
             sourceComponent: StyledText {
                 animate: true
-                text: Hyprland.kbLayout
+                text: Hyprland.kbLayoutBrief
                 color: root.colour
                 font.family: Appearance.font.family.mono
             }

--- a/services/Hyprland.qml
+++ b/services/Hyprland.qml
@@ -64,6 +64,6 @@ Singleton {
     Process {
 
         running: true
-        command: ["sh", "-c", "hyprctl switchxkblayout current next && hyprctl switchxkblayout current prev"]
+        command: ["fish", "-C", "hyprctl switchxkblayout current next && hyprctl switchxkblayout current prev"]
     }
 }


### PR DESCRIPTION
This PR replaces the current solution for detecting the keybaord layout in Hyprland service with `xkbcommon`, similar to [waybar repo](https://github.com/Alexays/Waybar/blob/94777921d96c2657c37c7d83a18f13968df486de/src/modules/hyprland/language.cpp#L118)'s code to fix the bad showing of keybaord layout in Bar.

It takes the layout's name that we have from Hyprland's IPC and detects the brief text using the new `kb_brief_detector` binary.
Because I couldn't find a command to give me the keybaord layout's brief text, I added `assets/kb_brief_detector` C++ file to use `xkbcommon` library  and Nix flake configurations to build and install it.

Before PR:
<img width="89" height="144" alt="image" src="https://github.com/user-attachments/assets/6881d519-167f-4d68-93bf-0d35e907517b" />

After PR for "English (US)" and "Persian":
<img width="50" height="151" alt="image" src="https://github.com/user-attachments/assets/e0dfba20-b3e6-4a0b-b3e2-6a9796adf6e3" />
<img width="51" height="147" alt="image" src="https://github.com/user-attachments/assets/b5282d2a-0c90-47f7-9bef-c727bfdb6175" />