### PR TITLE
nix/hm & readme: move environment to systemd.environment + refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,198 +217,196 @@ default, you must create it manually.
 
 ```json
 {
-  "appearance": {
-    "anim": {
-      "durations": {
-        "scale": 1
-      }
+    "appearance": {
+        "anim": {
+            "durations": {
+                "scale": 1
+            }
+        },
+        "font": {
+            "family": {
+                "material": "Material Symbols Rounded",
+                "mono": "CaskaydiaCove NF",
+                "sans": "Rubik"
+            },
+            "size": {
+                "scale": 1
+            }
+        },
+        "padding": {
+            "scale": 1
+        },
+        "rounding": {
+            "scale": 1
+        },
+        "spacing": {
+            "scale": 1
+        },
+        "transparency": {
+            "enabled": false,
+            "base": 0.85,
+            "layers": 0.4
+        }
     },
-    "font": {
-      "family": {
-        "material": "Material Symbols Rounded",
-        "mono": "CaskaydiaCove NF",
-        "sans": "Rubik"
-      },
-      "size": {
-        "scale": 1
-      }
+    "general": {
+        "apps": {
+            "terminal": ["foot"],
+            "audio": ["pavucontrol"]
+        }
     },
-    "padding": {
-      "scale": 1
+    "background": {
+        "desktopClock": {
+            "enabled": false
+        },
+        "enabled": true,
+        "visualiser": {
+            "enabled": false,
+            "autoHide": true,
+            "rounding": 1,
+            "spacing": 1
+        }
     },
-    "rounding": {
-      "scale": 1
+    "bar": {
+        "clock": {
+            "showIcon": true
+        },
+        "dragThreshold": 20,
+        "entries": [
+            {
+                "id": "logo",
+                "enabled": true
+            },
+            {
+                "id": "workspaces",
+                "enabled": true
+            },
+            {
+                "id": "spacer",
+                "enabled": true
+            },
+            {
+                "id": "activeWindow",
+                "enabled": true
+            },
+            {
+                "id": "spacer",
+                "enabled": true
+            },
+            {
+                "id": "tray",
+                "enabled": true
+            },
+            {
+                "id": "clock",
+                "enabled": true
+            },
+            {
+                "id": "statusIcons",
+                "enabled": true
+            },
+            {
+                "id": "power",
+                "enabled": true
+            },
+            {
+                "id": "idleInhibitor",
+                "enabled": false
+            }
+        ],
+        "persistent": true,
+        "showOnHover": true,
+        "status": {
+            "showAudio": false,
+            "showBattery": true,
+            "showBluetooth": true,
+            "showKbLayout": false,
+            "showNetwork": true
+        },
+        "tray": {
+            "background": false,
+            "recolour": false
+        },
+        "workspaces": {
+            "activeIndicator": true,
+            "activeLabel": "󰮯",
+            "activeTrail": false,
+            "label": "  ",
+            "occupiedBg": false,
+            "occupiedLabel": "󰮯",
+            "perMonitorWorkspaces": true,
+            "showWindows": true,
+            "shown": 5
+        }
     },
-    "spacing": {
-      "scale": 1
+    "border": {
+        "rounding": 25,
+        "thickness": 10
     },
-    "transparency": {
-      "enabled": false,
-      "base": 0.85,
-      "layers": 0.4
+    "dashboard": {
+        "enabled": true,
+        "dragThreshold": 50,
+        "mediaUpdateInterval": 500,
+        "showOnHover": true
+    },
+    "launcher": {
+        "actionPrefix": ">",
+        "dragThreshold": 50,
+        "vimKeybinds": false,
+        "enableDangerousActions": false,
+        "maxShown": 8,
+        "maxWallpapers": 9,
+        "specialPrefix": "@",
+        "useFuzzy": {
+            "apps": false,
+            "actions": false,
+            "schemes": false,
+            "variants": false,
+            "wallpapers": false
+        },
+        "showOnHover": false
+    },
+    "lock": {
+        "recolourLogo": false
+    },
+    "notifs": {
+        "actionOnClick": false,
+        "clearThreshold": 0.3,
+        "defaultExpireTimeout": 5000,
+        "expandThreshold": 20,
+        "expire": false
+    },
+    "osd": {
+        "enabled": true,
+        "enableBrightness": true,
+        "enableMicrophone": false,
+        "hideDelay": 2000
+    },
+    "paths": {
+        "mediaGif": "root:/assets/bongocat.gif",
+        "sessionGif": "root:/assets/kurukuru.gif",
+        "wallpaperDir": "~/Pictures/Wallpapers"
+    },
+    "services": {
+        "audioIncrement": 0.1,
+        "defaultPlayer": "Spotify",
+        "gpuType": "",
+        "playerAliases": [{ "from": "com.github.th_ch.youtube_music", "to": "YT Music" }],
+        "weatherLocation": "",
+        "useFahrenheit": false,
+        "useTwelveHourClock": false,
+        "smartScheme": true,
+        "visualiserBars": 45
+    },
+    "session": {
+        "dragThreshold": 30,
+        "vimKeybinds": false,
+        "commands": {
+            "logout": ["loginctl", "terminate-user", ""],
+            "shutdown": ["systemctl", "poweroff"],
+            "hibernate": ["systemctl", "hibernate"],
+            "reboot": ["systemctl", "reboot"]
+        }
     }
-  },
-  "general": {
-    "apps": {
-      "terminal": ["foot"],
-      "audio": ["pavucontrol"]
-    }
-  },
-  "background": {
-    "desktopClock": {
-      "enabled": false
-    },
-    "enabled": true,
-    "visualiser": {
-      "enabled": false,
-      "autoHide": true,
-      "rounding": 1,
-      "spacing": 1
-    }
-  },
-  "bar": {
-    "clock": {
-      "showIcon": true
-    },
-    "dragThreshold": 20,
-    "entries": [
-      {
-        "id": "logo",
-        "enabled": true
-      },
-      {
-        "id": "workspaces",
-        "enabled": true
-      },
-      {
-        "id": "spacer",
-        "enabled": true
-      },
-      {
-        "id": "activeWindow",
-        "enabled": true
-      },
-      {
-        "id": "spacer",
-        "enabled": true
-      },
-      {
-        "id": "tray",
-        "enabled": true
-      },
-      {
-        "id": "clock",
-        "enabled": true
-      },
-      {
-        "id": "statusIcons",
-        "enabled": true
-      },
-      {
-        "id": "power",
-        "enabled": true
-      },
-      {
-        "id": "idleInhibitor",
-        "enabled": false
-      }
-    ],
-    "persistent": true,
-    "showOnHover": true,
-    "status": {
-      "showAudio": false,
-      "showBattery": true,
-      "showBluetooth": true,
-      "showKbLayout": false,
-      "showNetwork": true
-    },
-    "tray": {
-      "background": false,
-      "recolour": false
-    },
-    "workspaces": {
-      "activeIndicator": true,
-      "activeLabel": "󰮯",
-      "activeTrail": false,
-      "label": "  ",
-      "occupiedBg": false,
-      "occupiedLabel": "󰮯",
-      "perMonitorWorkspaces": true,
-      "showWindows": true,
-      "shown": 5
-    }
-  },
-  "border": {
-    "rounding": 25,
-    "thickness": 10
-  },
-  "dashboard": {
-    "enabled": true,
-    "dragThreshold": 50,
-    "mediaUpdateInterval": 500,
-    "showOnHover": true
-  },
-  "launcher": {
-    "actionPrefix": ">",
-    "dragThreshold": 50,
-    "vimKeybinds": false,
-    "enableDangerousActions": false,
-    "maxShown": 8,
-    "maxWallpapers": 9,
-    "specialPrefix": "@",
-    "useFuzzy": {
-      "apps": false,
-      "actions": false,
-      "schemes": false,
-      "variants": false,
-      "wallpapers": false
-    },
-    "showOnHover": false
-  },
-  "lock": {
-    "recolourLogo": false
-  },
-  "notifs": {
-    "actionOnClick": false,
-    "clearThreshold": 0.3,
-    "defaultExpireTimeout": 5000,
-    "expandThreshold": 20,
-    "expire": false
-  },
-  "osd": {
-    "enabled": true,
-    "enableBrightness": true,
-    "enableMicrophone": false,
-    "hideDelay": 2000
-  },
-  "paths": {
-    "mediaGif": "root:/assets/bongocat.gif",
-    "sessionGif": "root:/assets/kurukuru.gif",
-    "wallpaperDir": "~/Pictures/Wallpapers"
-  },
-  "services": {
-    "audioIncrement": 0.1,
-    "defaultPlayer": "Spotify",
-    "gpuType": "",
-    "playerAliases": [
-      { "from": "com.github.th_ch.youtube_music", "to": "YT Music" }
-    ],
-    "weatherLocation": "",
-    "useFahrenheit": false,
-    "useTwelveHourClock": false,
-    "smartScheme": true,
-    "visualiserBars": 45
-  },
-  "session": {
-    "dragThreshold": 30,
-    "vimKeybinds": false,
-    "commands": {
-      "logout": ["loginctl", "terminate-user", ""],
-      "shutdown": ["systemctl", "poweroff"],
-      "hibernate": ["systemctl", "hibernate"],
-      "reboot": ["systemctl", "reboot"]
-    }
-  }
 }
 ```
 
