### PR TITLE
config: respect user locale for twelve hour clock, temperature

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ All configuration options are in `~/.config/caelestia/shell.json`.
             "rounded": true,
             "showWindows": true,
             "shown": 5
-        },
+        }
     },
     "border": {
         "rounding": 25,

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ All configuration options are in `~/.config/caelestia/shell.json`.
             "shown": 5
         },
         "clock": {
-          "useTwelveHourClock": false
+          "format": "hh:mm"
         }
     },
     "border": {

--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ All configuration options are in `~/.config/caelestia/shell.json`.
             "rounded": true,
             "showWindows": true,
             "shown": 5
+        },
+        "clock": {
+          "useTwelveHourClock": false
         }
     },
     "border": {

--- a/README.md
+++ b/README.md
@@ -176,9 +176,6 @@ All configuration options are in `~/.config/caelestia/shell.json`.
             "showWindows": true,
             "shown": 5
         },
-        "clock": {
-          "format": "hh:mm"
-        }
     },
     "border": {
         "rounding": 25,
@@ -223,7 +220,8 @@ All configuration options are in `~/.config/caelestia/shell.json`.
     },
     "services": {
       "weatherLocation": "10,10",
-      "useFahrenheit": false
+      "useFahrenheit": false,
+      "useTwelveHourClock": false
     },
     "session": {
         "dragThreshold": 30

--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -5,6 +5,7 @@ JsonObject {
     property bool showOnHover: true
     property int dragThreshold: 20
     property Workspaces workspaces: Workspaces {}
+    property Clock clock: Clock {}
     property Status status: Status {}
     property Sizes sizes: Sizes {}
 
@@ -18,6 +19,10 @@ JsonObject {
         property string label: "  "
         property string occupiedLabel: "󰮯 "
         property string activeLabel: "󰮯 "
+    }
+
+    component Clock: JsonObject {
+        property bool useTwelveHourClock: false
     }
 
     component Status: JsonObject {

--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -5,7 +5,6 @@ JsonObject {
     property bool showOnHover: true
     property int dragThreshold: 20
     property Workspaces workspaces: Workspaces {}
-    property Clock clock: Clock {}
     property Status status: Status {}
     property Sizes sizes: Sizes {}
 
@@ -19,10 +18,6 @@ JsonObject {
         property string label: "  "
         property string occupiedLabel: "󰮯 "
         property string activeLabel: "󰮯 "
-    }
-
-    component Clock: JsonObject {
-        property string format: "hh:mm"
     }
 
     component Status: JsonObject {

--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -22,7 +22,7 @@ JsonObject {
     }
 
     component Clock: JsonObject {
-        property bool useTwelveHourClock: false
+        property string format: "hh:mm"
     }
 
     component Status: JsonObject {

--- a/config/ServiceConfig.qml
+++ b/config/ServiceConfig.qml
@@ -3,6 +3,6 @@ import QtQuick
 
 JsonObject {
     property string weatherLocation: "" // A lat,long pair or empty for autodetection, e.g. "37.8267,-122.4233"
-    property bool useFahrenheit: false
+    property bool useFahrenheit: [Locale.ImperialUSSystem, Locale.ImperialSystem].includes(Qt.locale().measurementSystem)
     property bool useTwelveHourClock: Qt.locale().timeFormat(Locale.ShortFormat).toLowerCase().includes("a")
 }

--- a/config/ServiceConfig.qml
+++ b/config/ServiceConfig.qml
@@ -1,6 +1,8 @@
 import Quickshell.Io
+import QtQuick
 
 JsonObject {
     property string weatherLocation: "" // A lat,long pair or empty for autodetection, e.g. "37.8267,-122.4233"
     property bool useFahrenheit: false
+    property bool useTwelveHourClock: Qt.locale().timeFormat(Locale.ShortFormat).toLowerCase().includes("a")
 }

--- a/modules/background/DesktopClock.qml
+++ b/modules/background/DesktopClock.qml
@@ -10,10 +10,8 @@ Item {
     StyledText {
         id: timeText
 
-        readonly property string clockFormat: Config.services.useTwelveHourClock ? "hh:mm:ss A" : "hh:mm:ss"
-
         anchors.centerIn: parent
-        text: Time.format(clockFormat)
+        text: Time.format(Config.services.useTwelveHourClock ? "hh:mm:ss A" : "hh:mm:ss")
         font.pointSize: Appearance.font.size.extraLarge
         font.bold: true
     }

--- a/modules/background/DesktopClock.qml
+++ b/modules/background/DesktopClock.qml
@@ -10,8 +10,10 @@ Item {
     StyledText {
         id: timeText
 
+        readonly property string clockFormat: Config.services.useTwelveHourClock ? "hh:mm:ss A" : "hh:mm:ss"
+
         anchors.centerIn: parent
-        text: Time.format("hh:mm:ss")
+        text: Time.format(clockFormat)
         font.pointSize: Appearance.font.size.extraLarge
         font.bold: true
     }

--- a/modules/bar/components/Clock.qml
+++ b/modules/bar/components/Clock.qml
@@ -22,12 +22,10 @@ Column {
     StyledText {
         id: text
 
-        readonly property string clockFormat: Config.services.useTwelveHourClock ? "hh\nmm\nA" : "hh\nmm"
-
         anchors.horizontalCenter: parent.horizontalCenter
 
         horizontalAlignment: StyledText.AlignHCenter
-        text: Time.format(clockFormat)
+        text: Time.format(Config.services.useTwelveHourClock ? "hh\nmm\nA" : "hh\nmm")
         font.pointSize: Appearance.font.size.smaller
         font.family: Appearance.font.family.mono
         color: root.colour

--- a/modules/bar/components/Clock.qml
+++ b/modules/bar/components/Clock.qml
@@ -22,10 +22,12 @@ Column {
     StyledText {
         id: text
 
+        readonly property string clockFormat: (Config.bar.clock.useTwelveHourClock) ? "hh\nmm\na" : "hh\nmm"
+
         anchors.horizontalCenter: parent.horizontalCenter
 
         horizontalAlignment: StyledText.AlignHCenter
-        text: Time.format("hh\nmm")
+        text: Time.format(clockFormat)
         font.pointSize: Appearance.font.size.smaller
         font.family: Appearance.font.family.mono
         color: root.colour

--- a/modules/bar/components/Clock.qml
+++ b/modules/bar/components/Clock.qml
@@ -22,7 +22,7 @@ Column {
     StyledText {
         id: text
 
-        readonly property string clockFormat: (Config.bar.clock.useTwelveHourClock) ? "hh\nmm\na" : "hh\nmm"
+        readonly property string clockFormat: Config.bar.clock.format.replace(/:/g, "\n")
 
         anchors.horizontalCenter: parent.horizontalCenter
 

--- a/modules/bar/components/Clock.qml
+++ b/modules/bar/components/Clock.qml
@@ -22,7 +22,7 @@ Column {
     StyledText {
         id: text
 
-        readonly property string clockFormat: Config.bar.clock.format.replace(/:/g, "\n")
+        readonly property string clockFormat: Config.services.useTwelveHourClock ? "hh\nmm\nA" : "hh\nmm"
 
         anchors.horizontalCenter: parent.horizontalCenter
 

--- a/modules/dashboard/dash/DateTime.qml
+++ b/modules/dashboard/dash/DateTime.qml
@@ -7,84 +7,62 @@ import QtQuick.Layouts
 Item {
     id: root
 
+    readonly property list<string> timeComponents: Time.format(Config.services.useTwelveHourClock ? "hh:mm:A" : "hh:mm").split(":")
+
     anchors.top: parent.top
     anchors.bottom: parent.bottom
     implicitWidth: Config.dashboard.sizes.dateTimeWidth
 
-    readonly property list<string> timeComponents: Time.format(Config.services.useTwelveHourClock ? "hh:mm:A" : "hh:mm").split(":")
-
     ColumnLayout {
-        id: timeColumn
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: 0
 
-        anchors.centerIn: parent
-        spacing: Appearance.spacing.normal
-
-        Item {
-            id: timeDisplay
-
-            width: root.width
-            height: childrenRect.height
-
-            ColumnLayout {
-                anchors.horizontalCenter: parent.horizontalCenter
-                spacing: -(Appearance.font.size.extraLarge * 0.5)
-
-                StyledText {
-                    id: hoursText
-
-                    Layout.alignment: Qt.AlignHCenter
-                    horizontalAlignment: Text.AlignHCenter
-                    text: root.timeComponents[0]
-                    color: Colours.palette.m3secondary
-                    font.pointSize: Appearance.font.size.extraLarge
-                    font.weight: 500
-                }
-
-                StyledText {
-                    id: separator
-
-                    Layout.alignment: Qt.AlignHCenter
-                    horizontalAlignment: Text.AlignHCenter
-                    text: "•••"
-                    color: Colours.palette.m3primary
-                    font.pointSize: Appearance.font.size.extraLarge * 0.9
-                }
-
-                StyledText {
-                    id: minutesText
-
-                    Layout.alignment: Qt.AlignHCenter
-                    horizontalAlignment: Text.AlignHCenter
-                    text: root.timeComponents[1]
-                    color: Colours.palette.m3secondary
-                    font.pointSize: Appearance.font.size.extraLarge
-                    font.weight: 500
-                }
-
-                StyledText {
-                    id: amPmText
-
-                    visible: Config.services.useTwelveHourClock
-                    Layout.alignment: Qt.AlignHCenter
-                    horizontalAlignment: Text.AlignHCenter
-                    text: root.timeComponents[2]
-                    color: Colours.palette.m3secondary
-                    font.pointSize: Appearance.font.size.extraLarge
-                    font.weight: 500
-                }
-            }
+        StyledText {
+            Layout.alignment: Qt.AlignHCenter
+            text: root.timeComponents[0]
+            color: Colours.palette.m3secondary
+            font.pointSize: Appearance.font.size.extraLarge
+            font.weight: 600
         }
 
         StyledText {
-            id: dateDisplay
-
-            width: root.width
+            Layout.topMargin: -(font.pointSize * 0.2)
             Layout.alignment: Qt.AlignHCenter
+            text: "•••"
+            color: Colours.palette.m3primary
+            font.pointSize: Appearance.font.size.extraLarge * 0.9
+        }
+
+        StyledText {
+            Layout.alignment: Qt.AlignHCenter
+            text: root.timeComponents[1]
+            color: Colours.palette.m3secondary
+            font.pointSize: Appearance.font.size.extraLarge
+            font.weight: 600
+        }
+
+        StyledText {
+            visible: Config.services.useTwelveHourClock
+            Layout.topMargin: Appearance.spacing.small
+            Layout.alignment: Qt.AlignHCenter
+
+            text: root.timeComponents[2]
+            color: Colours.palette.m3secondary
+            font.pointSize: Appearance.font.size.large
+            font.weight: 600
+        }
+
+        StyledText {
+            Layout.topMargin: Appearance.spacing.normal
+            Layout.fillWidth: true
             horizontalAlignment: Text.AlignHCenter
             text: Time.format("ddd, d")
             color: Colours.palette.m3tertiary
             font.pointSize: Appearance.font.size.normal
             font.weight: 500
+            elide: Text.ElideRight
         }
     }
 }

--- a/modules/dashboard/dash/DateTime.qml
+++ b/modules/dashboard/dash/DateTime.qml
@@ -2,6 +2,7 @@ import qs.widgets
 import qs.services
 import qs.config
 import QtQuick
+import QtQuick.Layouts
 
 Item {
     id: root
@@ -10,27 +11,28 @@ Item {
     anchors.bottom: parent.bottom
     implicitWidth: Config.dashboard.sizes.dateTimeWidth
 
-    readonly property bool use12HourFormat: Config.services.useTwelveHourClock
-    readonly property string timeFormat: use12HourFormat ? "hh:mm:A" : "hh:mm"
-    readonly property list<string> timeComponents: Time.format(timeFormat).split(":")
+    readonly property list<string> timeComponents: Time.format(Config.services.useTwelveHourClock ? "hh:mm:A" : "hh:mm").split(":")
 
-    Column {
+    ColumnLayout {
         id: timeColumn
+
         anchors.centerIn: parent
         spacing: Appearance.spacing.normal
 
         Item {
             id: timeDisplay
+
             width: root.width
             height: childrenRect.height
 
-            Column {
+            ColumnLayout {
                 anchors.horizontalCenter: parent.horizontalCenter
                 spacing: -(Appearance.font.size.extraLarge * 0.5)
 
                 StyledText {
                     id: hoursText
-                    anchors.horizontalCenter: parent.horizontalCenter
+
+                    Layout.alignment: Qt.AlignHCenter
                     horizontalAlignment: Text.AlignHCenter
                     text: root.timeComponents[0]
                     color: Colours.palette.m3secondary
@@ -40,7 +42,8 @@ Item {
 
                 StyledText {
                     id: separator
-                    anchors.horizontalCenter: parent.horizontalCenter
+
+                    Layout.alignment: Qt.AlignHCenter
                     horizontalAlignment: Text.AlignHCenter
                     text: "•••"
                     color: Colours.palette.m3primary
@@ -49,7 +52,8 @@ Item {
 
                 StyledText {
                     id: minutesText
-                    anchors.horizontalCenter: parent.horizontalCenter
+
+                    Layout.alignment: Qt.AlignHCenter
                     horizontalAlignment: Text.AlignHCenter
                     text: root.timeComponents[1]
                     color: Colours.palette.m3secondary
@@ -59,8 +63,9 @@ Item {
 
                 StyledText {
                     id: amPmText
-                    visible: root.use12HourFormat
-                    anchors.horizontalCenter: parent.horizontalCenter
+
+                    visible: Config.services.useTwelveHourClock
+                    Layout.alignment: Qt.AlignHCenter
                     horizontalAlignment: Text.AlignHCenter
                     text: root.timeComponents[2]
                     color: Colours.palette.m3secondary
@@ -72,7 +77,9 @@ Item {
 
         StyledText {
             id: dateDisplay
+
             width: root.width
+            Layout.alignment: Qt.AlignHCenter
             horizontalAlignment: Text.AlignHCenter
             text: Time.format("ddd, d")
             color: Colours.palette.m3tertiary

--- a/modules/dashboard/dash/DateTime.qml
+++ b/modules/dashboard/dash/DateTime.qml
@@ -10,62 +10,74 @@ Item {
     anchors.bottom: parent.bottom
     implicitWidth: Config.dashboard.sizes.dateTimeWidth
 
-    StyledText {
-        id: hours
+    readonly property bool use12HourFormat: Config.services.useTwelveHourClock
+    readonly property string timeFormat: use12HourFormat ? "hh:mm:A" : "hh:mm"
+    readonly property list<string> timeComponents: Time.format(timeFormat).split(":")
 
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.topMargin: (root.height - (hours.implicitHeight + sep.implicitHeight + sep.anchors.topMargin + mins.implicitHeight + mins.anchors.topMargin + date.implicitHeight + date.anchors.topMargin)) / 2
+    Column {
+        id: timeColumn
+        anchors.centerIn: parent
+        spacing: Appearance.spacing.normal
 
-        horizontalAlignment: Text.AlignHCenter
-        text: Time.format("HH")
-        color: Colours.palette.m3secondary
-        font.pointSize: Appearance.font.size.extraLarge
-        font.weight: 500
-    }
+        Item {
+            id: timeDisplay
+            width: root.width
+            height: childrenRect.height
 
-    StyledText {
-        id: sep
+            Column {
+                anchors.horizontalCenter: parent.horizontalCenter
+                spacing: -(Appearance.font.size.extraLarge * 0.5)
 
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: hours.bottom
-        anchors.topMargin: -font.pointSize * 0.5
+                StyledText {
+                    id: hoursText
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    horizontalAlignment: Text.AlignHCenter
+                    text: root.timeComponents[0]
+                    color: Colours.palette.m3secondary
+                    font.pointSize: Appearance.font.size.extraLarge
+                    font.weight: 500
+                }
 
-        horizontalAlignment: Text.AlignHCenter
-        text: "•••"
-        color: Colours.palette.m3primary
-        font.pointSize: Appearance.font.size.extraLarge * 0.9
-    }
+                StyledText {
+                    id: separator
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    horizontalAlignment: Text.AlignHCenter
+                    text: "•••"
+                    color: Colours.palette.m3primary
+                    font.pointSize: Appearance.font.size.extraLarge * 0.9
+                }
 
-    StyledText {
-        id: mins
+                StyledText {
+                    id: minutesText
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    horizontalAlignment: Text.AlignHCenter
+                    text: root.timeComponents[1]
+                    color: Colours.palette.m3secondary
+                    font.pointSize: Appearance.font.size.extraLarge
+                    font.weight: 500
+                }
 
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: sep.bottom
-        anchors.topMargin: -sep.font.pointSize * 0.45
+                StyledText {
+                    id: amPmText
+                    visible: root.use12HourFormat
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    horizontalAlignment: Text.AlignHCenter
+                    text: root.timeComponents[2]
+                    color: Colours.palette.m3secondary
+                    font.pointSize: Appearance.font.size.extraLarge
+                    font.weight: 500
+                }
+            }
+        }
 
-        horizontalAlignment: Text.AlignHCenter
-        text: Time.format("mm")
-        color: Colours.palette.m3secondary
-        font.pointSize: Appearance.font.size.extraLarge
-        font.weight: 500
-    }
-
-    StyledText {
-        id: date
-
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: mins.bottom
-        anchors.topMargin: Appearance.spacing.normal
-
-        horizontalAlignment: Text.AlignHCenter
-        text: Time.format("ddd, d")
-        color: Colours.palette.m3tertiary
-        font.pointSize: Appearance.font.size.normal
-        font.weight: 500
+        StyledText {
+            id: dateDisplay
+            width: root.width
+            horizontalAlignment: Text.AlignHCenter
+            text: Time.format("ddd, d")
+            color: Colours.palette.m3tertiary
+            font.pointSize: Appearance.font.size.normal
+            font.weight: 500
+        }
     }
 }

--- a/modules/lock/Clock.qml
+++ b/modules/lock/Clock.qml
@@ -8,13 +8,17 @@ ColumnLayout {
 
     spacing: 0
 
+    readonly property bool use12HourFormat: Config.services.useTwelveHourClock
+    readonly property string timeFormat: use12HourFormat ? "hh:mm:A" : "hh:mm"
+    readonly property list<string> timeComponents: Time.format(timeFormat).split(":")
+
     RowLayout {
         Layout.alignment: Qt.AlignHCenter
         spacing: Appearance.spacing.small
 
         StyledText {
             Layout.alignment: Qt.AlignVCenter
-            text: Time.format("HH")
+            text: root.timeComponents[0]
             color: Colours.palette.m3secondary
             font.pointSize: Appearance.font.size.extraLarge * 4
             font.family: Appearance.font.family.mono
@@ -32,7 +36,7 @@ ColumnLayout {
 
         StyledText {
             Layout.alignment: Qt.AlignVCenter
-            text: Time.format("mm")
+            text: root.timeComponents[1] + (root.timeComponents[2] || "")
             color: Colours.palette.m3secondary
             font.pointSize: Appearance.font.size.extraLarge * 4
             font.family: Appearance.font.family.mono

--- a/modules/lock/Clock.qml
+++ b/modules/lock/Clock.qml
@@ -36,7 +36,17 @@ ColumnLayout {
 
         StyledText {
             Layout.alignment: Qt.AlignVCenter
-            text: root.timeComponents[1] + (root.timeComponents[2] || "")
+            text: root.timeComponents[1]
+            color: Colours.palette.m3secondary
+            font.pointSize: Appearance.font.size.extraLarge * 4
+            font.family: Appearance.font.family.mono
+            font.weight: 800
+        }
+
+        StyledText {
+            Layout.alignment: Qt.AlignVCenter
+            visible: root.use12HourFormat
+            text: root.timeComponents[2]
             color: Colours.palette.m3secondary
             font.pointSize: Appearance.font.size.extraLarge * 4
             font.family: Appearance.font.family.mono

--- a/modules/lock/Clock.qml
+++ b/modules/lock/Clock.qml
@@ -8,9 +8,7 @@ ColumnLayout {
 
     spacing: 0
 
-    readonly property list<string> timeComponents: Time.format(
-        Config.services.useTwelveHourClock ? "hh:mm:A" : "hh:mm"
-    ).split(":")
+    readonly property list<string> timeComponents: Time.format(Config.services.useTwelveHourClock ? "hh:mm:A" : "hh:mm").split(":")
 
     RowLayout {
         Layout.alignment: Qt.AlignHCenter

--- a/modules/lock/Clock.qml
+++ b/modules/lock/Clock.qml
@@ -1,6 +1,7 @@
 import qs.widgets
 import qs.services
 import qs.config
+import QtQuick
 import QtQuick.Layouts
 
 ColumnLayout {
@@ -43,12 +44,13 @@ ColumnLayout {
 
         StyledText {
             visible: Config.services.useTwelveHourClock
+            Layout.leftMargin: Appearance.spacing.normal
             Layout.alignment: Qt.AlignVCenter
+
             text: root.timeComponents[2]
-            color: Colours.palette.m3secondary
-            font.pointSize: Appearance.font.size.extraLarge * 4
-            font.family: Appearance.font.family.mono
-            font.weight: 800
+            color: Colours.palette.m3primary
+            font.pointSize: Appearance.font.size.extraLarge * 3
+            font.weight: 700
         }
     }
 

--- a/modules/lock/Clock.qml
+++ b/modules/lock/Clock.qml
@@ -8,9 +8,9 @@ ColumnLayout {
 
     spacing: 0
 
-    readonly property bool use12HourFormat: Config.services.useTwelveHourClock
-    readonly property string timeFormat: use12HourFormat ? "hh:mm:A" : "hh:mm"
-    readonly property list<string> timeComponents: Time.format(timeFormat).split(":")
+    readonly property list<string> timeComponents: Time.format(
+        Config.services.useTwelveHourClock ? "hh:mm:A" : "hh:mm"
+    ).split(":")
 
     RowLayout {
         Layout.alignment: Qt.AlignHCenter
@@ -44,8 +44,8 @@ ColumnLayout {
         }
 
         StyledText {
+            visible: Config.services.useTwelveHourClock
             Layout.alignment: Qt.AlignVCenter
-            visible: root.use12HourFormat
             text: root.timeComponents[2]
             color: Colours.palette.m3secondary
             font.pointSize: Appearance.font.size.extraLarge * 4


### PR DESCRIPTION
Add a simple option to config to use 12 hour clock, for the americans.

Here's what it looks like:
<img width="46" height="118" alt="image" src="https://github.com/user-attachments/assets/ae783710-f9d7-480a-b5ce-298c92a38153" />

The functionality is opt-in and existing setups will continue using 24h format unless they change their settings

closes: https://github.com/caelestia-dots/shell/issues/261 
closes: https://github.com/caelestia-dots/shell/issues/207