### PR TITLE
internal: add min max volume

### DIFF
--- a/modules/bar/components/ActiveWindow.qml
+++ b/modules/bar/components/ActiveWindow.qml
@@ -25,9 +25,9 @@ Item {
 
         function onWheel(event: WheelEvent): void {
             if (event.angleDelta.y > 0)
-                Audio.setVolume(Audio.volume + 0.1);
+                Audio.incrementVolume()
             else if (event.angleDelta.y < 0)
-                Audio.setVolume(Audio.volume - 0.1);
+                Audio.decrementVolume()
         }
     }
 

--- a/modules/bar/popouts/Audio.qml
+++ b/modules/bar/popouts/Audio.qml
@@ -87,9 +87,9 @@ Item {
 
             onWheel: event => {
                 if (event.angleDelta.y > 0)
-                    Audio.setVolume(Audio.volume + 0.1);
+                    Audio.incrementVolume()
                 else if (event.angleDelta.y < 0)
-                    Audio.setVolume(Audio.volume - 0.1);
+                    Audio.decrementVolume()
             }
 
             StyledSlider {
@@ -97,6 +97,8 @@ Item {
                 anchors.right: parent.right
                 implicitHeight: parent.implicitHeight
 
+                from: Audio.minVolume
+                to: Audio.maxVolume
                 value: Audio.volume
                 onMoved: Audio.setVolume(value)
 

--- a/modules/osd/Content.qml
+++ b/modules/osd/Content.qml
@@ -22,15 +22,17 @@ Column {
 
         onWheel: event => {
             if (event.angleDelta.y > 0)
-                Audio.setVolume(Audio.volume + 0.1);
+                Audio.incrementVolume()
             else if (event.angleDelta.y < 0)
-                Audio.setVolume(Audio.volume - 0.1);
+                Audio.decrementVolume()
         }
 
         FilledSlider {
             anchors.fill: parent
 
             icon: Icons.getVolumeIcon(value, Audio.muted)
+            from: Audio.minVolume
+            to: Audio.maxVolume
             value: Audio.volume
             onMoved: Audio.setVolume(value)
         }

--- a/services/Audio.qml
+++ b/services/Audio.qml
@@ -6,6 +6,9 @@ import Quickshell.Services.Pipewire
 Singleton {
     id: root
 
+    readonly property int minVolume: 0
+    readonly property int maxVolume: 1
+
     readonly property var nodes: Pipewire.nodes.values.reduce((acc, node) => {
         if (!node.isStream) {
             if (node.isSink) acc.sinks.push(node)
@@ -26,8 +29,15 @@ Singleton {
     function setVolume(newVolume: real): void {
         if (sink?.ready && sink?.audio) {
             sink.audio.muted = false;
-            sink.audio.volume = newVolume;
+            sink.audio.volume = Math.max(minVolume, Math.min(maxVolume, newVolume));
         }
+    }
+
+    function incrementVolume(amount = 0.1) {
+        setVolume(volume + amount)
+    }
+    function decrementVolume(amount = 0.1) {
+        setVolume(volume - amount)
     }
 
     function setAudioSink(newSink: PwNode): void {


### PR DESCRIPTION
Added a minimum and maximum value to audio volume. This wasn't breaking before because the default max value of the slider is already 1.0 but with the addition of scrolling to increase volume, it could be increased to infinity. I've added the min and max values to the sliders as well to be more explicit and for the (unlikely) case that we'd ever want to change these values
<img width="234" height="286" alt="image" src="https://github.com/user-attachments/assets/a5b66e46-9a87-4123-94eb-be28446cc5c2" />

Typically I would use `SCREAMING_SNAKE_CASE` syntax for constants like `minVolume` and `maxVolume` but I didn't see that being used anywhere in the project so I just used camelCase

The lack of explicit min and max values for brightness is not breaking on my device currently, probably because of some internal logic, but I could add a min and max there as well for extra safety