@@ -502,7 +500,7 @@ which helped me a lot with learning how to use Quickshell.
 
 Finally another thank you to all the configs I took inspiration from (only one for now):
 
-- [Axenide/Ax-Shell](https://github.com/Axenide/Ax-Shell)
+-   [Axenide/Ax-Shell](https://github.com/Axenide/Ax-Shell)
 
 ## Stonks 📈
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ https://github.com/user-attachments/assets/0840f496-575c-4ca6-83a8-87bb01a85c5f
 
 ## Components
 
-- Widgets: [`Quickshell`](https://quickshell.outfoxxed.me)
-- Window manager: [`Hyprland`](https://hyprland.org)
-- Dots: [`caelestia`](https://github.com/caelestia-dots)
+-   Widgets: [`Quickshell`](https://quickshell.outfoxxed.me)
+-   Window manager: [`Hyprland`](https://hyprland.org)
+-   Dots: [`caelestia`](https://github.com/caelestia-dots)
 
 ## Installation
 
@@ -73,32 +73,32 @@ For home-manager, you can also use the Caelestia's home manager module (explaine
 
 Dependencies:
 
-- [`caelestia-cli`](https://github.com/caelestia-dots/cli)
-- [`quickshell-git`](https://quickshell.outfoxxed.me) - this has to be the git version, not the latest tagged version
-- [`ddcutil`](https://github.com/rockowitz/ddcutil)
-- [`brightnessctl`](https://github.com/Hummer12007/brightnessctl)
-- [`app2unit`](https://github.com/Vladimir-csp/app2unit)
-- [`cava`](https://github.com/karlstav/cava)
-- [`networkmanager`](https://networkmanager.dev)
-- [`lm-sensors`](https://github.com/lm-sensors/lm-sensors)
-- [`fish`](https://github.com/fish-shell/fish-shell)
-- [`aubio`](https://github.com/aubio/aubio)
-- [`libpipewire`](https://pipewire.org)
-- `glibc`
-- `qt6-declarative`
-- `gcc-libs`
-- [`material-symbols`](https://fonts.google.com/icons)
-- [`caskaydia-cove-nerd`](https://www.nerdfonts.com/font-downloads)
-- [`swappy`](https://github.com/jtheoof/swappy)
-- [`libqalculate`](https://github.com/Qalculate/libqalculate)
-- [`bash`](https://www.gnu.org/software/bash)
-- `qt6-base`
-- `qt6-declarative`
+-   [`caelestia-cli`](https://github.com/caelestia-dots/cli)
+-   [`quickshell-git`](https://quickshell.outfoxxed.me) - this has to be the git version, not the latest tagged version
+-   [`ddcutil`](https://github.com/rockowitz/ddcutil)
+-   [`brightnessctl`](https://github.com/Hummer12007/brightnessctl)
+-   [`app2unit`](https://github.com/Vladimir-csp/app2unit)
+-   [`cava`](https://github.com/karlstav/cava)
+-   [`networkmanager`](https://networkmanager.dev)
+-   [`lm-sensors`](https://github.com/lm-sensors/lm-sensors)
+-   [`fish`](https://github.com/fish-shell/fish-shell)
+-   [`aubio`](https://github.com/aubio/aubio)
+-   [`libpipewire`](https://pipewire.org)
+-   `glibc`
+-   `qt6-declarative`
+-   `gcc-libs`
+-   [`material-symbols`](https://fonts.google.com/icons)
+-   [`caskaydia-cove-nerd`](https://www.nerdfonts.com/font-downloads)
+-   [`swappy`](https://github.com/jtheoof/swappy)
+-   [`libqalculate`](https://github.com/Qalculate/libqalculate)
+-   [`bash`](https://www.gnu.org/software/bash)
+-   `qt6-base`
+-   `qt6-declarative`
 
 Build dependencies:
 
-- [`cmake`](https://cmake.org)
-- [`ninja`](https://github.com/ninja-build/ninja)
+-   [`cmake`](https://cmake.org)
+-   [`ninja`](https://github.com/ninja-build/ninja)
 
 To install the shell manually, install all dependencies and clone this repo to `$XDG_CONFIG_HOME/quickshell/caelestia`.
 Then simply build and install using `cmake`.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ or a devshell. The shell can then be run via `caelestia-shell`.
 > The default package does not have the CLI enabled by default, which is required for full funcionality.
 > To enable the CLI, use the `with-cli` package.
 
-For home-manager, you can also use the Caelestia's home manager module (explained in [configuring](https://github.com/caelestia-dots/shell?tab=readme-ov-file#configuring)) that installs and configures the shell and the CLI.
+For home-manager, you can also use the Caelestia's home manager module (explained in [configuring](https://github.com/caelestia-dots/shell?tab=readme-ov-file#home-manager-module)) that installs and configures the shell and the CLI.
 
 ### Manual installation
 
@@ -206,43 +206,14 @@ git pull
 All configuration options should be put in `~/.config/caelestia/shell.json`. This file is _not_ created by
 default, you must create it manually.
 
-For NixOS users, a home manager module is also available.
-
-<details><summary><code>home.nix</code></summary>
-
-```nix
-programs.caelestia = {
-  enable = true;
-  systemd = {
-    enable = false; # if you prefer starting from your compositor
-    target = "graphical-session.target";
-    environment = [];
-  };
-  settings = {
-    bar.status = {
-      showBattery = false;
-    };
-    paths.wallpaperDir = "~/Images";
-  };
-  cli = {
-    enable = true; # Also add caelestia-cli to path
-    settings = {
-      theme.enableGtk = false;
-    };
-  };
-};
-```
-
-The module automatically adds Caelestia shell to the path with **full functionality**. The CLI is not required, however you have the option to enable and configure it.
-
-</details>
+### Example configuration
 
 > [!NOTE]
 > The example configuration only includes recommended configuration options. For more advanced customisation
 > such as modifying the size of individual items or changing constants in the code, there are some other
 > options which can be found in the source files in the `config` directory.
 
-<details><summary>Example configuration</summary>
+<details><summary>Example</summary>
 
 ```json
 {
@@ -440,6 +411,39 @@ The module automatically adds Caelestia shell to the path with **full functional
   }
 }
 ```
+
+</details>
+
+### Home Manager Module
+
+For NixOS users, a home manager module is also available.
+
+<details><summary><code>home.nix</code></summary>
+
+```nix
+programs.caelestia = {
+  enable = true;
+  systemd = {
+    enable = false; # if you prefer starting from your compositor
+    target = "graphical-session.target";
+    environment = [];
+  };
+  settings = {
+    bar.status = {
+      showBattery = false;
+    };
+    paths.wallpaperDir = "~/Images";
+  };
+  cli = {
+    enable = true; # Also add caelestia-cli to path
+    settings = {
+      theme.enableGtk = false;
+    };
+  };
+};
+```
+
+The module automatically adds Caelestia shell to the path with **full functionality**. The CLI is not required, however you have the option to enable and configure it.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ https://github.com/user-attachments/assets/0840f496-575c-4ca6-83a8-87bb01a85c5f
 
 ## Components
 
--   Widgets: [`Quickshell`](https://quickshell.outfoxxed.me)
--   Window manager: [`Hyprland`](https://hyprland.org)
--   Dots: [`caelestia`](https://github.com/caelestia-dots)
+- Widgets: [`Quickshell`](https://quickshell.outfoxxed.me)
+- Window manager: [`Hyprland`](https://hyprland.org)
+- Dots: [`caelestia`](https://github.com/caelestia-dots)
 
 ## Installation
 
@@ -73,32 +73,32 @@ For home-manager, you can also use the Caelestia's home manager module (explaine
 
 Dependencies:
 
--   [`caelestia-cli`](https://github.com/caelestia-dots/cli)
--   [`quickshell-git`](https://quickshell.outfoxxed.me) - this has to be the git version, not the latest tagged version
--   [`ddcutil`](https://github.com/rockowitz/ddcutil)
--   [`brightnessctl`](https://github.com/Hummer12007/brightnessctl)
--   [`app2unit`](https://github.com/Vladimir-csp/app2unit)
--   [`cava`](https://github.com/karlstav/cava)
--   [`networkmanager`](https://networkmanager.dev)
--   [`lm-sensors`](https://github.com/lm-sensors/lm-sensors)
--   [`fish`](https://github.com/fish-shell/fish-shell)
--   [`aubio`](https://github.com/aubio/aubio)
--   [`libpipewire`](https://pipewire.org)
--   `glibc`
--   `qt6-declarative`
--   `gcc-libs`
--   [`material-symbols`](https://fonts.google.com/icons)
--   [`caskaydia-cove-nerd`](https://www.nerdfonts.com/font-downloads)
--   [`swappy`](https://github.com/jtheoof/swappy)
--   [`libqalculate`](https://github.com/Qalculate/libqalculate)
--   [`bash`](https://www.gnu.org/software/bash)
--   `qt6-base`
--   `qt6-declarative`
+- [`caelestia-cli`](https://github.com/caelestia-dots/cli)
+- [`quickshell-git`](https://quickshell.outfoxxed.me) - this has to be the git version, not the latest tagged version
+- [`ddcutil`](https://github.com/rockowitz/ddcutil)
+- [`brightnessctl`](https://github.com/Hummer12007/brightnessctl)
+- [`app2unit`](https://github.com/Vladimir-csp/app2unit)
+- [`cava`](https://github.com/karlstav/cava)
+- [`networkmanager`](https://networkmanager.dev)
+- [`lm-sensors`](https://github.com/lm-sensors/lm-sensors)
+- [`fish`](https://github.com/fish-shell/fish-shell)
+- [`aubio`](https://github.com/aubio/aubio)
+- [`libpipewire`](https://pipewire.org)
+- `glibc`
+- `qt6-declarative`
+- `gcc-libs`
+- [`material-symbols`](https://fonts.google.com/icons)
+- [`caskaydia-cove-nerd`](https://www.nerdfonts.com/font-downloads)
+- [`swappy`](https://github.com/jtheoof/swappy)
+- [`libqalculate`](https://github.com/Qalculate/libqalculate)
+- [`bash`](https://www.gnu.org/software/bash)
+- `qt6-base`
+- `qt6-declarative`
 
 Build dependencies:
 
--   [`cmake`](https://cmake.org)
--   [`ninja`](https://github.com/ninja-build/ninja)
+- [`cmake`](https://cmake.org)
+- [`ninja`](https://github.com/ninja-build/ninja)
 
 To install the shell manually, install all dependencies and clone this repo to `$XDG_CONFIG_HOME/quickshell/caelestia`.
 Then simply build and install using `cmake`.
@@ -216,6 +216,7 @@ programs.caelestia = {
   systemd = {
     enable = false; # if you prefer starting from your compositor
     target = "graphical-session.target";
+    environment = [];
   };
   settings = {
     bar.status = {
@@ -223,7 +224,6 @@ programs.caelestia = {
     };
     paths.wallpaperDir = "~/Images";
   };
-  environment = [];
   cli = {
     enable = true; # Also add caelestia-cli to path
     settings = {
@@ -246,198 +246,198 @@ The module automatically adds Caelestia shell to the path with **full functional
 
 ```json
 {
-    "appearance": {
-        "anim": {
-            "durations": {
-                "scale": 1
-            }
-        },
-        "font": {
-            "family": {
-                "material": "Material Symbols Rounded",
-                "mono": "CaskaydiaCove NF",
-                "sans": "Rubik"
-            },
-            "size": {
-                "scale": 1
-            }
-        },
-        "padding": {
-            "scale": 1
-        },
-        "rounding": {
-            "scale": 1
-        },
-        "spacing": {
-            "scale": 1
-        },
-        "transparency": {
-            "enabled": false,
-            "base": 0.85,
-            "layers": 0.4
-        }
+  "appearance": {
+    "anim": {
+      "durations": {
+        "scale": 1
+      }
     },
-    "general": {
-        "apps": {
-            "terminal": ["foot"],
-            "audio": ["pavucontrol"]
-        }
+    "font": {
+      "family": {
+        "material": "Material Symbols Rounded",
+        "mono": "CaskaydiaCove NF",
+        "sans": "Rubik"
+      },
+      "size": {
+        "scale": 1
+      }
     },
-    "background": {
-        "desktopClock": {
-            "enabled": false
-        },
-        "enabled": true,
-        "visualiser": {
-            "enabled": false,
-            "autoHide": true,
-            "rounding": 1,
-            "spacing": 1
-        }
+    "padding": {
+      "scale": 1
     },
-    "bar": {
-        "clock": {
-            "showIcon": true
-        },
-        "dragThreshold": 20,
-        "entries": [
-            {
-                "id": "logo",
-                "enabled": true
-            },
-            {
-                "id": "workspaces",
-                "enabled": true
-            },
-            {
-                "id": "spacer",
-                "enabled": true
-            },
-            {
-                "id": "activeWindow",
-                "enabled": true
-            },
-            {
-                "id": "spacer",
-                "enabled": true
-            },
-            {
-                "id": "tray",
-                "enabled": true
-            },
-            {
-                "id": "clock",
-                "enabled": true
-            },
-            {
-                "id": "statusIcons",
-                "enabled": true
-            },
-            {
-                "id": "power",
-                "enabled": true
-            },
-            {
-                "id": "idleInhibitor",
-                "enabled": false
-            }
-        ],
-        "persistent": true,
-        "showOnHover": true,
-        "status": {
-            "showAudio": false,
-            "showBattery": true,
-            "showBluetooth": true,
-            "showKbLayout": false,
-            "showNetwork": true
-        },
-        "tray": {
-            "background": false,
-            "recolour": false
-        },
-        "workspaces": {
-            "activeIndicator": true,
-            "activeLabel": "󰮯",
-            "activeTrail": false,
-            "label": "  ",
-            "occupiedBg": false,
-            "occupiedLabel": "󰮯",
-            "perMonitorWorkspaces": true,
-            "showWindows": true,
-            "shown": 5
-        }
+    "rounding": {
+      "scale": 1
     },
-    "border": {
-        "rounding": 25,
-        "thickness": 10
+    "spacing": {
+      "scale": 1
     },
-    "dashboard": {
-        "enabled": true,
-        "dragThreshold": 50,
-        "mediaUpdateInterval": 500,
-        "showOnHover": true
-    },
-    "launcher": {
-        "actionPrefix": ">",
-        "dragThreshold": 50,
-        "vimKeybinds": false,
-        "enableDangerousActions": false,
-        "maxShown": 8,
-        "maxWallpapers": 9,
-        "specialPrefix": "@",
-        "useFuzzy": {
-            "apps": false,
-            "actions": false,
-            "schemes": false,
-            "variants": false,
-            "wallpapers": false
-        },
-        "showOnHover": false
-    },
-    "lock": {
-        "recolourLogo": false
-    },
-    "notifs": {
-        "actionOnClick": false,
-        "clearThreshold": 0.3,
-        "defaultExpireTimeout": 5000,
-        "expandThreshold": 20,
-        "expire": false
-    },
-    "osd": {
-        "enabled": true,
-        "enableBrightness": true,
-        "enableMicrophone": false,
-        "hideDelay": 2000
-    },
-    "paths": {
-        "mediaGif": "root:/assets/bongocat.gif",
-        "sessionGif": "root:/assets/kurukuru.gif",
-        "wallpaperDir": "~/Pictures/Wallpapers"
-    },
-    "services": {
-        "audioIncrement": 0.1,
-        "defaultPlayer": "Spotify",
-        "gpuType": "",
-        "playerAliases": [
-            { "from": "com.github.th_ch.youtube_music", "to": "YT Music" }
-        ],
-        "weatherLocation": "",
-        "useFahrenheit": false,
-        "useTwelveHourClock": false,
-        "smartScheme": true,
-        "visualiserBars": 45
-    },
-    "session": {
-        "dragThreshold": 30,
-        "vimKeybinds": false,
-        "commands": {
-            "logout": ["loginctl", "terminate-user", ""],
-            "shutdown": ["systemctl", "poweroff"],
-            "hibernate": ["systemctl", "hibernate"],
-            "reboot": ["systemctl", "reboot"]
-        }
+    "transparency": {
+      "enabled": false,
+      "base": 0.85,
+      "layers": 0.4
     }
+  },
+  "general": {
+    "apps": {
+      "terminal": ["foot"],
+      "audio": ["pavucontrol"]
+    }
+  },
+  "background": {
+    "desktopClock": {
+      "enabled": false
+    },
+    "enabled": true,
+    "visualiser": {
+      "enabled": false,
+      "autoHide": true,
+      "rounding": 1,
+      "spacing": 1
+    }
+  },
+  "bar": {
+    "clock": {
+      "showIcon": true
+    },
+    "dragThreshold": 20,
+    "entries": [
+      {
+        "id": "logo",
+        "enabled": true
+      },
+      {
+        "id": "workspaces",
+        "enabled": true
+      },
+      {
+        "id": "spacer",
+        "enabled": true
+      },
+      {
+        "id": "activeWindow",
+        "enabled": true
+      },
+      {
+        "id": "spacer",
+        "enabled": true
+      },
+      {
+        "id": "tray",
+        "enabled": true
+      },
+      {
+        "id": "clock",
+        "enabled": true
+      },
+      {
+        "id": "statusIcons",
+        "enabled": true
+      },
+      {
+        "id": "power",
+        "enabled": true
+      },
+      {
+        "id": "idleInhibitor",
+        "enabled": false
+      }
+    ],
+    "persistent": true,
+    "showOnHover": true,
+    "status": {
+      "showAudio": false,
+      "showBattery": true,
+      "showBluetooth": true,
+      "showKbLayout": false,
+      "showNetwork": true
+    },
+    "tray": {
+      "background": false,
+      "recolour": false
+    },
+    "workspaces": {
+      "activeIndicator": true,
+      "activeLabel": "󰮯",
+      "activeTrail": false,
+      "label": "  ",
+      "occupiedBg": false,
+      "occupiedLabel": "󰮯",
+      "perMonitorWorkspaces": true,
+      "showWindows": true,
+      "shown": 5
+    }
+  },
+  "border": {
+    "rounding": 25,
+    "thickness": 10
+  },
+  "dashboard": {
+    "enabled": true,
+    "dragThreshold": 50,
+    "mediaUpdateInterval": 500,
+    "showOnHover": true
+  },
+  "launcher": {
+    "actionPrefix": ">",
+    "dragThreshold": 50,
+    "vimKeybinds": false,
+    "enableDangerousActions": false,
+    "maxShown": 8,
+    "maxWallpapers": 9,
+    "specialPrefix": "@",
+    "useFuzzy": {
+      "apps": false,
+      "actions": false,
+      "schemes": false,
+      "variants": false,
+      "wallpapers": false
+    },
+    "showOnHover": false
+  },
+  "lock": {
+    "recolourLogo": false
+  },
+  "notifs": {
+    "actionOnClick": false,
+    "clearThreshold": 0.3,
+    "defaultExpireTimeout": 5000,
+    "expandThreshold": 20,
+    "expire": false
+  },
+  "osd": {
+    "enabled": true,
+    "enableBrightness": true,
+    "enableMicrophone": false,
+    "hideDelay": 2000
+  },
+  "paths": {
+    "mediaGif": "root:/assets/bongocat.gif",
+    "sessionGif": "root:/assets/kurukuru.gif",
+    "wallpaperDir": "~/Pictures/Wallpapers"
+  },
+  "services": {
+    "audioIncrement": 0.1,
+    "defaultPlayer": "Spotify",
+    "gpuType": "",
+    "playerAliases": [
+      { "from": "com.github.th_ch.youtube_music", "to": "YT Music" }
+    ],
+    "weatherLocation": "",
+    "useFahrenheit": false,
+    "useTwelveHourClock": false,
+    "smartScheme": true,
+    "visualiserBars": 45
+  },
+  "session": {
+    "dragThreshold": 30,
+    "vimKeybinds": false,
+    "commands": {
+      "logout": ["loginctl", "terminate-user", ""],
+      "shutdown": ["systemctl", "poweroff"],
+      "hibernate": ["systemctl", "hibernate"],
+      "reboot": ["systemctl", "reboot"]
+    }
+  }
 }
 ```
 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -33,7 +33,7 @@ in {
           description = ''
             The systemd target that will automatically start the Caelestia shell.
           '';
-          default = "graphical-session.target";
+          default = config.wayland.systemd.target;
         };
         environment = mkOption {
           type = types.listOf types.str;

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -11,6 +11,9 @@ self: {
 
   cfg = config.programs.caelestia;
 in {
+  imports = [
+    (lib.mkRenamedOptionModule ["programs" "caelestia" "environment"] ["programs" "caelestia" "systemd" "environment"])
+  ];
   options = with lib; {
     programs.caelestia = {
       enable = mkEnableOption "Enable Caelestia shell";
@@ -32,6 +35,14 @@ in {
           '';
           default = "graphical-session.target";
         };
+        environment = mkOption {
+          type = types.listOf types.str;
+          description = "Extra Environment variables to pass to the Caelestia shell systemd service.";
+          default = [];
+          example = [
+            "QT_QPA_PLATFORMTHEME=gtk3"
+          ];
+        };
       };
       settings = mkOption {
         type = types.attrsOf types.anything;
@@ -42,14 +53,6 @@ in {
         type = types.str;
         default = "";
         description = "Caelestia shell extra configs written to shell.json";
-      };
-      environment = mkOption {
-        type = types.listOf types.str;
-        description = "Extra Environment variables to pass to the Caelestia shell systemd service.";
-        default = [ ];
-        example = [
-          "QT_QPA_PLATFORMTHEME=gtk3"
-        ];
       };
       cli = {
         enable = mkEnableOption "Enable Caelestia CLI";
@@ -93,10 +96,11 @@ in {
           Restart = "on-failure";
           RestartSec = "5s";
           TimeoutStopSec = "5s";
-          Environment = [
-            "QT_QPA_PLATFORM=wayland"
-          ]
-          ++ cfg.environment;
+          Environment =
+            [
+              "QT_QPA_PLATFORM=wayland"
+            ]
+            ++ cfg.systemd.environment;
 
           Slice = "session.slice";
         };

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -76,8 +76,8 @@ in {
   };
 
   config = let
-    cli = cfg.cli.package or cli-default;
-    shell = cfg.package or shell-default;
+    cli = cfg.cli.package;
+    shell = cfg.package;
   in
     lib.mkIf cfg.enable {
       systemd.user.services.caelestia = lib.mkIf cfg.systemd.enable {


### PR DESCRIPTION
This PR renames `programs.caelestia.environment` to `programs.caelestia.systemd.environment` in hm module without breaking current behavior (may be fully removed in future). Since this environment is exclusive of the systemd service, so does make more sense to define it in this place. 

Also changes the default systemd target to `config.wayland.systemd.target` since this is a home manager convention for wayland services, allowing the user change that option and modify the target of all wayland systemd services.

And it does a refactor in the readme in a way the configuring section be more clear.