### PR TITLE
Automatically restart the shell when config changes after home-manager activation

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -60,6 +60,9 @@ in {
           Description = "Caelestia Shell Service";
           After = ["graphical-session.target"];
           PartOf = ["graphical-session.target"];
+          X-Restart-Triggers = lib.mkIf (cfg.settings != { }) [
+            "${config.xdg.configFile."caelestia/shell.json".source}"
+          ];
         };
 
         Service = {


### PR DESCRIPTION
Here's the usual way home-manager modules automatically restart a systemd service after changes to the module's configuration.