### PR TITLE
nix: use newer version of app2unit (fix #417)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
           withX11 = false;
           withI3 = false;
         };
+        app2unit = pkgs.callPackage ./nix/app2unit.nix {inherit pkgs;};
         caelestia-cli = inputs.caelestia-cli.packages.${pkgs.system}.default;
       };
       with-cli = caelestia-shell.override {withCli = true;};

--- a/nix/app2unit.nix
+++ b/nix/app2unit.nix
@@ -1,0 +1,14 @@
+{
+  pkgs, # To ensure the nixpkgs version of app2unit
+  fetchFromGitHub,
+  ...
+}:
+pkgs.app2unit.overrideAttrs (final: prev: rec {
+  version = "1.0.3"; # Fix old issue related to missing env var
+  src = fetchFromGitHub {
+    owner = "Vladimir-csp";
+    repo = "app2unit";
+    tag = "v${version}";
+    hash = "sha256-7eEVjgs+8k+/NLteSBKgn4gPaPLHC+3Uzlmz6XB0930=";
+  };
+})


### PR DESCRIPTION
This PR uses nixpkgs app2unit version but with a newer version (1.0.3), this fixes a bug where app2unit cannot launch any app if some env vars are missing. See [this issue](https://github.com/Vladimir-csp/app2unit/issues/6). Since the nixpkgs uses an older version, this issue exists.

Fixes #417 