### PR TITLE
fix(brightness): detect monitors by connector instead of model

### DIFF
--- a/services/Brightness.qml
+++ b/services/Brightness.qml
@@ -59,15 +59,9 @@ Singleton {
 
         command: ["ddcutil", "detect", "--brief"]
         stdout: StdioCollector {
-            onStreamFinished: root.ddcMonitors = text.trim()
-                .split("\n\n")
-                .filter(d => d.startsWith("Display "))
-                .map(d => ({
-                    model: d.match(/Monitor:.*:(.*):.*/)[1],
-                    busNum: d.match(/I2C bus:[ ]*\/dev\/i2c-([0-9]+)/)[1],
-                    connector: d
-                        .match(/DRM connector:\s+(.*)/)[1]
-                        .replace(/^card\d+-/, "") // strip "card1-"
+            onStreamFinished: root.ddcMonitors = text.trim().split("\n\n").filter(d => d.startsWith("Display ")).map(d => ({
+                        busNum: d.match(/I2C bus:[ ]*\/dev\/i2c-([0-9]+)/)[1],
+                        connector: d.match(/DRM connector:\s+(.*)/)[1].replace(/^card\d+-/, "") // strip "card1-"
                     }))
         }
     }
@@ -88,7 +82,7 @@ Singleton {
         id: monitor
 
         required property ShellScreen modelData
-        readonly property bool isDdc: root.ddcMonitors.some(m => m.model === modelData.model)
+        readonly property bool isDdc: root.ddcMonitors.some(m => m.connector === modelData.name)
         readonly property string busNum: root.ddcMonitors.find(m => m.connector === modelData.name)?.busNum ?? ""
         readonly property bool isAppleDisplay: root.appleDisplayPresent && modelData.model.startsWith("StudioDisplay")
         property real brightness

--- a/services/Brightness.qml
+++ b/services/Brightness.qml
@@ -59,9 +59,15 @@ Singleton {
 
         command: ["ddcutil", "detect", "--brief"]
         stdout: StdioCollector {
-            onStreamFinished: root.ddcMonitors = text.trim().split("\n\n").filter(d => d.startsWith("Display ")).map(d => ({
-                        model: d.match(/Monitor:.*:(.*):.*/)[1],
-                        busNum: d.match(/I2C bus:[ ]*\/dev\/i2c-([0-9]+)/)[1]
+            onStreamFinished: root.ddcMonitors = text.trim()
+                .split("\n\n")
+                .filter(d => d.startsWith("Display "))
+                .map(d => ({
+                    model: d.match(/Monitor:.*:(.*):.*/)[1],
+                    busNum: d.match(/I2C bus:[ ]*\/dev\/i2c-([0-9]+)/)[1],
+                    connector: d
+                        .match(/DRM connector:\s+(.*)/)[1]
+                        .replace(/^card\d+-/, "") // strip "card1-"
                     }))
         }
     }
@@ -83,7 +89,7 @@ Singleton {
 
         required property ShellScreen modelData
         readonly property bool isDdc: root.ddcMonitors.some(m => m.model === modelData.model)
-        readonly property string busNum: root.ddcMonitors.find(m => m.model === modelData.model)?.busNum ?? ""
+        readonly property string busNum: root.ddcMonitors.find(m => m.connector === modelData.name)?.busNum ?? ""
         readonly property bool isAppleDisplay: root.appleDisplayPresent && modelData.model.startsWith("StudioDisplay")
         property real brightness
         property real queuedBrightness: NaN


### PR DESCRIPTION
Previously, monitor detection was based on the model name. This caused issues when using multiple monitors with the same model name: changing the brightness of either would only affect one of them.  

Detection is now based on the connector, ensuring that each monitor can be controlled individually.