### PR TITLE
session: add optional vim-like keybinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ All configuration options are in `~/.config/caelestia/shell.json`.
       "useFahrenheit": false
     },
     "session": {
-        "dragThreshold": 30
+        "dragThreshold": 30,
+        "vimKeybinds": false
     }
 }
 ```

--- a/config/SessionConfig.qml
+++ b/config/SessionConfig.qml
@@ -3,6 +3,7 @@ import Quickshell.Io
 JsonObject {
     property bool enabled: true
     property int dragThreshold: 30
+    property bool vimKeybinds: false
     property Sizes sizes: Sizes {}
 
     component Sizes: JsonObject {

--- a/modules/session/Content.qml
+++ b/modules/session/Content.qml
@@ -98,6 +98,28 @@ Column {
         Keys.onEnterPressed: Quickshell.execDetached(button.command)
         Keys.onReturnPressed: Quickshell.execDetached(button.command)
         Keys.onEscapePressed: root.visibilities.session = false
+        Keys.onPressed: event => {
+            if (!Config.session.vimKeybinds)
+                return;
+
+            if (event.modifiers & Qt.ControlModifier) {
+                if (event.key === Qt.Key_J && KeyNavigation.down) {
+                    KeyNavigation.down.focus = true;
+                    event.accepted = true;
+                } else if (event.key === Qt.Key_K && KeyNavigation.up) {
+                    KeyNavigation.up.focus = true;
+                    event.accepted = true;
+                }
+            } else if (event.key === Qt.Key_Tab && KeyNavigation.down) {
+                KeyNavigation.down.focus = true;
+                event.accepted = true;
+            } else if (event.key === Qt.Key_Backtab || (event.key === Qt.Key_Tab && (event.modifiers & Qt.ShiftModifier))) {
+                if (KeyNavigation.up) {
+                    KeyNavigation.up.focus = true;
+                    event.accepted = true;
+                }
+            }
+        }
 
         StateLayer {
             radius: parent.radius


### PR DESCRIPTION
This adds the same keybinds I made for the launcher to the session menu. That also includes the Tab key. 

There are some decisions I made here (and for launcher), that may need to be discussed. For example that the Tab-Key navigation could also be enable by default, without enabling vimKeybinds, but I will leave it like this, to change your defaults as little as possible. 
I am happy enough if these changes make it upstream at all, so hmu if something needs changing.