### PR TITLE
nix: add systemd.target in home-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,10 @@ For NixOS users, a home manager module is also available.
 ```nix
 programs.caelestia = {
   enable = true;
-  systemd.enable = false; # if you prefer starting from your compositor
+  systemd = {
+    enable = false; # if you prefer starting from your compositor
+    target = "graphical-session.target" # if you're using `hyprland with uwsm`, for example, `wayland-session@hyprland.desktop.target`
+  };
   settings = {
     bar.status = {
       showBattery = false;

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ programs.caelestia = {
   enable = true;
   systemd = {
     enable = false; # if you prefer starting from your compositor
-    target = "graphical-session.target" # if you're using `hyprland with uwsm`, for example, `wayland-session@hyprland.desktop.target`
+    target = "graphical-session.target"; # if you're using `hyprland with uwsm`, for example, `wayland-session@hyprland.desktop.target`
   };
   settings = {
     bar.status = {

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ programs.caelestia = {
   enable = true;
   systemd = {
     enable = false; # if you prefer starting from your compositor
-    target = "graphical-session.target"; # if you're using `hyprland with uwsm`, for example, `wayland-session@hyprland.desktop.target`
+    target = "graphical-session.target";
   };
   settings = {
     bar.status = {

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -93,7 +93,7 @@ in {
         };
 
         Install = {
-          WantedBy = [ cfg.systemd.target ];
+          WantedBy = [cfg.systemd.target];
         };
       };
 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -25,6 +25,13 @@ in {
           default = true;
           description = "Enable the systemd service for Caelestia shell";
         };
+        target = mkOption {
+          type = types.str;
+          description = ''
+            The systemd target that will automatically start the Caelestia shell.
+          '';
+          default = "graphical-session.target";
+        };
       };
       settings = mkOption {
         type = types.attrsOf types.anything;
@@ -86,7 +93,7 @@ in {
         };
 
         Install = {
-          WantedBy = ["graphical-session.target"];
+          WantedBy = [ cfg.systemd.target ];
         };
       };
 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -72,8 +72,8 @@ in {
       systemd.user.services.caelestia = lib.mkIf cfg.systemd.enable {
         Unit = {
           Description = "Caelestia Shell Service";
-          After = ["graphical-session.target"];
-          PartOf = ["graphical-session.target"];
+          After = [cfg.systemd.target];
+          PartOf = [cfg.systemd.target];
           X-Restart-Triggers = lib.mkIf (cfg.settings != {}) [
             "${config.xdg.configFile."caelestia/shell.json".source}"
           ];


### PR DESCRIPTION
This PR will enable systemd services to start automatically only in specific desktop environments, Like other services ([waybar](https://github.com/NixOS/nixpkgs/blob/7e012249499ba8c991a1b56b5af3454d3a496548/nixos/modules/programs/wayland/waybar.nix#L19) [others](https://mynixos.com/search?q=systemdTarget)).