### PR TITLE
nix: add home manager module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,5 +51,7 @@
           CAELESTIA_BD_PATH = "${shell}/bin/beat_detector";
         };
     });
+
+    homeManagerModules.default = import ./nix/hm-module.nix self;
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
     formatter = forAllSystems (pkgs: pkgs.alejandra);
 
     packages = forAllSystems (pkgs: rec {
-      caelestia-shell = pkgs.callPackage ./default.nix {
+      caelestia-shell = pkgs.callPackage ./nix {
         rev = self.rev or self.dirtyRev;
         quickshell = inputs.quickshell.packages.${pkgs.system}.default.override {
           withX11 = false;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -62,7 +62,7 @@ in
   stdenv.mkDerivation {
     pname = "caelestia-shell";
     version = "${rev}";
-    src = ./.;
+    src = ./..;
 
     nativeBuildInputs = [gcc makeWrapper];
     buildInputs = [quickshell aubio pipewire];

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -4,6 +4,7 @@ self: {
   lib,
   ...
 }: let
+  cli-default = self.inputs.caelestia-cli.packages.${pkgs.system}.default;
   shell-default = self.packages.${pkgs.system}.default;
 
   cfg = config.programs.caelestia;
@@ -26,10 +27,19 @@ in {
         default = "";
         description = "Caelestia shell extra configs written to shell.json";
       };
+      cli = {
+        enable = mkEnableOption "Enable Caelestia CLI";
+        package = mkOption {
+          type = types.package;
+          default = cli-default;
+          description = "The package of Caelestia CLI";
+        };
+      };
     };
   };
 
   config = let
+    cli = cfg.cli.package or cli-default;
     shell = cfg.package or shell-default;
   in
     lib.mkIf cfg.enable {
@@ -71,6 +81,6 @@ in {
         builtins.toJSON (lib.recursiveUpdate
           (cfg.settings or {}) (builtins.fromJSON extraConfig));
 
-      home.packages = [shell];
+      home.packages = [shell] ++ lib.optional cfg.cli.enable cli;
     };
 }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -4,143 +4,73 @@ self: {
   lib,
   ...
 }: let
-  caelestia-cli = self.inputs.caelestia-cli.packages.${pkgs.system}.default;
-  caelestia-shell = self.packages.${pkgs.system}.default;
-
-  caelestia-cli-ipc = "${caelestia-cli}/bin/caelestia shell";
-  caelestia-shell-ipc = "${caelestia-shell}/bin/caelestia-shell ipc call"; # Using this seems faster than caelestia-cli-ipc
+  shell-default = self.packages.${pkgs.system}.default;
 
   cfg = config.programs.caelestia;
 in {
   options = with lib; {
     programs.caelestia = {
       enable = mkEnableOption "Enable Caelestia shell";
-
+      package = mkOption {
+        type = types.package;
+        default = shell-default;
+        description = "The package of Caelestia shell";
+      };
       settings = mkOption {
         type = types.attrs;
         default = {};
-        description = "Caelestia settings written to shell.json";
+        description = "Caelestia shell settings";
       };
-
-      ipcType = mkOption {
-        type = types.enum [
-          "shell"
-          "cli"
-        ];
-        default = "shell";
-        description = "Caelestia IPC type, can be either \"shell\" or \"cli\", note that some commands may not work on both";
-      };
-
-      ipcCmd = mkOption {
+      extraConfig = mkOption {
         type = types.str;
-        description = "IPC command used in this module, configured by ipcType option";
-        readOnly = true;
-      };
-
-      binds = {
-        enable = mkEnableOption "Enable useful keybinds to Hyprland";
-        toggleDashboard = mkOption {
-          type = types.str;
-          description = "Hyprland bind to toggle the dashboard.";
-          example = "SUPER, D";
-          default = "";
-        };
-        toggleLauncher = mkOption {
-          type = types.str;
-          description = "Hyprland bind to toggle the launcher.";
-          example = "SUPER, D";
-          default = "";
-        };
-        toggleOsd = mkOption {
-          type = types.str;
-          description = "Hyprland bind to toggle the OSD.";
-          example = "SUPER, D";
-          default = "";
-        };
-        toggleBar = mkOption {
-          type = types.str;
-          description = "Hyprland bind to toggle the bar.";
-          example = "SUPER, D";
-          default = "";
-        };
-        openPicker = mkOption {
-          type = types.str;
-          description = "Hyprland bind to open the picker.";
-          example = "SUPER, D";
-          default = "";
-        };
-        openPickerFreeze = mkOption {
-          type = types.str;
-          description = "Hyprland bind to open the picker while freezing the screen.";
-          example = "SUPER, D";
-          default = "";
-        };
-        openControlCenter = mkOption {
-          type = types.str;
-          description = "Hyprland bind to open the Control Center.";
-          example = "SUPER, D";
-          default = "";
-        };
+        default = "";
+        description = "Caelestia shell extra configs written to shell.json";
       };
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    programs.caelestia.ipcCmd =
-      if cfg.ipcType == "shell"
-      then caelestia-shell-ipc
-      else caelestia-cli-ipc;
+  config = let
+    shell = cfg.package or shell-default;
+  in
+    lib.mkIf cfg.enable {
+      systemd.user.services.caelestia = {
+        Unit = {
+          Description = "Caelestia Shell Service";
+          After = ["hyprland-session.target"];
+          Requires = ["hyprland-session.target"];
+          PartOf = ["graphical-session.target"];
+        };
 
-    wayland.windowManager.hyprland = {
-      settings = {
-        bind = let
-          bindIfConfigured = bindOpt: bindCmd: (lib.optional (bindOpt != "") "${bindOpt}, exec, ${cfg.ipcCmd} ${bindCmd}");
-        in
-          with cfg.binds;
-            lib.optionals cfg.binds.enable (
-              []
-              ++ bindIfConfigured toggleDashboard "drawers toggle dashboard"
-              ++ bindIfConfigured toggleLauncher "drawers toggle launcher"
-              ++ bindIfConfigured toggleOsd "drawers toggle osd"
-              ++ bindIfConfigured toggleBar "drawers toggle bar"
-              ++ bindIfConfigured openPicker "picker open"
-              ++ bindIfConfigured openPickerFreeze "picker openFreeze"
-              ++ bindIfConfigured openControlCenter "controlcenter open"
-            );
+        Service = {
+          ExecStart = "${shell}/bin/caelestia-shell";
+          Restart = "on-failure";
+          RestartSec = "5s";
+          Environment = [
+            "QT_QPA_PLATFORM=wayland"
+          ];
+
+          PassEnvironment = [
+            "WAYLAND_DISPLAY"
+            "XDG_RUNTIME_DIR"
+            "HYPRLAND_INSTANCE_SIGNATURE"
+          ];
+          Slice = "session.slice";
+        };
+
+        Install = {
+          WantedBy = ["hyprland-session.target"];
+        };
       };
+
+      home.file.".config/caelestia/shell.json".text = let
+        extraConfig =
+          if cfg.extraConfig != ""
+          then cfg.extraConfig
+          else "{}";
+      in
+        builtins.toJSON (lib.recursiveUpdate
+          (cfg.settings or {}) (builtins.fromJSON extraConfig));
+
+      home.packages = [shell];
     };
-
-    systemd.user.services.caelestia = {
-      Unit = {
-        Description = "Caelestia Shell Service";
-        After = ["hyprland-session.target"];
-        Requires = ["hyprland-session.target"];
-        PartOf = ["graphical-session.target"];
-      };
-
-      Service = {
-        ExecStart = "${caelestia-shell}/bin/caelestia-shell";
-        Restart = "on-failure";
-        RestartSec = "5s";
-        Environment = [
-          "QT_QPA_PLATFORM=wayland"
-        ];
-
-        PassEnvironment = [
-          "WAYLAND_DISPLAY"
-          "XDG_RUNTIME_DIR"
-          "HYPRLAND_INSTANCE_SIGNATURE"
-        ];
-        Slice = "session.slice";
-      };
-
-      Install = {
-        WantedBy = ["hyprland-session.target"];
-      };
-    };
-
-    home.file.".config/caelestia/shell.json".text = builtins.toJSON (cfg.settings or {});
-
-    home.packages = [caelestia-cli caelestia-shell];
-  };
 }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,146 @@
+self: {
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  caelestia-cli = self.inputs.caelestia-cli.packages.${pkgs.system}.default;
+  caelestia-shell = self.packages.${pkgs.system}.default;
+
+  caelestia-cli-ipc = "${caelestia-cli}/bin/caelestia shell";
+  caelestia-shell-ipc = "${caelestia-shell}/bin/caelestia-shell ipc call"; # Using this seems faster than caelestia-cli-ipc
+
+  cfg = config.programs.caelestia;
+in {
+  options = with lib; {
+    programs.caelestia = {
+      enable = mkEnableOption "Enable Caelestia shell";
+
+      settings = mkOption {
+        type = types.attrs;
+        default = {};
+        description = "Caelestia settings written to shell.json";
+      };
+
+      ipcType = mkOption {
+        type = types.enum [
+          "shell"
+          "cli"
+        ];
+        default = "shell";
+        description = "Caelestia IPC type, can be either \"shell\" or \"cli\", note that some commands may not work on both";
+      };
+
+      ipcCmd = mkOption {
+        type = types.str;
+        description = "IPC command used in this module, configured by ipcType option";
+        readOnly = true;
+      };
+
+      binds = {
+        enable = mkEnableOption "Enable useful keybinds to Hyprland";
+        toggleDashboard = mkOption {
+          type = types.str;
+          description = "Hyprland bind to toggle the dashboard.";
+          example = "SUPER, D";
+          default = "";
+        };
+        toggleLauncher = mkOption {
+          type = types.str;
+          description = "Hyprland bind to toggle the launcher.";
+          example = "SUPER, D";
+          default = "";
+        };
+        toggleOsd = mkOption {
+          type = types.str;
+          description = "Hyprland bind to toggle the OSD.";
+          example = "SUPER, D";
+          default = "";
+        };
+        toggleBar = mkOption {
+          type = types.str;
+          description = "Hyprland bind to toggle the bar.";
+          example = "SUPER, D";
+          default = "";
+        };
+        openPicker = mkOption {
+          type = types.str;
+          description = "Hyprland bind to open the picker.";
+          example = "SUPER, D";
+          default = "";
+        };
+        openPickerFreeze = mkOption {
+          type = types.str;
+          description = "Hyprland bind to open the picker while freezing the screen.";
+          example = "SUPER, D";
+          default = "";
+        };
+        openControlCenter = mkOption {
+          type = types.str;
+          description = "Hyprland bind to open the Control Center.";
+          example = "SUPER, D";
+          default = "";
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.caelestia.ipcCmd =
+      if cfg.ipcType == "shell"
+      then caelestia-shell-ipc
+      else caelestia-cli-ipc;
+
+    wayland.windowManager.hyprland = {
+      settings = {
+        bind = let
+          bindIfConfigured = bindOpt: bindCmd: (lib.optional (bindOpt != "") "${bindOpt}, exec, ${cfg.ipcCmd} ${bindCmd}");
+        in
+          with cfg.binds;
+            lib.optionals cfg.binds.enable (
+              []
+              ++ bindIfConfigured toggleDashboard "drawers toggle dashboard"
+              ++ bindIfConfigured toggleLauncher "drawers toggle launcher"
+              ++ bindIfConfigured toggleOsd "drawers toggle osd"
+              ++ bindIfConfigured toggleBar "drawers toggle bar"
+              ++ bindIfConfigured openPicker "picker open"
+              ++ bindIfConfigured openPickerFreeze "picker openFreeze"
+              ++ bindIfConfigured openControlCenter "controlcenter open"
+            );
+      };
+    };
+
+    systemd.user.services.caelestia = {
+      Unit = {
+        Description = "Caelestia Shell Service";
+        After = ["hyprland-session.target"];
+        Requires = ["hyprland-session.target"];
+        PartOf = ["graphical-session.target"];
+      };
+
+      Service = {
+        ExecStart = "${caelestia-shell}/bin/caelestia-shell";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        Environment = [
+          "QT_QPA_PLATFORM=wayland"
+        ];
+
+        PassEnvironment = [
+          "WAYLAND_DISPLAY"
+          "XDG_RUNTIME_DIR"
+          "HYPRLAND_INSTANCE_SIGNATURE"
+        ];
+        Slice = "session.slice";
+      };
+
+      Install = {
+        WantedBy = ["hyprland-session.target"];
+      };
+    };
+
+    home.file.".config/caelestia/shell.json".text = builtins.toJSON (cfg.settings or {});
+
+    home.packages = [caelestia-cli caelestia-shell];
+  };
+}

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -68,7 +68,7 @@ in {
         };
       };
 
-      home.file.".config/caelestia/shell.json".text = let
+      xdg.configFile."caelestia/shell.json".text = let
         extraConfig =
           if cfg.extraConfig != ""
           then cfg.extraConfig

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -46,29 +46,25 @@ in {
       systemd.user.services.caelestia = {
         Unit = {
           Description = "Caelestia Shell Service";
-          After = ["hyprland-session.target"];
-          Requires = ["hyprland-session.target"];
+          After = ["graphical-session.target"];
           PartOf = ["graphical-session.target"];
         };
 
         Service = {
+          Type = "exec";
           ExecStart = "${shell}/bin/caelestia-shell";
           Restart = "on-failure";
           RestartSec = "5s";
+          TimeoutStopSec = "5s";
           Environment = [
             "QT_QPA_PLATFORM=wayland"
           ];
 
-          PassEnvironment = [
-            "WAYLAND_DISPLAY"
-            "XDG_RUNTIME_DIR"
-            "HYPRLAND_INSTANCE_SIGNATURE"
-          ];
           Slice = "session.slice";
         };
 
         Install = {
-          WantedBy = ["hyprland-session.target"];
+          WantedBy = ["graphical-session.target"];
         };
       };
 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -5,7 +5,7 @@ self: {
   ...
 }: let
   cli-default = self.inputs.caelestia-cli.packages.${pkgs.system}.default;
-  shell-default = self.packages.${pkgs.system}.default;
+  shell-default = self.packages.${pkgs.system}.with-cli;
 
   cfg = config.programs.caelestia;
 in {
@@ -32,7 +32,7 @@ in {
         package = mkOption {
           type = types.package;
           default = cli-default;
-          description = "The package of Caelestia CLI";
+          description = "The package of Caelestia CLI"; # Doesn't override the shell's CLI, only change from home.packages
         };
       };
     };


### PR DESCRIPTION
This PR adds a home manager module and allow easily configuring `.config/caelestia/shell.json` option using Nix language. This module also creates a systemd user service which starts Caelestia shell after Hyprland.

With the growing of the project its good to have a home manager module for Nix users.

# Usage

```nix
# home.nix
programs.caelestia = {
    enable = true;
    settings = {
        bar.status = {
            showBattery = false;
        };
        paths.wallpaperDir = "~/Images";
    };
};
```

This module adds only `caelestia-shell` to PATH, if one wants to add the `caelestia` (CLI) too:

```nix
# home.nix
programs.caelestia.cli.enable = true;
```

Also allows a user to configure an `extraConfig` in the case they don't want to configure options using nix.

# Issues or limitations

~~At the time of writing this, the systemd service only works for Hyprland, but it's not hard to extend this to depends only in graphical target.~~

Should work on any wayland compositor with quickshell support, but ensure the correct env vars are imported to system environment using `dbus-update-activation-environment`