### PR TITLE
fix(service): fix player alias handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,9 +341,7 @@ default, you must create it manually.
         "defaultPlayer": "Spotify",
         "gpuType": "",
         "playerAliases": [
-            {
-                "com.github.th_ch.youtube_music": "YT Music"
-            }
+            { "from": "com.github.th_ch.youtube_music", "to": "YT Music" }
         ],
         "weatherLocation": "",
         "useFahrenheit": false,

--- a/config/ServiceConfig.qml
+++ b/config/ServiceConfig.qml
@@ -12,7 +12,8 @@ JsonObject {
     property string defaultPlayer: "Spotify"
     property list<var> playerAliases: [
         {
-            "com.github.th_ch.youtube_music": "YT Music"
+            "from": "com.github.th_ch.youtube_music",
+            "to": "YT Music"
         }
     ]
 }


### PR DESCRIPTION
This PR updates the `getIdentity` function to match the config type and simplifies the structure for defining player aliases.

Previously, `getIdentity` expected aliases as a list of objects:  
```json
"playerAliases": [
  { "from": "com.github.th_ch.youtube_music", "to": "YT Music" }
]
```
But the config actually defined them differently:
```json
"playerAliases": [
  { "com.github.th_ch.youtube_music": "YT Music" }
]
```
Now, aliases are a simple key-value object:
```json
"playerAliases": {
  "com.github.th_ch.youtube_music": "YT Music"
}
```