### PR TITLE
Added option to disable brightness slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,10 +307,9 @@ default, you must create it manually.
         "expire": false
     },
     "osd": {
-        "hideDelay": 2000,
-        "sliders": {
-            "showBrightnessSlider": true
-        }
+        "enabled": true,
+        "enableBrightness": true,
+        "hideDelay": 2000
     },
     "paths": {
         "mediaGif": "root:/assets/bongocat.gif",

--- a/README.md
+++ b/README.md
@@ -307,7 +307,10 @@ default, you must create it manually.
         "expire": false
     },
     "osd": {
-        "hideDelay": 2000
+        "hideDelay": 2000,
+        "sliders": {
+            "showBrightnessSlider": true
+        }
     },
     "paths": {
         "mediaGif": "root:/assets/bongocat.gif",

--- a/config/OsdConfig.qml
+++ b/config/OsdConfig.qml
@@ -3,14 +3,11 @@ import Quickshell.Io
 JsonObject {
     property bool enabled: true
     property int hideDelay: 2000
+    property bool enableBrightness: true
     property Sizes sizes: Sizes {}
-    property Sliders sliders: Sliders {}
 
     component Sizes: JsonObject {
         property int sliderWidth: 30
         property int sliderHeight: 150
-    }
-    component Sliders: JsonObject {
-        property bool showBrightnessSlider: true
     }
 }

--- a/config/OsdConfig.qml
+++ b/config/OsdConfig.qml
@@ -4,9 +4,13 @@ JsonObject {
     property bool enabled: true
     property int hideDelay: 2000
     property Sizes sizes: Sizes {}
+    property Sliders sliders: Sliders {}
 
     component Sizes: JsonObject {
         property int sliderWidth: 30
         property int sliderHeight: 150
+    }
+    component Sliders: JsonObject {
+        property bool showBrightnessSlider: true
     }
 }

--- a/modules/osd/Content.qml
+++ b/modules/osd/Content.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import qs.components.controls
 import qs.services
 import qs.config
@@ -16,6 +18,7 @@ Column {
 
     spacing: Appearance.spacing.normal
 
+    // Speaker volume
     CustomMouseArea {
         implicitWidth: Config.osd.sizes.sliderWidth
         implicitHeight: Config.osd.sizes.sliderHeight
@@ -36,10 +39,10 @@ Column {
         }
     }
 
-    // Brightness Slider
+    // Brightness
     WrappedLoader {
-        name: "brightnessSlider"
-        active: Config.osd.sliders.showBrightnessSlider
+        active: Config.osd.enableBrightness
+
         sourceComponent: CustomMouseArea {
             implicitWidth: Config.osd.sizes.sliderWidth
             implicitHeight: Config.osd.sizes.sliderHeight
@@ -64,7 +67,6 @@ Column {
         }
     }
     component WrappedLoader: Loader {
-        required property string name
         asynchronous: true
         visible: active
     }

--- a/modules/osd/Content.qml
+++ b/modules/osd/Content.qml
@@ -3,6 +3,7 @@ import qs.services
 import qs.config
 import qs.utils
 import QtQuick
+import QtQuick.Layouts
 
 Column {
     id: root
@@ -36,26 +37,38 @@ Column {
         }
     }
 
-    CustomMouseArea {
-        implicitWidth: Config.osd.sizes.sliderWidth
-        implicitHeight: Config.osd.sizes.sliderHeight
+    // Brightness Slider
+    WrappedLoader {
+        name: "brightness"
+        active: Config.osd.sliders.showBrightnessSlider
+        sourceComponent: CustomMouseArea {
+            implicitWidth: Config.osd.sizes.sliderWidth
+            implicitHeight: Config.osd.sizes.sliderHeight
 
-        onWheel: event => {
-            const monitor = root.monitor;
-            if (!monitor)
-                return;
-            if (event.angleDelta.y > 0)
-                monitor.setBrightness(monitor.brightness + 0.1);
-            else if (event.angleDelta.y < 0)
-                monitor.setBrightness(monitor.brightness - 0.1);
+            onWheel: event => {
+                const monitor = root.monitor;
+                if (!monitor)
+                    return;
+                if (event.angleDelta.y > 0)
+                    monitor.setBrightness(monitor.brightness + 0.1);
+                else if (event.angleDelta.y < 0)
+                    monitor.setBrightness(monitor.brightness - 0.1);
+            }
+
+            FilledSlider {
+                anchors.fill: parent
+
+                icon: `brightness_${(Math.round(value * 6) + 1)}`
+                value: root.monitor?.brightness ?? 0
+                onMoved: root.monitor?.setBrightness(value)
+            }
         }
+    }
+    component WrappedLoader: Loader {
+        required property string name
 
-        FilledSlider {
-            anchors.fill: parent
-
-            icon: `brightness_${(Math.round(value * 6) + 1)}`
-            value: root.monitor?.brightness ?? 0
-            onMoved: root.monitor?.setBrightness(value)
-        }
+        Layout.alignment: Qt.AlignHCenter
+        asynchronous: true
+        visible: active
     }
 }

--- a/modules/osd/Content.qml
+++ b/modules/osd/Content.qml
@@ -3,7 +3,6 @@ import qs.services
 import qs.config
 import qs.utils
 import QtQuick
-import QtQuick.Layouts
 
 Column {
     id: root
@@ -66,8 +65,6 @@ Column {
     }
     component WrappedLoader: Loader {
         required property string name
-
-        Layout.alignment: Qt.AlignHCenter
         asynchronous: true
         visible: active
     }

--- a/modules/osd/Content.qml
+++ b/modules/osd/Content.qml
@@ -38,7 +38,7 @@ Column {
 
     // Brightness Slider
     WrappedLoader {
-        name: "brightness"
+        name: "brightnessSlider"
         active: Config.osd.sliders.showBrightnessSlider
         sourceComponent: CustomMouseArea {
             implicitWidth: Config.osd.sizes.sliderWidth


### PR DESCRIPTION
### What would you like to be added?
An option to disable the brightness slider for desktop users.

### How will it help?
The brightness slider doesn’t really work on desktops and just takes up space, so turning it off for desktop users would keep the interface cleaner and less confusing.

![screenshot](https://github.com/user-attachments/assets/ea6729fe-f4cc-4337-83b2-e84d4e14db12)
