### PR TITLE
nix: move patch to prePatch to restore support for `patches` input

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -81,7 +81,7 @@ in
       (lib.cmakeFeature "INSTALL_QSCONFDIR" "${placeholder "out"}/share/caelestia-shell")
     ];
 
-    patchPhase = ''
+    prePatch = ''
       substituteInPlace assets/pam.d/fprint \
         --replace-fail pam_fprintd.so /run/current-system/sw/lib/security/pam_fprintd.so
     '';


### PR DESCRIPTION
This PR moves the patch from the `patchPhase` of the shell package to `prePatch`. Overriding `patchPhase` disables the `patches` derivation input, which prevents users from applying their own patches. Using `prePatch` fixes this issue.
