### PR TITLE
notifications: add top-level close button, timeout progress indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,7 +694,9 @@ For example, to disable the bar on DP-1:
         "expandThreshold": 20,
         "actionOnClick": false,
         "groupPreviewNum": 3,
-        "openExpanded": false
+        "openExpanded": false,
+        "timeoutBar": false,
+        "timeoutCircle": false,
     },
     "osd": {
         "enabled": true,

--- a/modules/notifications/Content.qml
+++ b/modules/notifications/Content.qml
@@ -33,7 +33,7 @@ Item {
 
         let height = (count - 1) * Tokens.spacing.medium;
         for (let i = 0; i < count; i++)
-            height += (list.itemAtIndex(i) as NotifWrapper)?.nonAnimHeight ?? 0;
+            height += (list.itemAtIndex(i) as NotifWrapper)?.implicitHeight ?? 0;
 
         if (screenState.osd) {
             const h = osdPanel.y - clampedPadding;

--- a/modules/notifications/Notification.qml
+++ b/modules/notifications/Notification.qml
@@ -24,8 +24,8 @@ StyledRect {
 
     color: root.modelData.urgency === NotificationUrgency.Critical ? Colours.palette.m3secondaryContainer : Colours.tPalette.m3surfaceContainer
     radius: Tokens.rounding.large
-
-    implicitHeight: inner.implicitHeight
+    implicitWidth: Tokens.sizes.notifs.width
+    implicitHeight: inner.implicitHeight + progressBar.implicitHeight
 
     x: implicitWidth
     Component.onCompleted: {
@@ -347,12 +347,78 @@ StyledRect {
                 font: Tokens.font.body.small
             }
 
+            Loader {
+                active: Config.notifs.timeoutCircle
+                asynchronous: true
+                anchors.centerIn: closeBtn
+                
+                sourceComponent: Shape {
+                    id: progressCircle
+                    width: closeBtn.implicitWidth + Tokens.padding.small
+                    height: closeBtn.implicitHeight + Tokens.padding.small
+                    preferredRendererType: Shape.CurveRenderer
+
+                    ShapePath {
+                        capStyle: ShapePath.FlatCap
+                        fillColor: "transparent"
+                        strokeWidth: Tokens.padding.small
+                        strokeColor: Colours.palette.m3tertiary
+
+                        PathAngleArc {
+                            centerX: progressCircle.width / 2
+                            centerY: progressCircle.height / 2
+                            radiusX: progressCircle.width / 2 - Tokens.padding.small / 2
+                            radiusY: progressCircle.height / 2 - Tokens.padding.small / 2
+
+                            startAngle: -90
+
+                            NumberAnimation on sweepAngle {
+                                from: 360
+                                to: 0
+                                duration: Config.notifs.defaultExpireTimeout
+                                running: root.modelData.timer.running
+                            }
+                        }
+                    }
+                }
+            }
+
             Item {
-                id: expandBtn
+                id: closeBtn
 
                 anchors.right: parent.right
                 anchors.top: parent.top
                 anchors.topMargin: -Tokens.padding.extraSmall
+
+                implicitWidth: closeIcon.implicitHeight
+                implicitHeight: closeIcon.implicitHeight
+
+                StateLayer {
+                    radius: Tokens.rounding.full
+                    color: Colours.palette.m3onSurface
+
+                    function onClicked() {
+                        root.modelData.notification.dismiss();
+                    }
+                }
+
+                MaterialIcon {
+                    id: closeIcon
+
+                    anchors.centerIn: parent
+
+                    animate: true
+                    text: "close"
+                    font.pointSize: Tokens.font.size.normal
+                }
+            }
+
+            Item {
+                id: expandBtn
+
+                anchors.right: closeBtn.left
+                anchors.top: parent.top
+                anchors.rightMargin: Tokens.spacing.small
 
                 implicitWidth: expandIcon.implicitHeight
                 implicitHeight: expandIcon.implicitHeight
@@ -519,6 +585,72 @@ StyledRect {
                         interval: 3000
                     }
                 }
+            }
+        }
+    }
+
+    Loader {
+        id: progressBar
+        active: Config.notifs.timeoutBar
+        asynchronous: true
+
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+
+        sourceComponent: StyledRect {
+            anchors.topMargin: Tokens.padding.small
+
+            implicitHeight: Tokens.padding.small
+
+            color: Colours.palette.m3tertiary
+
+            NumberAnimation on implicitWidth {
+                from: root.width
+                to: 0
+                duration: Config.notifs.defaultExpireTimeout
+                running: root.modelData.timer.running
+            }
+        }
+    }
+
+    component Action: StyledRect {
+        id: action
+
+        required property var modelData
+
+        radius: Tokens.rounding.full
+        color: root.modelData.urgency === NotificationUrgency.Critical ? Colours.palette.m3secondary : Colours.layer(Colours.palette.m3surfaceContainerHigh, 2)
+
+        Layout.preferredWidth: actionText.width + Tokens.padding.normal * 2
+        Layout.preferredHeight: actionText.height + Tokens.padding.small * 2
+        implicitWidth: actionText.width + Tokens.padding.normal * 2
+        implicitHeight: actionText.height + Tokens.padding.small * 2
+
+        StateLayer {
+            radius: Tokens.rounding.full
+            color: root.modelData.urgency === NotificationUrgency.Critical ? Colours.palette.m3onSecondary : Colours.palette.m3onSurface
+            onClicked: action.modelData.invoke()
+        }
+
+        StyledText {
+            id: actionText
+
+            anchors.centerIn: parent
+            text: actionTextMetrics.elidedText
+            color: root.modelData.urgency === NotificationUrgency.Critical ? Colours.palette.m3onSecondary : Colours.palette.m3onSurfaceVariant
+            font.pointSize: Tokens.font.size.small
+        }
+
+        TextMetrics {
+            id: actionTextMetrics
+
+            text: action.modelData.text
+            font.family: actionText.font.family
+            font.pointSize: actionText.font.pointSize
+            elide: Text.ElideRight
+            elideWidth: {
+                const numActions = root.modelData.actions.length + 1;
+                return (inner.width - actions.spacing * (numActions - 1)) / numActions - root.Tokens.padding.normal * 2;
             }
         }
     }

--- a/modules/notifications/Notification.qml
+++ b/modules/notifications/Notification.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import QtQuick.Layouts
 import QtQuick.Shapes
 import Quickshell
 import Quickshell.Services.Notifications
@@ -351,9 +352,10 @@ StyledRect {
                 active: Config.notifs.timeoutCircle
                 asynchronous: true
                 anchors.centerIn: closeBtn
-                
+
                 sourceComponent: Shape {
                     id: progressCircle
+
                     width: closeBtn.implicitWidth + Tokens.padding.small
                     height: closeBtn.implicitHeight + Tokens.padding.small
                     preferredRendererType: Shape.CurveRenderer
@@ -394,12 +396,12 @@ StyledRect {
                 implicitHeight: closeIcon.implicitHeight
 
                 StateLayer {
-                    radius: Tokens.rounding.full
-                    color: Colours.palette.m3onSurface
-
                     function onClicked() {
                         root.modelData.notification.dismiss();
                     }
+
+                    radius: Tokens.rounding.full
+                    color: Colours.palette.m3onSurface
                 }
 
                 MaterialIcon {
@@ -409,7 +411,7 @@ StyledRect {
 
                     animate: true
                     text: "close"
-                    font.pointSize: Tokens.font.size.normal
+                    font: Tokens.font.icon.medium
                 }
             }
 
@@ -591,6 +593,7 @@ StyledRect {
 
     Loader {
         id: progressBar
+
         active: Config.notifs.timeoutBar
         asynchronous: true
 
@@ -621,9 +624,9 @@ StyledRect {
         radius: Tokens.rounding.full
         color: root.modelData.urgency === NotificationUrgency.Critical ? Colours.palette.m3secondary : Colours.layer(Colours.palette.m3surfaceContainerHigh, 2)
 
-        Layout.preferredWidth: actionText.width + Tokens.padding.normal * 2
+        Layout.preferredWidth: actionText.width + Tokens.padding.medium * 2
         Layout.preferredHeight: actionText.height + Tokens.padding.small * 2
-        implicitWidth: actionText.width + Tokens.padding.normal * 2
+        implicitWidth: actionText.width + Tokens.padding.medium * 2
         implicitHeight: actionText.height + Tokens.padding.small * 2
 
         StateLayer {
@@ -638,7 +641,7 @@ StyledRect {
             anchors.centerIn: parent
             text: actionTextMetrics.elidedText
             color: root.modelData.urgency === NotificationUrgency.Critical ? Colours.palette.m3onSecondary : Colours.palette.m3onSurfaceVariant
-            font.pointSize: Tokens.font.size.small
+            font: Tokens.font.body.small
         }
 
         TextMetrics {
@@ -650,7 +653,7 @@ StyledRect {
             elide: Text.ElideRight
             elideWidth: {
                 const numActions = root.modelData.actions.length + 1;
-                return (inner.width - actions.spacing * (numActions - 1)) / numActions - root.Tokens.padding.normal * 2;
+                return (inner.width - actions.spacing * (numActions - 1)) / numActions - root.Tokens.padding.medium * 2;
             }
         }
     }

--- a/plugin/src/Caelestia/Config/notifsconfig.hpp
+++ b/plugin/src/Caelestia/Config/notifsconfig.hpp
@@ -14,6 +14,8 @@ class NotifsConfig : public ConfigObject {
     CONFIG_GLOBAL_PROPERTY(QString, fullscreen, QStringLiteral("on"))
     CONFIG_GLOBAL_PROPERTY(int, defaultExpireTimeout, 5000)
     CONFIG_GLOBAL_PROPERTY(int, fullscreenExpireTimeout, 2000)
+    CONFIG_GLOBAL_PROPERTY(bool, timeoutBar, false)
+    CONFIG_GLOBAL_PROPERTY(bool, timeoutCircle, false)
     CONFIG_PROPERTY(qreal, clearThreshold, 0.3)
     CONFIG_PROPERTY(int, expandThreshold, 20)
     CONFIG_GLOBAL_PROPERTY(bool, actionOnClick, false)


### PR DESCRIPTION
Adds an additional close button at the same level as the notification body text expansion button, along with two kinds of timeout indicators (circle and bar), with associated configuration (defaulted to false).