### PR TITLE
nix: add wrapQtAppsHook

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -26,6 +26,7 @@
   rubik,
   nerd-fonts,
   gcc,
+  qt6,
   quickshell,
   aubio,
   pipewire,
@@ -66,7 +67,7 @@ in
     version = "${rev}";
     src = ./..;
 
-    nativeBuildInputs = [gcc makeWrapper];
+    nativeBuildInputs = [gcc makeWrapper qt6.wrapQtAppsHook];
     buildInputs = [quickshell aubio pipewire];
     propagatedBuildInputs = runtimeDeps;
 


### PR DESCRIPTION
This PR adds a wrapper to run Qt applications on NixOS.
Without this, modules such as `org.kde.kirigami` will not function properly.