### PR TITLE
launcher: showOnHover config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,8 @@ default, you must create it manually.
             "schemes": false,
             "variants": false,
             "wallpapers": false
-        }
+        },
+        "showOnHover": false
     },
     "lock": {
         "recolourLogo": false

--- a/config/LauncherConfig.qml
+++ b/config/LauncherConfig.qml
@@ -2,6 +2,7 @@ import Quickshell.Io
 
 JsonObject {
     property bool enabled: true
+    property bool showOnHover: false
     property int maxShown: 8
     property int maxWallpapers: 9 // Warning: even numbers look bad
     property string specialPrefix: "@"

--- a/modules/drawers/Interactions.qml
+++ b/modules/drawers/Interactions.qml
@@ -121,8 +121,10 @@ CustomMouseArea {
                 visibilities.session = false;
         }
 
-        // Show/hide launcher on drag
-        if (pressed && inBottomPanel(panels.launcher, dragStart.x, dragStart.y) && withinPanelWidth(panels.launcher, x, y)) {
+        // Show launcher on hover, or show/hide on drag if hover is disabled
+        if (Config.launcher.showOnHover) {
+            visibilities.launcher = inBottomPanel(panels.launcher, x, y);
+        } else if (pressed && inBottomPanel(panels.launcher, dragStart.x, dragStart.y) && withinPanelWidth(panels.launcher, x, y)) {
             const dragY = y - dragStart.y;
             if (dragY < -Config.launcher.dragThreshold)
                 visibilities.launcher = true;


### PR DESCRIPTION
Added `showOnHover` to launcher config, disabled by default to preserve existing functionality. When enabled, drag-to-show/hide is disabled.