### PR TITLE
nix: fix devshell stdenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -9,9 +9,6 @@ watch_file plugin/**/*.cpp
 watch_file plugin/**/*.hpp
 watch_file **/CMakeLists.txt
 
-export CC=clang
-export CXX=clang++
-
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DDISTRIBUTOR=direnv
 cmake --build build
 export CAELESTIA_LIB_DIR="$PWD/build/lib"

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
       default = let
         shell = self.packages.${pkgs.system}.caelestia-shell;
       in
-        pkgs.mkShell {
+        pkgs.mkShell.override {stdenv = shell.stdenv;} {
           inputsFrom = [shell shell.plugin shell.assets];
           packages = with pkgs; [material-symbols rubik nerd-fonts.caskaydia-cove];
           CAELESTIA_XKB_RULES_PATH = "${pkgs.xkeyboard-config}/share/xkeyboard-config-2/rules/base.lst";


### PR DESCRIPTION
The commit 20a0bb691179e42fa29f845e4ec931d8d217fdf2 added an error in my devshell:

<img width="1310" height="339" alt="swappy-20250903_222535" src="https://github.com/user-attachments/assets/d673acde-bb3c-4766-8a44-4c484be60879" />

This is due the clang compiler not found, because the dev shell stdenv is for gcc. This pr fixes that overriding the mkShell to use the same stdenv of the caelestia package, regardless what's it.

Also, that changes made to the .envrc earlier are no longer required since the clangStdenv already sets them.