### PR TITLE
session/lock: Add custom session/lock menu button commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,13 @@ All configuration options are in `~/.config/caelestia/shell.json`.
       "useFahrenheit": false
     },
     "session": {
-        "dragThreshold": 30
+        "dragThreshold": 30,
+        "commands": {
+            "logout": ["loginctl", "terminate-user", ""],
+            "shutdown": ["systemctl", "poweroff"],
+            "hibernate": ["systemctl", "hibernate"],
+            "reboot": ["systemctl", "reboot"]
+        }
     }
 }
 ```

--- a/config/SessionConfig.qml
+++ b/config/SessionConfig.qml
@@ -3,7 +3,15 @@ import Quickshell.Io
 JsonObject {
     property bool enabled: true
     property int dragThreshold: 30
+    property Commands commands: Commands{}
     property Sizes sizes: Sizes {}
+    
+    component Commands: JsonObject {
+        property list<string> logout: ["loginctl", "terminate-user", ""]
+        property list<string> shutdown: ["systemctl", "poweroff"]
+        property list<string> hibernate: ["systemctl", "hibernate"]
+        property list<string> reboot: ["systemctl", "reboot"]
+    }
 
     component Sizes: JsonObject {
         property int button: 80

--- a/modules/lock/Buttons.qml
+++ b/modules/lock/Buttons.qml
@@ -50,22 +50,22 @@ Item {
 
         SessionButton {
             icon: "logout"
-            command: ["loginctl", "terminate-user", ""]
+            command: Config.session.commands.logout
         }
 
         SessionButton {
             icon: "power_settings_new"
-            command: ["systemctl", "poweroff"]
+            command: Config.session.commands.shutdown
         }
 
         SessionButton {
             icon: "downloading"
-            command: ["systemctl", "hibernate"]
+            command: Config.session.commands.hibernate
         }
 
         SessionButton {
             icon: "cached"
-            command: ["systemctl", "reboot"]
+            command: Config.session.commands.reboot
         }
 
         Behavior on anchors.margins {

--- a/modules/session/Content.qml
+++ b/modules/session/Content.qml
@@ -23,7 +23,7 @@ Column {
         id: logout
 
         icon: "logout"
-        command: ["loginctl", "terminate-user", ""]
+        command: Config.session.commands.logout
 
         KeyNavigation.down: shutdown
 
@@ -46,7 +46,7 @@ Column {
         id: shutdown
 
         icon: "power_settings_new"
-        command: ["systemctl", "poweroff"]
+        command: Config.session.commands.shutdown
 
         KeyNavigation.up: logout
         KeyNavigation.down: hibernate
@@ -68,7 +68,7 @@ Column {
         id: hibernate
 
         icon: "downloading"
-        command: ["systemctl", "hibernate"]
+        command: Config.session.commands.hibernate
 
         KeyNavigation.up: shutdown
         KeyNavigation.down: reboot
@@ -78,7 +78,7 @@ Column {
         id: reboot
 
         icon: "cached"
-        command: ["systemctl", "reboot"]
+        command: Config.session.commands.reboot
 
         KeyNavigation.up: hibernate
     }


### PR DESCRIPTION
This PR adds the ability to customize the commands that the session/lockscreen buttons execute in shell.json.

I for example don't use hibernate, so I changed it to systemctl suspend on my machine. LMK if this is okay. 

I could also seperate the config for the commands to lock and session, but I will leave the decision up to you boss.