### PR TITLE
nix: fixed package name typo

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -86,7 +86,7 @@
     };
 
     nativeBuildInputs = [cmake ninja pkg-config];
-    buildInputs = [qt6.qtbase qt6.qtdeclarative qt6.multimedia libqalculate aubio];
+    buildInputs = [qt6.qtbase qt6.qtdeclarative qt6.qtmultimedia libqalculate aubio];
 
     dontWrapQtApps = true;
     cmakeFlags =


### PR DESCRIPTION
The package qt6.multimedia does not exist, so I changed it to qt6.qtmultimedia, so I couldn't compile it on nix.

I have just tested it and it seems to work :+1: 
