### PR TITLE
dashboard: cleaner media dash styling, less duplicate text

### DIFF
--- a/modules/dashboard/Media.qml
+++ b/modules/dashboard/Media.qml
@@ -25,7 +25,7 @@ Item {
 
     function lengthStr(length: int): string {
         if (length < 0)
-            return "-1:-1";
+            return "";
 
         const hours = Math.floor(length / 3600);
         const mins = Math.floor((length % 3600) / 60);
@@ -160,7 +160,7 @@ Item {
         ElideText {
             id: title
 
-            label: (Players.active?.trackTitle ?? qsTr("No media")) || qsTr("Unknown title")
+            label: Players.active ? (Players.active.trackTitle || qsTr("Unkown title")) : null
             color: Colours.palette.m3primary
             font.pointSize: Appearance.font.size.normal
         }
@@ -168,7 +168,7 @@ Item {
         ElideText {
             id: album
 
-            label: (Players.active?.trackAlbum ?? qsTr("No media")) || qsTr("Unknown album")
+            label: Players.active ? (Players.active.trackAlbum || qsTr("Unknown album")) : null
             color: Colours.palette.m3outline
             font.pointSize: Appearance.font.size.small
         }
@@ -176,7 +176,7 @@ Item {
         ElideText {
             id: artist
 
-            label: (Players.active?.trackArtist ?? qsTr("No media")) || qsTr("Unknown artist")
+            label: Players.active ? (Players.active.trackArtist || qsTr("Unknown artist")) : qsTr("No media")
             color: Colours.palette.m3secondary
         }
 
@@ -403,6 +403,7 @@ Item {
                         Layout.maximumWidth: playerSelector.implicitWidth - implicitHeight - parent.spacing - Appearance.padding.normal * 2
                         text: Players.active?.identity ?? "No players"
                         color: Colours.palette.m3onSecondaryContainer
+                        font.pointSize: Appearance.font.size.small
                         elide: Text.ElideRight
                     }
                 }


### PR DESCRIPTION
Very opiniated PR so feel free to close or make edits, just wanted to make the media dash a bit cleaner as there is currently a lot of duplicate / redundant text.

### With media playing
<img width="282" height="284" alt="image" src="https://github.com/user-attachments/assets/471c0f8c-0870-4f7f-9680-48dede145aa5" />
<br>
Only thing that changed is slightly smaller font for player so it overflow less quickly

### No media playing
<img width="349" height="301" alt="image" src="https://github.com/user-attachments/assets/42f4a47b-a2ae-4304-9176-460a82d1efc9" />
<br>

- Removed the duplicate "No media" entries
- Removed the "-1:-1" duration

For reference, see the old panel below with no media playing

### No media playing (old)
<img width="305" height="319" alt="image" src="https://github.com/user-attachments/assets/7aea8af9-daf1-4e9c-9636-071b18faa5ce" />


The behavior around "Unknown album, artist, title" still works the same when media is playing