### PR TITLE
nix: fix missing icons in hm-module

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -68,6 +68,7 @@ in {
           TimeoutStopSec = "5s";
           Environment = [
             "QT_QPA_PLATFORM=wayland"
+            "QT_QPA_PLATFORMTHEME=gtk3"
           ];
 
           Slice = "session.slice";


### PR DESCRIPTION
This PR fixes #390 for people that use the `home-manager`-module of this project. Have a look at the issue for why we chose to export the environment variable instead of using the CLI to start the shell.