### PR TITLE
bar: add bluetooth connected icon state

### DIFF
--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -110,15 +110,10 @@ Item {
                 MaterialIcon {
                     animate: true
                     text: {
-                        if (!Bluetooth.defaultAdapter?.enabled) {
-                            return "bluetooth_disabled"
-                        }
-
-                        const isConnected = Bluetooth.devices.values.some(d => d.connected);
-                        if (isConnected) {
-                            return "bluetooth_connected"
-                        }
-
+                        if (!Bluetooth.defaultAdapter?.enabled)
+                            return "bluetooth_disabled";
+                        if (Bluetooth.devices.values.some(d => d.connected))
+                            return "bluetooth_connected";
                         return "bluetooth";
                     }
                     color: root.colour

--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -115,8 +115,8 @@ Item {
                             return "bluetooth_disabled"
                         }
 
-                        const connectedCount = Bluetooth.devices.values.filter(d => d.connected).length
-                        if (connectedCount > 0) {
+                        const isConnected = !!Bluetooth.devices.values.find(d => d.connected);
+                        if (isConnected) {
                             return "bluetooth_connected"
                         }
 

--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -109,7 +109,19 @@ Item {
                 // Bluetooth icon
                 MaterialIcon {
                     animate: true
-                    text: Bluetooth.defaultAdapter?.enabled ? "bluetooth" : "bluetooth_disabled"
+                    text: {
+                        const adapter = Bluetooth.defaultAdapter;
+                        if (!Bluetooth.defaultAdapter?.enabled) {
+                            return "bluetooth_disabled"
+                        }
+
+                        const connectedCount = Bluetooth.devices.values.filter(d => d.connected).length
+                        if (connectedCount > 0) {
+                            return "bluetooth_connected"
+                        }
+
+                        return "bluetooth";
+                    }
                     color: root.colour
                 }
 

--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -110,12 +110,11 @@ Item {
                 MaterialIcon {
                     animate: true
                     text: {
-                        const adapter = Bluetooth.defaultAdapter;
                         if (!Bluetooth.defaultAdapter?.enabled) {
                             return "bluetooth_disabled"
                         }
 
-                        const isConnected = !!Bluetooth.devices.values.find(d => d.connected);
+                        const isConnected = Bluetooth.devices.values.some(d => d.connected);
                         if (isConnected) {
                             return "bluetooth_connected"
                         }


### PR DESCRIPTION
Very small PR to use the "bluetooth connected" icon from material icons when a bluetooth device is connected

<img width="92" height="203" alt="image" src="https://github.com/user-attachments/assets/86265593-7a39-4e71-bd44-024d01bc381e" />

On my local machine I will be using this instead of the list of icons for each device to reduce a bit of clutter in the sidebar. I think this list is not needed with this new icon and the ability to see connected devices in the bluetooth panel.

 I left the removal of the icon list out on purpose in this PR in case you still want to have it. If you think we can remove the icon list I can add it to this PR as well