### PR TITLE
launcher: allow wallpaper switch when exactly 2 wallpapers present

### DIFF
--- a/modules/launcher/WallpaperList.qml
+++ b/modules/launcher/WallpaperList.qml
@@ -16,22 +16,22 @@ PathView {
             return 0;
         const itemWidth = Config.launcher.sizes.wallpaperWidth * 0.8;
         const max = Config.launcher.maxWallpapers;
-        if (max * itemWidth > screenWidth) {
-            const items = Math.floor(screenWidth / itemWidth);
-            return items > 1 && items % 2 === 0 ? items - 1 : items;
-        }
-        return max;
+        const maxItemsOnScreen = Math.floor(screenWidth / itemWidth);
+
+        const visible = Math.min(maxItemsOnScreen, max, scriptModel.values.length)
+        if (visible === 2)
+            return 1
+        else if (visible > 1 && visible %2 === 0)
+            return visible - 1
+        return visible;
     }
 
     model: ScriptModel {
+        id: scriptModel
+
         readonly property string search: root.search.text.split(" ").slice(1).join(" ")
 
-        values: {
-            const list = Wallpapers.query(search);
-            if (list.length > 1 && list.length % 2 === 0)
-                list.length -= 1; // Always show odd number
-            return list;
-        }
+        values: Wallpapers.query(search)
         onValuesChanged: root.currentIndex = search ? 0 : values.findIndex(w => w.path === Wallpapers.actualCurrent)
     }
 


### PR DESCRIPTION
Small fix that allows you to use the wallpaper selector when you have exactly two wallpapers. Here's what it looks like when you have two wallpapers present (same as before)

<img width="743" height="296" alt="image" src="https://github.com/user-attachments/assets/329090ee-ec3c-4e34-a67f-3f43b2e3b97d" />

I initially wanted to go for an infinite loop where the wallpapers would be displayed as `list[0], list[1], list[0]` but it gave me giant headache. This way, the styling is not perfect but at least the functionality works