### PR TITLE
internal: allow symlinked wallpaper directory

### DIFF
--- a/services/Wallpapers.qml
+++ b/services/Wallpapers.qml
@@ -86,7 +86,7 @@ Searcher {
         id: getWallsProc
 
         running: true
-        command: ["find", Paths.expandTilde(Config.paths.wallpaperDir), "-type", "d", "-path", '*/.*', "-prune", "-o", "-not", "-name", '.*', "-type", "f", "-print"]
+        command: ["find", "-L", Paths.expandTilde(Config.paths.wallpaperDir), "-type", "d", "-path", '*/.*', "-prune", "-o", "-not", "-name", '.*', "-type", "f", "-print"]
         stdout: StdioCollector {
             onStreamFinished: wallpapers.model = text.trim().split("\n").filter(w => Images.isValidImageByName(w)).sort()
         }


### PR DESCRIPTION
useful when you have wallpapers managed by a dotfiles manager, for example