### PR TITLE
nix: better dev shell + refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,13 @@ set(INSTALL_QSCONFDIR "etc/xdg/quickshell/caelestia" CACHE STRING "Quickshell co
 
 add_compile_options(-Wall -Wextra)
 
-add_subdirectory(assets/cpp)
-add_subdirectory(plugin)
+if(NOT DONT_BUILD_ASSETS)
+    add_subdirectory(assets/cpp)
+endif()
+
+if(NOT DONT_BUILD_PLUGIN)
+    add_subdirectory(plugin)
+endif()
 
 foreach(dir assets components config modules services utils)
     install(DIRECTORY ${dir} DESTINATION "${INSTALL_QSCONFDIR}")

--- a/assets/cpp/CMakeLists.txt
+++ b/assets/cpp/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.19)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PIPEWIRE REQUIRED libpipewire-0.3)
 pkg_check_modules(AUBIO REQUIRED aubio)

--- a/flake.nix
+++ b/flake.nix
@@ -45,10 +45,17 @@
       default = let
         shell = self.packages.${pkgs.system}.caelestia-shell;
       in
-        pkgs.mkShellNoCC {
-          inputsFrom = [shell];
+        pkgs.mkShell {
+          inputsFrom = [shell shell.plugin shell.assets];
           packages = with pkgs; [material-symbols rubik nerd-fonts.caskaydia-cove];
-          CAELESTIA_LIB_DIR = "${shell}/lib";
+
+          CAELESTIA_XKB_RULES_PATH = "${pkgs.xkeyboard-config}/share/xkeyboard-config-2/rules/base.lst";
+          shellHook = ''
+            cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+            cmake --build build
+            export CAELESTIA_LIB_DIR="$PWD/build/assets/cpp";
+            export QML2_IMPORT_PATH="$PWD/build/qml";
+          '';
         };
     });
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -63,25 +63,44 @@
   fontconfig = makeFontsConf {
     fontDirectories = [material-symbols rubik nerd-fonts.caskaydia-cove];
   };
+
+  assets = stdenv.mkDerivation {
+    name = "caelestia-assets";
+    src = ./../assets/cpp;
+
+    nativeBuildInputs = [cmake pkg-config];
+    buildInputs = [aubio pipewire];
+
+    cmakeFlags = [(lib.cmakeFeature "INSTALL_LIBDIR" "${placeholder "out"}/lib")];
+  };
+
+  plugin = stdenv.mkDerivation {
+    name = "caelestia-qml-plugin";
+    src = ./../plugin;
+    nativeBuildInputs = [cmake];
+    buildInputs = [qt6.qtbase qt6.qtdeclarative];
+    dontWrapQtApps = true;
+    cmakeFlags = [(lib.cmakeFeature "INSTALL_QMLDIR" qt6.qtbase.qtQmlPrefix)];
+  };
 in
   stdenv.mkDerivation {
     inherit version;
     pname = "caelestia-shell";
     src = ./..;
 
-    nativeBuildInputs = [cmake ninja pkg-config makeWrapper qt6.wrapQtAppsHook];
-    buildInputs = [quickshell aubio pipewire xkeyboard-config qt6.qtbase qt6.qtdeclarative];
+    nativeBuildInputs = [cmake ninja makeWrapper qt6.wrapQtAppsHook];
+    buildInputs = [quickshell assets plugin xkeyboard-config qt6.qtbase];
     propagatedBuildInputs = runtimeDeps;
 
     cmakeBuildType = "Release";
     cmakeFlags = [
       (lib.cmakeFeature "VERSION" version)
-      (lib.cmakeFeature "INSTALL_LIBDIR" "${placeholder "out"}/lib")
-      (lib.cmakeFeature "INSTALL_QMLDIR" qt6.qtbase.qtQmlPrefix)
+      (lib.cmakeFeature "DONT_BUILD_PLUGIN" "ON")
+      (lib.cmakeFeature "DONT_BUILD_ASSETS" "ON")
       (lib.cmakeFeature "INSTALL_QSCONFDIR" "${placeholder "out"}/share/caelestia-shell")
     ];
 
-    patchPhase = ''
+    prePatch = ''
       substituteInPlace assets/pam.d/fprint \
         --replace-fail pam_fprintd.so /run/current-system/sw/lib/security/pam_fprintd.so
     '';
@@ -90,10 +109,14 @@ in
       makeWrapper ${quickshell}/bin/qs $out/bin/caelestia-shell \
       	--prefix PATH : "${lib.makeBinPath runtimeDeps}" \
       	--set FONTCONFIG_FILE "${fontconfig}" \
-      	--set CAELESTIA_LIB_DIR $out/lib \
+      	--set CAELESTIA_LIB_DIR ${assets}/lib \
         --set CAELESTIA_XKB_RULES_PATH ${xkeyboard-config}/share/xkeyboard-config-2/rules/base.lst \
       	--add-flags "-p $out/share/caelestia-shell"
     '';
+
+    passthru = {
+      inherit plugin assets;
+    };
 
     meta = {
       description = "A very segsy desktop shell";

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.19)
 find_package(Qt6 REQUIRED COMPONENTS Core Qml)
 
 if(QT_KNOWN_POLICY_QTP0001)


### PR DESCRIPTION
# Issue
With the latest changes (d65fb180ad5ee41049b9d0f9a962901524636b6a) the caelestia plugin was added, and this broke the nix develop environment (no more `qs -p .`, it fails with missing module) since the quickshell package exposed to that environment is not wrapped with `wrapQtAppsHook` and the plugin. 

# Changelist
- fixes this issue wrapping separately the quickshell into a package and adding it to `buildInputs`. 
- use `caelestiaEnv` to automatically add env vars to package and dev shell.
- uneeded binaries were removed from PATH
- removed old `gcc` dependency from caelestia-shell `nativeBuildInputs`