### PR TITLE
Bar: add microphone icon and popout

### DIFF
--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -74,7 +74,7 @@ JsonObject {
 
     component Status: JsonObject {
         property bool showAudio: false
-        property bool showMicrophone: true
+        property bool showMicrophone: false
         property bool showKbLayout: false
         property bool showNetwork: true
         property bool showBluetooth: true

--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -74,6 +74,7 @@ JsonObject {
 
     component Status: JsonObject {
         property bool showAudio: false
+        property bool showMicrophone: true
         property bool showKbLayout: false
         property bool showNetwork: true
         property bool showBluetooth: true

--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -115,6 +115,18 @@ StyledRect {
             }
         }
 
+        // Microphone icon
+        WrappedLoader {
+            name: "microphone"
+            active: Config.bar.status.showMicrophone
+
+            sourceComponent: MaterialIcon {
+                animate: true
+                text: Icons.getMicVolumeIcon(!Audio.sourceMuted)
+                color: root.colour
+            }
+        }
+
         // Keyboard layout icon
         WrappedLoader {
             name: "kblayout"

--- a/modules/bar/popouts/Content.qml
+++ b/modules/bar/popouts/Content.qml
@@ -54,6 +54,11 @@ Item {
         }
 
         Popout {
+            name: "microphone"
+            source: "Microphone.qml"
+        }
+
+        Popout {
             name: "kblayout"
             source: "KbLayout.qml"
         }

--- a/modules/bar/popouts/Microphone.qml
+++ b/modules/bar/popouts/Microphone.qml
@@ -1,0 +1,6 @@
+import qs.components
+import qs.services
+
+StyledText {
+    text: qsTr("Microphone: %1").arg(Audio.sourceMuted ? "Muted" : "Unmuted")
+}


### PR DESCRIPTION
#  Microphone Icon Added to the Bar Module

A new microphone icon has been added to the bar module.  
Hovering over the icon displays a popout showing the current microphone status.

---

## Demo

### Muted
![Muted](https://github.com/user-attachments/assets/e6b1f7bc-4728-4a11-9cdd-63009041d56e)

### Unmuted
![Unmuted](https://github.com/user-attachments/assets/c4f1c944-105b-4055-8c19-82576e94d688)

### Muted on Hover
![Muted on Hover](https://github.com/user-attachments/assets/691bb123-8bd0-43cb-aad3-9d836c04c6eb)

### Unmuted on Hover
![Unmuted on Hover](https://github.com/user-attachments/assets/08008a79-f233-402a-b9d9-fa918c3aa6a7)


