### PR TITLE
feat(dashboard): Allow renaming media players

### DIFF
--- a/config/DashboardConfig.qml
+++ b/config/DashboardConfig.qml
@@ -7,7 +7,7 @@ JsonObject {
     property int visualiserBars: 45
     property int dragThreshold: 50
     property Sizes sizes: Sizes {}
-    property list<var> playerRenames: []
+    property list<var> mediaPlayerAliases: []
 
     component Sizes: JsonObject {
         readonly property int tabIndicatorHeight: 3

--- a/modules/dashboard/Media.qml
+++ b/modules/dashboard/Media.qml
@@ -27,7 +27,7 @@ Item {
 
     function getPlayerName(identity) {
         if (!identity) return "No players";
-        const rename = Config.dashboard.playerRenames.find(r => r.from === identity);
+        const rename = Config.dashboard.mediaPlayerAliases.find(r => r.from === identity);
         return rename ? rename.to : identity;
     }
 


### PR DESCRIPTION
This PR adds support for `mediaPlayerAliases` in the dashboard configuration.

Some media players (like YouTube Music) expose very long and ugly application identities (e.g. `com.github.th_ch.youtube_music`). With this change, you can configure custom names in your `~/.config/caelestia/shell.json`:
```json
{
    ...
    "dashboard": {
        ...
        "mediaPlayerAliases": [
            {"from": "com.github.th_ch.youtube_music", "to": "YT Music"}
        ]
    }
}
```
### Before

<img width="1180" height="550" alt="image" src="https://github.com/user-attachments/assets/fd0060fc-5f3e-4ee7-b1df-1d4eaf4c1426" />

### After

<img width="1180" height="550" alt="image" src="https://github.com/user-attachments/assets/dd2bb8df-6c35-44c2-b10a-a907f56fc35a" />

### Future Improvements

I couldn't figure out how to apply the alias to the identity name of the default active `MprisPlayer` in [services/Players.qml#12](https://github.com/caelestia-dots/shell/blob/d4c5415770d3eeeeb1612e11c1ea8c61765fe715/services/Players.qml#L12C90-L12C97).
It seems to be caused by a timing issue: the config file is evaluated before the active player is set, so the alias isn’t available at that point. If someone has an idea for a fix, please let me know.