### PR TITLE
config: allow configuring terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ All configuration options are in `~/.config/caelestia/shell.json`.
         "enableDangerousActions": false,
         "maxShown": 8,
         "maxWallpapers": 9,
+        "terminal": "foot",
         "useFuzzy": {
             "apps": false,
             "actions": false,

--- a/config/LauncherConfig.qml
+++ b/config/LauncherConfig.qml
@@ -8,6 +8,7 @@ JsonObject {
     property bool enableDangerousActions: false // Allow actions that can cause losing data, like shutdown, reboot and logout
     property int dragThreshold: 50
     property bool vimKeybinds: false
+    property string terminal: "foot"
     property UseFuzzy useFuzzy: UseFuzzy {}
     property Sizes sizes: Sizes {}
 

--- a/modules/launcher/items/CalcItem.qml
+++ b/modules/launcher/items/CalcItem.qml
@@ -111,7 +111,7 @@ Item {
                 color: Colours.palette.m3onTertiary
 
                 function onClicked(): void {
-                    Quickshell.execDetached(["app2unit", "--", "foot", "fish", "-C", `exec qalc -i '${root.math}'`]);
+                    Quickshell.execDetached(["app2unit", "--", Config.launcher.terminal, "fish", "-C", `exec qalc -i '${root.math}'`]);
                     root.list.visibilities.launcher = false;
                 }
             }

--- a/modules/launcher/services/Apps.qml
+++ b/modules/launcher/services/Apps.qml
@@ -13,7 +13,7 @@ Searcher {
     function launch(entry: DesktopEntry): void {
         if (entry.runInTerminal)
             Quickshell.execDetached({
-                command: ["app2unit", "--", "foot", `${Quickshell.shellDir}/assets/wrap_term_launch.sh`, ...entry.command],
+                command: ["app2unit", "--", Config.launcher.terminal, `${Quickshell.shellDir}/assets/wrap_term_launch.sh`, ...entry.command],
                 workingDirectory: entry.workingDirectory
             });
         else


### PR DESCRIPTION
Adds a simple option to config to change the terminal emulator in which commands like "btop" or the calculator run when selected in the launcher.

The default is still foot.

closes #305 