### PR TITLE
bar: add config to hide active window from bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ All configuration options are in `~/.config/caelestia/shell.json`.
         "dragThreshold": 20,
         "persistent": true,
         "showOnHover": true,
+        "showActiveWindow": true,
         "status": {
             "showAudio": false,
             "showBattery": true,

--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -3,6 +3,7 @@ import Quickshell.Io
 JsonObject {
     property bool persistent: true
     property bool showOnHover: true
+    property bool showActiveWindow: true
     property int dragThreshold: 20
     property Workspaces workspaces: Workspaces {}
     property Status status: Status {}

--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -17,8 +17,6 @@ Item {
 
     function checkPopout(y: real): void {
         const spacing = Appearance.spacing.small;
-        const aw = activeWindow.child;
-        const awy = activeWindow.y + aw.y;
 
         const ty = tray.y;
         const th = tray.implicitHeight;
@@ -43,10 +41,15 @@ Item {
             }
         }
 
-        if (y >= awy && y <= awy + aw.implicitHeight) {
-            popouts.currentName = "activewindow";
-            popouts.currentCenter = Qt.binding(() => activeWindow.y + aw.y + aw.implicitHeight / 2);
-            popouts.hasCurrent = true;
+        const aw = activeWindowLoader.item?.child;
+        if (aw) {
+            const awy = activeWindowLoader.y + aw.y;
+
+            if (y >= awy && y <= awy + aw.implicitHeight) {
+                popouts.currentName = "activewindow";
+                popouts.currentCenter = Qt.binding(() => activeWindowLoader.y + aw.y + aw.implicitHeight / 2);
+                popouts.hasCurrent = true;
+            }
         } else if (y > ty && y < ty + th) {
             const index = Math.floor(((y - ty) / th) * trayItems.count);
             const item = trayItems.itemAt(index);
@@ -72,7 +75,7 @@ Item {
         anchors.bottom: parent.bottom
         anchors.horizontalCenter: parent.horizontalCenter
 
-        implicitWidth: Math.max(osIcon.implicitWidth, workspaces.implicitWidth, activeWindow.implicitWidth, tray.implicitWidth, clock.implicitWidth, statusIcons.implicitWidth, power.implicitWidth)
+        implicitWidth: Math.max(osIcon.implicitWidth, workspaces.implicitWidth, (activeWindowLoader.item?.implicitWidth ?? 0), tray.implicitWidth, clock.implicitWidth, statusIcons.implicitWidth, power.implicitWidth)
 
         OsIcon {
             id: osIcon
@@ -116,15 +119,23 @@ Item {
             }
         }
 
-        ActiveWindow {
-            id: activeWindow
+        Loader {
+            id: activeWindowLoader
+
+            active: Config.bar.showActiveWindow
+            asynchronous: true
 
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.top: workspaces.bottom
             anchors.bottom: tray.top
             anchors.margins: Appearance.spacing.large
 
-            monitor: Brightness.getMonitorForScreen(root.screen)
+            sourceComponent: ActiveWindow {
+                id: activeWindow
+
+                anchors.fill: parent
+                monitor: Brightness.getMonitorForScreen(root.screen)
+            }
         }
 
         Tray {


### PR DESCRIPTION
For a more minimal bar 
<img width="476" height="1431" alt="image" src="https://github.com/user-attachments/assets/5f20dfe7-e40b-4375-8894-5156a7ee076a" />

Just to add my specific use case: I use zen browser with vertical tabs in compact mode. I often accidentally hover over the active window indicator causing it to expand when I want to expand my tabs. This could also be fixed by adding a hover delay but I don't really use this panel anyway and it looks kinda clean without
