### PR TITLE
dashboard: add month/year and paging to calendar

### DIFF
--- a/modules/dashboard/Dash.qml
+++ b/modules/dashboard/Dash.qml
@@ -56,6 +56,8 @@ GridLayout {
 
         Calendar {
             id: calendar
+
+            state: root.state
         }
     }
 

--- a/modules/dashboard/Wrapper.qml
+++ b/modules/dashboard/Wrapper.qml
@@ -15,6 +15,7 @@ Item {
     required property PersistentProperties visibilities
     readonly property PersistentProperties state: PersistentProperties {
         property int currentTab
+        property date currentDate: new Date()
 
         readonly property FileDialog facePicker: FileDialog {
             title: qsTr("Select a profile picture")

--- a/modules/dashboard/dash/Calendar.qml
+++ b/modules/dashboard/dash/Calendar.qml
@@ -5,6 +5,7 @@ import qs.services
 import qs.config
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 Column {
     id: root
@@ -14,8 +15,95 @@ Column {
     padding: Appearance.padding.large
     spacing: Appearance.spacing.small
 
+    property date currentDate: new Date()
+
+    RowLayout {
+        id: monthNavigationRow
+
+        width: parent.width - (root.padding * 2)
+        spacing: Appearance.spacing.small
+
+        Item {
+            Layout.preferredWidth: 30
+            Layout.preferredHeight: 30
+
+            StyledRect {
+                anchors.centerIn: parent
+
+                implicitWidth: implicitHeight
+                implicitHeight: prevMonthText.implicitHeight + Appearance.padding.small * 2
+
+                radius: Appearance.rounding.full
+                color: prevMonthMouseArea.containsMouse ? Colours.palette.m3primary : "transparent"
+            }
+
+            StyledText {
+                id: prevMonthText
+                anchors.centerIn: parent
+                text: "<"
+                color: prevMonthMouseArea.containsMouse ? Colours.palette.m3onPrimary : Colours.palette.m3primary 
+                font.pointSize: Appearance.font.size.normal
+                font.weight: 700
+            }
+
+            MouseArea {
+                id: prevMonthMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                onClicked: {
+                    root.currentDate = new Date(root.currentDate.getFullYear(), root.currentDate.getMonth() - 1, 1);
+                }
+            }
+        }
+
+        StyledText {
+            id: monthYearDisplay
+
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
+            text: Qt.formatDateTime(root.currentDate, "MMMM yyyy")
+            color: Colours.palette.m3primary
+            font.pointSize: Appearance.font.size.normal
+            font.weight: 500
+            font.capitalization: Font.Capitalize
+        }
+
+        Item {
+            Layout.preferredWidth: 30
+            Layout.preferredHeight: 30
+
+            StyledRect {
+                anchors.centerIn: parent
+
+                implicitWidth: implicitHeight
+                implicitHeight: nextMonthText.implicitHeight + Appearance.padding.small * 2
+
+                radius: Appearance.rounding.full
+                color: nextMonthMouseArea.containsMouse ? Colours.palette.m3primary : "transparent"
+            }
+
+            StyledText {
+                id: nextMonthText
+                anchors.centerIn: parent
+                text: ">"
+                color: nextMonthMouseArea.containsMouse ? Colours.palette.m3onPrimary : Colours.palette.m3primary
+                font.pointSize: Appearance.font.size.normal
+                font.weight: 700
+            }
+
+            MouseArea {
+                id: nextMonthMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                onClicked: {
+                    root.currentDate = new Date(root.currentDate.getFullYear(), root.currentDate.getMonth() + 1, 1);
+                }
+            }
+        }
+    }
+
     DayOfWeekRow {
-        id: days
+        id: daysRow
 
         anchors.left: parent.left
         anchors.right: parent.right
@@ -25,14 +113,18 @@ Column {
             required property var model
 
             horizontalAlignment: Text.AlignHCenter
-            text: model.shortName
+            text: model.shortName.toLowerCase()
             font.family: Appearance.font.family.sans
             font.weight: 500
+            color: (model.index === 0 || model.index === 6) ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
         }
     }
 
     MonthGrid {
         id: grid
+
+        month: root.currentDate.getMonth()
+        year: root.currentDate.getFullYear()
 
         anchors.left: parent.left
         anchors.right: parent.right
@@ -41,7 +133,7 @@ Column {
         spacing: 3
 
         delegate: Item {
-            id: day
+            id: dayItem
 
             required property var model
 
@@ -55,17 +147,31 @@ Column {
                 implicitHeight: parent.implicitHeight
 
                 radius: Appearance.rounding.full
-                color: Qt.alpha(Colours.palette.m3primary, day.model.today ? 1 : 0)
+                color: model.today ? Colours.palette.m3primary : "transparent"
+            }
 
-                StyledText {
-                    id: text
+            StyledText {
+                id: text
 
-                    anchors.centerIn: parent
+                anchors.centerIn: parent
 
-                    horizontalAlignment: Text.AlignHCenter
-                    text: Qt.formatDate(day.model.date, "d")
-                    color: day.model.today ? Colours.palette.m3onPrimary : day.model.month === grid.month ? Colours.palette.m3onSurfaceVariant : Colours.palette.m3outline
+                horizontalAlignment: Text.AlignHCenter
+                text: Qt.formatDate(dayItem.model.date, "d")
+                color: {
+                    var dayOfWeek = (dayItem.model.date.getDay()+1)%7;
+                    if (dayItem.model.today) {
+                        return Colours.palette.m3onPrimary;
+                    } else if (dayOfWeek === 0 || dayOfWeek === 6) {
+                        return Colours.palette.m3primary;
+                    } else if (dayItem.model.month === grid.month) {
+                        return Colours.palette.m3onSurfaceVariant;
+                    } else {
+                        return Colours.palette.m3outline;
+                    }
                 }
+                opacity: dayItem.model.month === grid.month ? 1.0 : 0.4
+                font.pointSize: Appearance.font.size.normal
+                font.weight: 500
             }
         }
     }

--- a/modules/dashboard/dash/Calendar.qml
+++ b/modules/dashboard/dash/Calendar.qml
@@ -16,97 +16,105 @@ Column {
     spacing: Appearance.spacing.small
 
     property date currentDate: new Date()
-    property int currMonth: currentDate.getMonth()
-    property int currYear: currentDate.getFullYear()
+    readonly property int currMonth: currentDate.getMonth()
+    readonly property int currYear: currentDate.getFullYear()
 
     RowLayout {
         id: monthNavigationRow
 
-        width: parent.width - (root.padding * 2)
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.margins: parent.padding
         spacing: Appearance.spacing.small
 
-        Item {
-            Layout.preferredWidth: 30
-            Layout.preferredHeight: 30
+        StyledRect {
+            implicitWidth: implicitHeight
+            implicitHeight: prevMonthText.implicitHeight + Appearance.padding.small * 2
 
-            StyledRect {
-                anchors.centerIn: parent
+            radius: Appearance.rounding.full
 
-                implicitWidth: implicitHeight
-                implicitHeight: prevMonthText.implicitHeight + Appearance.padding.small * 2
+            StateLayer {
+                id: prevMonthStateLayer
 
-                radius: Appearance.rounding.full
-                color: prevMonthMouseArea.containsMouse ? Colours.palette.m3primary : "transparent"
+                function onClicked(): void {
+                    root.currentDate = new Date(root.currYear, root.currMonth - 1, 1);
+                }
             }
 
             MaterialIcon {
                 id: prevMonthText
+
                 anchors.centerIn: parent
                 text: "chevron_left"
-                color: prevMonthMouseArea.containsMouse ? Colours.palette.m3onPrimary : Colours.palette.m3primary 
+                color: Colours.palette.m3tertiary
                 font.pointSize: Appearance.font.size.normal
                 font.weight: 700
             }
-
-            MouseArea {
-                id: prevMonthMouseArea
-                anchors.fill: parent
-                hoverEnabled: true
-                onClicked: {
-                    root.currentDate = new Date(root.currYear, root.currMonth - 1, 1);
-                }
-            }
-        }
-
-        StyledText {
-            id: monthYearDisplay
-
-            Layout.fillWidth: true
-            horizontalAlignment: Text.AlignHCenter
-            text: grid.title
-            color: Colours.palette.m3primary
-            font.pointSize: Appearance.font.size.normal
-            font.weight: 500
-            font.capitalization: Font.Capitalize
         }
 
         Item {
-            Layout.preferredWidth: 30
-            Layout.preferredHeight: 30
+            Layout.fillWidth: true
 
-            StyledRect {
-                anchors.centerIn: parent
+            implicitWidth: monthYearDisplay.implicitWidth + Appearance.padding.small * 2
+            implicitHeight: monthYearDisplay.implicitHeight + Appearance.padding.small * 2
 
-                implicitWidth: implicitHeight
-                implicitHeight: nextMonthText.implicitHeight + Appearance.padding.small * 2
+            StateLayer {
+                anchors.fill: monthYearDisplay
+                anchors.margins: -Appearance.padding.small
+                anchors.leftMargin: -Appearance.padding.normal
+                anchors.rightMargin: -Appearance.padding.normal
 
                 radius: Appearance.rounding.full
-                color: nextMonthMouseArea.containsMouse ? Colours.palette.m3primary : "transparent"
+                disabled: root.currentDate.toDateString() == new Date().toDateString()
+
+                function onClicked(): void {
+                    root.currentDate = new Date();
+                }
+            }
+
+            StyledText {
+                id: monthYearDisplay
+
+                anchors.centerIn: parent
+                text: grid.title
+                color: Colours.palette.m3primary
+                font.pointSize: Appearance.font.size.normal
+                font.weight: 500
+                font.capitalization: Font.Capitalize
+            }
+        }
+
+        StyledRect {
+            implicitWidth: implicitHeight
+            implicitHeight: nextMonthText.implicitHeight + Appearance.padding.small * 2
+
+            radius: Appearance.rounding.full
+
+            StateLayer {
+                id: nextMonthStateLayer
+
+                function onClicked(): void {
+                    root.currentDate = new Date(root.currYear, root.currMonth + 1, 1);
+                }
             }
 
             MaterialIcon {
                 id: nextMonthText
+
                 anchors.centerIn: parent
                 text: "chevron_right"
-                color: nextMonthMouseArea.containsMouse ? Colours.palette.m3onPrimary : Colours.palette.m3primary
+                color: Colours.palette.m3tertiary
                 font.pointSize: Appearance.font.size.normal
                 font.weight: 700
-            }
-
-            MouseArea {
-                id: nextMonthMouseArea
-                anchors.fill: parent
-                hoverEnabled: true
-                onClicked: {
-                    root.currentDate = new Date(root.currYear, root.currMonth + 1, 1);
-                }
             }
         }
     }
 
     DayOfWeekRow {
         id: daysRow
+
         locale: grid.locale
+
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.margins: parent.padding
@@ -116,9 +124,8 @@ Column {
 
             horizontalAlignment: Text.AlignHCenter
             text: model.shortName
-            font.family: Appearance.font.family.sans
             font.weight: 500
-            color: (model.day === 0 || model.day === 6) ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+            color: (model.day === 0 || model.day === 6) ? Colours.palette.m3secondary : Colours.palette.m3onSurfaceVariant
         }
     }
 
@@ -161,18 +168,16 @@ Column {
                 horizontalAlignment: Text.AlignHCenter
                 text: grid.locale.toString(dayItem.model.day)
                 color: {
-                    var dayOfWeek = dayItem.model.date.getUTCDay();
-                    if (dayItem.model.today) {
+                    if (dayItem.model.today)
                         return Colours.palette.m3onPrimary;
-                    } else if (dayOfWeek === 0 || dayOfWeek === 6) {
-                        return Colours.palette.m3primary;
-                    } else if (dayItem.model.month === grid.month) {
-                        return Colours.palette.m3onSurfaceVariant;
-                    } else {
-                        return Colours.palette.m3outline;
-                    }
+
+                    const dayOfWeek = dayItem.model.date.getUTCDay();
+                    if (dayOfWeek === 0 || dayOfWeek === 6)
+                        return Colours.palette.m3secondary;
+
+                    return Colours.palette.m3onSurfaceVariant;
                 }
-                opacity: dayItem.model.month === grid.month ? 1.0 : 0.4
+                opacity: dayItem.model.today || dayItem.model.month === grid.month ? 1 : 0.4
                 font.pointSize: Appearance.font.size.normal
                 font.weight: 500
             }

--- a/modules/dashboard/dash/Calendar.qml
+++ b/modules/dashboard/dash/Calendar.qml
@@ -16,6 +16,8 @@ Column {
     spacing: Appearance.spacing.small
 
     property date currentDate: new Date()
+    property int currMonth: currentDate.getMonth()
+    property int currYear: currentDate.getFullYear()
 
     RowLayout {
         id: monthNavigationRow
@@ -51,7 +53,7 @@ Column {
                 anchors.fill: parent
                 hoverEnabled: true
                 onClicked: {
-                    root.currentDate = new Date(root.currentDate.getFullYear(), root.currentDate.getMonth() - 1, 1);
+                    root.currentDate = new Date(root.currYear, root.currMonth - 1, 1);
                 }
             }
         }
@@ -96,7 +98,7 @@ Column {
                 anchors.fill: parent
                 hoverEnabled: true
                 onClicked: {
-                    root.currentDate = new Date(root.currentDate.getFullYear(), root.currentDate.getMonth() + 1, 1);
+                    root.currentDate = new Date(root.currYear, root.currMonth + 1, 1);
                 }
             }
         }
@@ -123,8 +125,8 @@ Column {
     MonthGrid {
         id: grid
 
-        month: root.currentDate.getMonth()
-        year: root.currentDate.getFullYear()
+        month: root.currMonth
+        year: root.currYear
 
         anchors.left: parent.left
         anchors.right: parent.right
@@ -157,9 +159,9 @@ Column {
                 anchors.centerIn: parent
 
                 horizontalAlignment: Text.AlignHCenter
-                text: grid.locale.toString(dayItem.model.date, "d")
+                text: grid.locale.toString(dayItem.model.day)
                 color: {
-                    var dayOfWeek = dayItem.model.date.getDay();
+                    var dayOfWeek = dayItem.model.date.getUTCDay();
                     if (dayItem.model.today) {
                         return Colours.palette.m3onPrimary;
                     } else if (dayOfWeek === 0 || dayOfWeek === 6) {

--- a/modules/dashboard/dash/Calendar.qml
+++ b/modules/dashboard/dash/Calendar.qml
@@ -158,7 +158,7 @@ Column {
                 horizontalAlignment: Text.AlignHCenter
                 text: Qt.formatDate(dayItem.model.date, "d")
                 color: {
-                    var dayOfWeek = (dayItem.model.date.getDay()+1)%7;
+                    var dayOfWeek = dayItem.model.date.getDay();
                     if (dayItem.model.today) {
                         return Colours.palette.m3onPrimary;
                     } else if (dayOfWeek === 0 || dayOfWeek === 6) {

--- a/modules/dashboard/dash/Calendar.qml
+++ b/modules/dashboard/dash/Calendar.qml
@@ -37,10 +37,10 @@ Column {
                 color: prevMonthMouseArea.containsMouse ? Colours.palette.m3primary : "transparent"
             }
 
-            StyledText {
+            MaterialIcon {
                 id: prevMonthText
                 anchors.centerIn: parent
-                text: "<"
+                text: "chevron_left"
                 color: prevMonthMouseArea.containsMouse ? Colours.palette.m3onPrimary : Colours.palette.m3primary 
                 font.pointSize: Appearance.font.size.normal
                 font.weight: 700
@@ -61,7 +61,7 @@ Column {
 
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignHCenter
-            text: Qt.formatDateTime(root.currentDate, "MMMM yyyy")
+            text: grid.title
             color: Colours.palette.m3primary
             font.pointSize: Appearance.font.size.normal
             font.weight: 500
@@ -82,10 +82,10 @@ Column {
                 color: nextMonthMouseArea.containsMouse ? Colours.palette.m3primary : "transparent"
             }
 
-            StyledText {
+            MaterialIcon {
                 id: nextMonthText
                 anchors.centerIn: parent
-                text: ">"
+                text: "chevron_right"
                 color: nextMonthMouseArea.containsMouse ? Colours.palette.m3onPrimary : Colours.palette.m3primary
                 font.pointSize: Appearance.font.size.normal
                 font.weight: 700
@@ -104,7 +104,7 @@ Column {
 
     DayOfWeekRow {
         id: daysRow
-
+        locale: grid.locale
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.margins: parent.padding
@@ -113,10 +113,10 @@ Column {
             required property var model
 
             horizontalAlignment: Text.AlignHCenter
-            text: model.shortName.toLowerCase()
+            text: model.shortName
             font.family: Appearance.font.family.sans
             font.weight: 500
-            color: (model.index === 0 || model.index === 6) ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+            color: (model.day === 0 || model.day === 6) ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
         }
     }
 
@@ -131,6 +131,7 @@ Column {
         anchors.margins: parent.padding
 
         spacing: 3
+        locale: Qt.locale()
 
         delegate: Item {
             id: dayItem
@@ -147,7 +148,7 @@ Column {
                 implicitHeight: parent.implicitHeight
 
                 radius: Appearance.rounding.full
-                color: model.today ? Colours.palette.m3primary : "transparent"
+                color: dayItem.model.today ? Colours.palette.m3primary : "transparent"
             }
 
             StyledText {
@@ -156,7 +157,7 @@ Column {
                 anchors.centerIn: parent
 
                 horizontalAlignment: Text.AlignHCenter
-                text: Qt.formatDate(dayItem.model.date, "d")
+                text: grid.locale.toString(dayItem.model.date, "d")
                 color: {
                     var dayOfWeek = dayItem.model.date.getDay();
                     if (dayItem.model.today) {

--- a/modules/dashboard/dash/Calendar.qml
+++ b/modules/dashboard/dash/Calendar.qml
@@ -29,14 +29,14 @@ Column {
         anchors.margins: parent.padding
         spacing: Appearance.spacing.small
 
-        StyledRect {
+        Item {
             implicitWidth: implicitHeight
             implicitHeight: prevMonthText.implicitHeight + Appearance.padding.small * 2
 
-            radius: Appearance.rounding.full
-
             StateLayer {
                 id: prevMonthStateLayer
+
+                radius: Appearance.rounding.full
 
                 function onClicked(): void {
                     root.state.currentDate = new Date(root.currYear, root.currMonth - 1, 1);
@@ -86,14 +86,14 @@ Column {
             }
         }
 
-        StyledRect {
+        Item {
             implicitWidth: implicitHeight
             implicitHeight: nextMonthText.implicitHeight + Appearance.padding.small * 2
 
-            radius: Appearance.rounding.full
-
             StateLayer {
                 id: nextMonthStateLayer
+
+                radius: Appearance.rounding.full
 
                 function onClicked(): void {
                     root.state.currentDate = new Date(root.currYear, root.currMonth + 1, 1);

--- a/modules/dashboard/dash/Calendar.qml
+++ b/modules/dashboard/dash/Calendar.qml
@@ -11,14 +11,15 @@ import QtQuick.Layouts
 Column {
     id: root
 
+    required property var state
+
+    readonly property int currMonth: state.currentDate.getMonth()
+    readonly property int currYear: state.currentDate.getFullYear()
+
     anchors.left: parent.left
     anchors.right: parent.right
     padding: Appearance.padding.large
     spacing: Appearance.spacing.small
-
-    property date currentDate: new Date()
-    readonly property int currMonth: currentDate.getMonth()
-    readonly property int currYear: currentDate.getFullYear()
 
     RowLayout {
         id: monthNavigationRow
@@ -38,7 +39,7 @@ Column {
                 id: prevMonthStateLayer
 
                 function onClicked(): void {
-                    root.currentDate = new Date(root.currYear, root.currMonth - 1, 1);
+                    root.state.currentDate = new Date(root.currYear, root.currMonth - 1, 1);
                 }
             }
 
@@ -66,10 +67,10 @@ Column {
                 anchors.rightMargin: -Appearance.padding.normal
 
                 radius: Appearance.rounding.full
-                disabled: root.currentDate.toDateString() == new Date().toDateString()
+                disabled: root.state.currentDate.toDateString() == new Date().toDateString()
 
                 function onClicked(): void {
-                    root.currentDate = new Date();
+                    root.state.currentDate = new Date();
                 }
             }
 
@@ -95,7 +96,7 @@ Column {
                 id: nextMonthStateLayer
 
                 function onClicked(): void {
-                    root.currentDate = new Date(root.currYear, root.currMonth + 1, 1);
+                    root.state.currentDate = new Date(root.currYear, root.currMonth + 1, 1);
                 }
             }
 

--- a/modules/dashboard/dash/DateTime.qml
+++ b/modules/dashboard/dash/DateTime.qml
@@ -5,7 +5,6 @@ import qs.services
 import qs.config
 import QtQuick
 import QtQuick.Layouts
-import QtQml
 
 Item {
     id: root

--- a/modules/dashboard/dash/DateTime.qml
+++ b/modules/dashboard/dash/DateTime.qml
@@ -5,6 +5,7 @@ import qs.services
 import qs.config
 import QtQuick
 import QtQuick.Layouts
+import QtQml
 
 Item {
     id: root
@@ -26,17 +27,17 @@ Item {
             Layout.alignment: Qt.AlignHCenter
             text: root.timeComponents[0]
             color: Colours.palette.m3secondary
-            font.pointSize: Appearance.font.size.extraLarge
+            font.pointSize: Appearance.font.size.extraLarge * 1.3
             font.family: Appearance.font.family.clock
             font.weight: 600
         }
 
         StyledText {
-            Layout.topMargin: -(font.pointSize * 0.1)
+            Layout.topMargin: 0
             Layout.alignment: Qt.AlignHCenter
             text: "•••"
             color: Colours.palette.m3primary
-            font.pointSize: Appearance.font.size.extraLarge * 0.9
+            font.pointSize: Appearance.font.size.extraLarge
             font.family: Appearance.font.family.clock
         }
 
@@ -45,7 +46,7 @@ Item {
             Layout.alignment: Qt.AlignHCenter
             text: root.timeComponents[1]
             color: Colours.palette.m3secondary
-            font.pointSize: Appearance.font.size.extraLarge
+            font.pointSize: Appearance.font.size.extraLarge * 1.3
             font.family: Appearance.font.family.clock
             font.weight: 600
         }
@@ -64,18 +65,6 @@ Item {
                 font.family: Appearance.font.family.clock
                 font.weight: 600
             }
-        }
-
-        StyledText {
-            Layout.topMargin: Appearance.spacing.normal
-            Layout.fillWidth: true
-            horizontalAlignment: Text.AlignHCenter
-            text: Time.format("ddd, d")
-            color: Colours.palette.m3tertiary
-            font.pointSize: Appearance.font.size.normal
-            font.family: Appearance.font.family.clock
-            font.weight: 500
-            elide: Text.ElideRight
         }
     }
 }

--- a/modules/dashboard/dash/DateTime.qml
+++ b/modules/dashboard/dash/DateTime.qml
@@ -26,17 +26,16 @@ Item {
             Layout.alignment: Qt.AlignHCenter
             text: root.timeComponents[0]
             color: Colours.palette.m3secondary
-            font.pointSize: Appearance.font.size.extraLarge * 1.3
+            font.pointSize: Appearance.font.size.extraLarge
             font.family: Appearance.font.family.clock
             font.weight: 600
         }
 
         StyledText {
-            Layout.topMargin: 0
             Layout.alignment: Qt.AlignHCenter
             text: "•••"
             color: Colours.palette.m3primary
-            font.pointSize: Appearance.font.size.extraLarge
+            font.pointSize: Appearance.font.size.extraLarge * 0.9
             font.family: Appearance.font.family.clock
         }
 
@@ -45,7 +44,7 @@ Item {
             Layout.alignment: Qt.AlignHCenter
             text: root.timeComponents[1]
             color: Colours.palette.m3secondary
-            font.pointSize: Appearance.font.size.extraLarge * 1.3
+            font.pointSize: Appearance.font.size.extraLarge
             font.family: Appearance.font.family.clock
             font.weight: 600
         }
@@ -59,7 +58,7 @@ Item {
 
             sourceComponent: StyledText {
                 text: root.timeComponents[2] ?? ""
-                color: Colours.palette.m3secondary
+                color: Colours.palette.m3primary
                 font.pointSize: Appearance.font.size.large
                 font.family: Appearance.font.family.clock
                 font.weight: 600


### PR DESCRIPTION
Adds the month/year to the top of the calendar, and provides buttons for paging. Also removed day/month from time panel, and added highlighting to weekends