### PR TITLE
Add caps lock indicator

### DIFF
--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -45,12 +45,26 @@ StyledRect {
         WrappedLoader {
             name: "kblayout"
             active: Config.bar.status.showKbLayout
-
             sourceComponent: StyledText {
                 animate: true
-                text: Hypr.kbLayout
+                text: Hypr.capsLock ? Hypr.kbLayout.toUpperCase() : Hypr.kbLayout
                 color: root.colour
                 font.family: Appearance.font.family.mono
+
+                Rectangle {
+                    anchors.centerIn: parent
+                    width: parent.width + Appearance.padding.normal
+                    height: parent.height + Appearance.padding.normal
+                    radius: Appearance.rounding.full
+                    color: Hypr.capsLock ? Colours.palette.m3primaryContainer : "transparent"
+                    z: -1
+
+                    Behavior on color {
+                        ColorAnimation {
+                            duration: Appearance.AnimDurations.small
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Simple caps-lock indicator in the bar

This can be temporary or permanent

**Enabled** | **Disabled**

<img width="50" height="111" alt="image" src="https://github.com/user-attachments/assets/851a47db-7714-4c47-a558-cf5fbb585be3" />
<img width="50" height="117" alt="image" src="https://github.com/user-attachments/assets/723d9f6e-a6be-47ff-8572-007dc6e105d7" />
