### PR TITLE
services(brightness): add IpcHandler with brightnessctl like set function

### DIFF
--- a/services/Brightness.qml
+++ b/services/Brightness.qml
@@ -17,21 +17,40 @@ Singleton {
         return monitors.find(m => m.modelData === screen);
     }
 
+    function getMonitor(query: string): var {
+        if (query === "active") {
+            return monitors.find(m => Hypr.monitorFor(m.modelData)?.focused);
+        }
+
+        if (query.startsWith("model:")) {
+            const model = query.slice(6);
+            return monitors.find(m => m.modelData.model === model);
+        }
+
+        if (query.startsWith("serial:")) {
+            const serial = query.slice(7);
+            return monitors.find(m => m.modelData.serialNumber === serial);
+        }
+
+        if (query.startsWith("id:")) {
+            const id = parseInt(query.slice(3), 10);
+            return monitors.find(m => Hypr.monitorFor(m.modelData)?.id === id);
+        }
+
+        return monitors.find(m => m.modelData.name === query);
+    }
+
     function increaseBrightness(): void {
-        const focusedName = Hypr.focusedMonitor.name;
-        const monitor = monitors.find(m => focusedName === m.modelData.name);
+        const monitor = getMonitor("active");
         if (monitor)
             monitor.setBrightness(monitor.brightness + 0.1);
     }
 
     function decreaseBrightness(): void {
-        const focusedName = Hypr.focusedMonitor.name;
-        const monitor = monitors.find(m => focusedName === m.modelData.name);
+        const monitor = getMonitor("active");
         if (monitor)
             monitor.setBrightness(monitor.brightness - 0.1);
     }
-
-    reloadableId: "brightness"
 
     onMonitorsChanged: {
         ddcMonitors = [];
@@ -82,39 +101,52 @@ Singleton {
         target: "brightness"
 
         function get(): real {
-            const focusedName = Hypr.focusedMonitor.name;
-            const monitor = monitors.find(m => focusedName === m.modelData.name);
-            return monitor ? monitor.brightness : -1;
+            return getFor("active");
+        }
+
+        // Allows searching by active/model/serial/id/name
+        function getFor(query: string): real {
+            return root.getMonitor(query)?.brightness ?? -1;
+        }
+
+        function set(value: string): string {
+            return setFor("active", value);
         }
 
         // Handles brightness value like brightnessctl: 0.1, +0.1, 0.1-, 10%, +10%, 10%-
-        function set(value: string): void {
-            const focusedName = Hypr.focusedMonitor.name;
-            const monitor = monitors.find(m => focusedName === m.modelData.name);
+        function setFor(query: string, value: string): string {
+            const monitor = root.getMonitor(query);
             if (!monitor)
-                return;
+                return "Invalid monitor: " + query;
 
             let targetBrightness;
-            if (value.endsWith('%-')) {
+            if (value.endsWith("%-")) {
                 const percent = parseFloat(value.slice(0, -2));
                 targetBrightness = monitor.brightness - (percent / 100);
-            } else if (value.startsWith('+') && value.endsWith('%')) {
+            } else if (value.startsWith("+") && value.endsWith("%")) {
                 const percent = parseFloat(value.slice(1, -1));
                 targetBrightness = monitor.brightness + (percent / 100);
-            } else if (value.endsWith('%')) {
+            } else if (value.endsWith("%")) {
                 const percent = parseFloat(value.slice(0, -1));
                 targetBrightness = percent / 100;
-            } else if (value.startsWith('+')) {
+            } else if (value.startsWith("+")) {
                 const increment = parseFloat(value.slice(1));
                 targetBrightness = monitor.brightness + increment;
-            } else if (value.endsWith('-')) {
+            } else if (value.endsWith("-")) {
                 const decrement = parseFloat(value.slice(0, -1));
                 targetBrightness = monitor.brightness - decrement;
+            } else if (value.includes("%") || value.includes("-") || value.includes("+")) {
+                return `Invalid brightness format: ${value}\nExpected: 0.1, +0.1, 0.1-, 10%, +10%, 10%-`;
             } else {
                 targetBrightness = parseFloat(value);
             }
 
+            if (isNaN(targetBrightness))
+                return `Failed to parse value: ${value}\nExpected: 0.1, +0.1, 0.1-, 10%, +10%, 10%-`;
+
             monitor.setBrightness(targetBrightness);
+
+            return `Set monitor ${monitor.modelData.name} brightness to ${+monitor.brightness.toFixed(2)}`;
         }
     }
 


### PR DESCRIPTION
I'd like an Ipc handler because I use custom logic in a shell script for my brightness.
Also, I added a set function that works like brightnessctl's set function to have flexibility. Let me know what you think.

In anothre PR, I'd like to add an option for those who want to prevent the brightness to be set to 0 with caelestia (it will set it to 0.001 instead for example).