### PR TITLE
modules/launcher: allow more queries to app searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,13 @@ All configuration options are in `~/.config/caelestia/shell.json`.
             "schemes": false,
             "variants": false,
             "wallpapers": false
+        },
+        "appQueryWeigths": {
+		        "name": 2,
+		        "comment": 1,
+		        "genericName": 0,
+		        "categories": 1,
+		        "keywords": 0
         }
     },
     "lock": {

--- a/config/LauncherConfig.qml
+++ b/config/LauncherConfig.qml
@@ -10,9 +10,10 @@ JsonObject {
     property bool vimKeybinds: false
     property UseFuzzy useFuzzy: UseFuzzy {}
     property Sizes sizes: Sizes {}
+    property AppQueryWeights appQueryWeights: AppQueryWeights {}
 
     component UseFuzzy: JsonObject {
-        property bool apps: false
+        property bool apps: true
         property bool actions: false
         property bool schemes: false
         property bool variants: false
@@ -24,5 +25,14 @@ JsonObject {
         property int itemHeight: 57
         property int wallpaperWidth: 280
         property int wallpaperHeight: 200
+    }
+
+    component AppQueryWeights: JsonObject {
+        property real name: 2
+        property real comment: 1
+        property real genericName: 0 // Zero or less = desconsidered query
+        property real categories: 0
+        property real keywords: 0
+
     }
 }

--- a/modules/launcher/services/Apps.qml
+++ b/modules/launcher/services/Apps.qml
@@ -8,6 +8,15 @@ Searcher {
     id: root
 
     list: DesktopEntries.applications.values.filter(a => !a.noDisplay).sort((a, b) => a.name.localeCompare(b.name))
+    keys: ["name", "comment", "genericName", "categories", "keywords"]
+    weights: [
+    	Config.launcher.appQueryWeights.name,
+    	Config.launcher.appQueryWeights.comment,
+    	Config.launcher.appQueryWeights.genericName,
+    	Config.launcher.appQueryWeights.categories,
+    	Config.launcher.appQueryWeights.keywords
+    ]
+
     useFuzzy: Config.launcher.useFuzzy.apps
 
     function launch(entry: DesktopEntry): void {

--- a/utils/Searcher.qml
+++ b/utils/Searcher.qml
@@ -27,7 +27,7 @@ Singleton {
 	            if(typeof e[k][0] === "string")
 	                obj[k] = Fuzzy.prepare(e[k].join());
 	        }
-            else
+            else if(typeof e[k] === "string")
                 obj[k] = Fuzzy.prepare(e[k]);
         }
         return obj;


### PR DESCRIPTION
This PR enhances app searching by allowing users to search for additional desktop entry attributes, including **Comment**, **GenericName**, **Categories**, and **Keywords**, as suggested in #451. 

I utilized the existing Fuzzy mechanism to implement this "advanced search," although fzf's advanced search feature is not yet available. I enabled Fuzzy sorting by default to improve the search algorithm, but I'm open to suggestions on this.

New configuration options in the launcher section allow users to adjust the weights for each search field, with **Name** and **Comment** set to `2` and `1`, respectively. I also made minor adjustments to the **Searcher** to support multi-searching for other mechanisms that may need to search within a `list<string>`.

Overall, these changes improve search functionality, particularly for users looking to search by **Category**, **Keywords**, **GenericName**, and **Comment**, which I believe enhances the user experience.