### PR TITLE
change the pkg.system so it would not cause this error when using the…

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -4,8 +4,10 @@ self: {
   lib,
   ...
 }: let
-  cli-default = self.inputs.caelestia-cli.packages.${pkgs.system}.default;
-  shell-default = self.packages.${pkgs.system}.with-cli;
+  inherit (pkgs.stdenv.hostPlatform) system;
+
+  cli-default = self.inputs.caelestia-cli.packages.${system}.default;
+  shell-default = self.packages.${system}.with-cli;
 
   cfg = config.programs.caelestia;
 in {


### PR DESCRIPTION
hello 
i have noticed that when using the home-manager module it shows this error
```
error: attribute 'system' missing
```
while setting
```shell-default = self.packages.${pkgs.system}.with-cli;```

so tried changing the way that the system type is set in the nix config to get the system architecture form ```pkgs.stdenv.hostPlatform``` rather then ```pkgs.system```