### PR TITLE
QOL: Add battery icon to the lock screen

### DIFF
--- a/modules/lock/Status.qml
+++ b/modules/lock/Status.qml
@@ -30,9 +30,8 @@ WrapperItem {
     implicitHeight: nonAnimHeight
 
     margin: Appearance.padding.large * 2
-    leftMargin: -50
-    rightMargin: 70
-    topMargin: -20
+    rightMargin: 0
+    topMargin: 0
 
     Timer {
         running: true

--- a/modules/lock/Status.qml
+++ b/modules/lock/Status.qml
@@ -30,8 +30,9 @@ WrapperItem {
     implicitHeight: nonAnimHeight
 
     margin: Appearance.padding.large * 2
-    rightMargin: 0
-    topMargin: 0
+    leftMargin: -50
+    rightMargin: 70
+    topMargin: -20
 
     Timer {
         running: true
@@ -71,7 +72,7 @@ WrapperItem {
 
                 sourceComponent: StyledText {
                     animate: true
-                    text: qsTr("%1%2% remaining").arg(UPower.onBattery ? "" : "(+) ").arg(Math.round(UPower.displayDevice.percentage * 100))
+                    text: qsTr("%1%2% remaining").arg(UPower.onBattery ? "" : "󰂄  ").arg(Math.round(UPower.displayDevice.percentage * 100))
                     color: !UPower.onBattery || UPower.displayDevice.percentage > 0.2 ? Colours.palette.m3onSurface : Colours.palette.m3error
                 }
             }


### PR DESCRIPTION
On the lock screen, it is displaying a `(+)` icon to represent the process of charging, which I added a nerd font icon (which is one of the dependencies of the shell already) to represent it better.