### PR TITLE
nix: extend `hm-module` for CLI config options and add `extraRuntimeDeps` to package

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -31,6 +31,7 @@
   pipewire,
   caelestia-cli,
   withCli ? false,
+  extraRuntimeDeps ? [],
 }: let
   runtimeDeps =
     [
@@ -53,6 +54,7 @@
       findutils
       file
     ]
+    ++ extraRuntimeDeps
     ++ lib.optional withCli caelestia-cli;
 
   fontconfig = makeFontsConf {

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -34,6 +34,16 @@ in {
           default = cli-default;
           description = "The package of Caelestia CLI"; # Doesn't override the shell's CLI, only change from home.packages
         };
+        settings = mkOption {
+          type = types.attrs;
+          default = {};
+          description = "Caelestia CLI settings";
+        };
+        extraConfig = mkOption {
+          type = types.str;
+          default = "{}";
+          description = "Caelestia shell extra configs written to shell.json";
+        };
       };
     };
   };
@@ -68,14 +78,21 @@ in {
         };
       };
 
-      xdg.configFile."caelestia/shell.json".text = let
-        extraConfig =
-          if cfg.extraConfig != ""
-          then cfg.extraConfig
-          else "{}";
-      in
-        builtins.toJSON (lib.recursiveUpdate
-          (cfg.settings or {}) (builtins.fromJSON extraConfig));
+      xdg.configFile = let
+        mkConfig = c:
+          lib.pipe (
+            if c.extraConfig != ""
+            then c.extraConfig
+            else "{}"
+          ) [
+            builtins.fromJSON
+            (lib.recursiveUpdate c.settings)
+            builtins.toJSON
+          ];
+      in {
+        "caelestia/shell.json".text = mkConfig cfg;
+        "caelestia/cli.json".text = mkConfig cfg.cli;
+      };
 
       home.packages = [shell] ++ lib.optional cfg.cli.enable cli;
     };


### PR DESCRIPTION
The Home Manager module was missing configuration options for the CLI. I added `settings` and `extraConfig` (just like the shell already has) to the CLI.
It’s debatable whether the CLI-related module logic should live here or be moved into the CLI repo, but for now this makes configuration more consistent.

The options can be used like this:

```nix
# home.nix
programs.caelestia = {
  # ...
  cli = {
    enable = true;
    settings = {
      theme.enableGtk = false;
    };
    extraConfig = ''
      {
        "theme": {
          "enableQt": false
        }
      }
    '';
  };
};
This results in ~/.config/caelestia/cli.json:
```json
{
  "theme": {
    "enableQt": false,
    "enableGtk": false
  }
}
```
#### Additional

I also added an `extraRuntimeDeps` input to the package function.
This makes it possible to inject specific packages into `caelestia-shell`’s `PATH`:
```nix
final: prev: {
  caelestia-shell = inputs.caelestia-shell.packages.${prev.system}.override {
    extraRuntimeDeps = [prev.pulseaudio];
  };
}
```