### PR TITLE
fix: reset title to "Desktop" when switching to empty workspace

### DIFF
--- a/modules/bar/components/ActiveWindow.qml
+++ b/modules/bar/components/ActiveWindow.qml
@@ -8,6 +8,32 @@ import QtQuick
 
 Item {
     id: root
+    // Helper function to retrieve active window icon
+    function getActiveWindowIcon() {
+        const ws = Hyprland.focusedWorkspace;
+        if (!ws)
+            return "desktop_windows";
+
+        const at = Hyprland.activeToplevel;
+        if (at && at.workspace === ws) {
+            return Icons.getAppCategoryIcon(at.lastIpcObject.class, "desktop_windows");
+        }
+        return "desktop_windows";
+    }
+
+    // Helper function to retrieve active window title
+    function getActiveWindowTitle() {
+        const ws = Hyprland.focusedWorkspace;
+        if (!ws)
+            return qsTr("Desktop");
+
+        const at = Hyprland.activeToplevel;
+        if (at && at.workspace === ws) {
+            return at.title && at.title.length ? at.title : qsTr("Desktop");
+        }
+
+        return qsTr("Desktop");
+    }
 
     required property var bar
     required property Brightness.Monitor monitor
@@ -31,7 +57,7 @@ Item {
         anchors.horizontalCenter: parent.horizontalCenter
 
         animate: true
-        text: Icons.getAppCategoryIcon(Hyprland.activeToplevel?.lastIpcObject.class, "desktop_windows")
+        text: getActiveWindowIcon()
         color: root.colour
     }
 
@@ -46,7 +72,7 @@ Item {
     TextMetrics {
         id: metrics
 
-        text: Hyprland.activeToplevel?.title ?? qsTr("Desktop")
+        text: getActiveWindowTitle()
         font.pointSize: Appearance.font.size.smaller
         font.family: Appearance.font.family.mono
         elide: Qt.ElideRight


### PR DESCRIPTION
This PR intends to fix a bug where the active window title failed to show "Desktop" on new workspace switch. On switching from an existing workspace withan already running window (say, Spotify) to a new and fresh workspace where I am expecting to see "Desktop" as the title, the "Spotify" title from last workspace still persists.

Before, on switching from an old to a new workspace:
<img width="130" height="1080" alt="1755885342_grim" src="https://github.com/user-attachments/assets/05d564e4-f0b9-49b5-b02a-a0ef6cf21d2b" /><img width="105" height="1080" alt="1755885359_grim" src="https://github.com/user-attachments/assets/13149c58-2420-400e-a084-cb1996cfc197" />

This PR adds two helper functions that resolve this issue. One for text and the other for icon. Both being similar. Each of these helper functions checks whether the window whose title/icon is being displayed even belongs to the current workspace or not. This prevents persistence and I believe is much more efficient than using mere ? : operators.

After using the helper functions, on switching from an old to a new workspace:
<img width="102" height="1080" alt="1755885799_grim" src="https://github.com/user-attachments/assets/3a19e7d1-73e4-4604-812a-a06e2c98f031" /><img width="96" height="1080" alt="1755885809_grim" src="https://github.com/user-attachments/assets/3be93cca-8213-47cc-a1f9-970c68ba450a" />
