### PR TITLE
nix: fix devshell qml import

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
             cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
             cmake --build build
             export CAELESTIA_LIB_DIR="$PWD/build/lib";
-            export QML2_IMPORT_PATH="$PWD/build/qml";
+            export QML2_IMPORT_PATH="$PWD/build/qml":"''${QML2_IMPORT_PATH:-}";
           '';
         };
     });


### PR DESCRIPTION
prefix QML2_IMPORT_PATH instead of overriding, fixing issue with QtQuick programs inside dev shell testing. Related to #515 