### PR TITLE
bar(entries): added hyprsunset toggle to enable/disable nightlight

### DIFF
--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -53,7 +53,8 @@ JsonObject {
         },
         {
             id: "hyprsunset",
-            enabled: true
+            enabled: true,
+            temperature: 2500
         }
     ]
 

--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -50,6 +50,10 @@ JsonObject {
         {
             id: "idleInhibitor",
             enabled: false
+        },
+        {
+            id: "hyprsunset",
+            enabled: true
         }
     ]
 

--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -149,6 +149,12 @@ ColumnLayout {
                     sourceComponent: IdleInhibitor {}
                 }
             }
+            DelegateChoice {
+                roleValue: "hyprsunset"
+                delegate: WrappedLoader {
+                    sourceComponent: Hyprsunset {}
+                }
+            }
         }
     }
 

--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -152,7 +152,15 @@ ColumnLayout {
             DelegateChoice {
                 roleValue: "hyprsunset"
                 delegate: WrappedLoader {
-                    sourceComponent: Hyprsunset {}
+                    sourceComponent: Hyprsunset {
+                        Component.onCompleted: {
+                            const entry = Config.bar.entries.find(e => e.id === "hyprsunset");
+                            const temperature = entry?.temperature || 2500;
+                            const controlledTemperature = Math.max(1000, Math.min(6000, temperature));
+
+                            Hyprsunset.temperature = controlledTemperature;
+                        }
+                    }
                 }
             }
         }

--- a/modules/bar/components/Hyprsunset.qml
+++ b/modules/bar/components/Hyprsunset.qml
@@ -1,0 +1,33 @@
+import qs.components
+import qs.services
+import qs.config
+import Quickshell
+import QtQuick
+
+StyledRect {
+    id: root
+
+    implicitWidth: implicitHeight
+    implicitHeight: icon.implicitHeight + Appearance.padding.small * 2
+
+    radius: Appearance.rounding.full
+    color: Qt.alpha(Colours.palette.m3primaryContainer, Hyprsunset.enabled ? 1 : 0)
+
+    StateLayer {
+        function onClicked(): void {
+            Hyprsunset.enabled = !Hyprsunset.enabled;
+        }
+    }
+
+    MaterialIcon {
+        id: icon
+
+        anchors.centerIn: parent
+        anchors.horizontalCenterOffset: -1
+
+        text: "nightlight"
+        color: Hyprsunset.enabled ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3secondary
+        font.bold: true
+        font.pointSize: Appearance.font.size.normal
+    }
+}

--- a/services/Hyprsunset.qml
+++ b/services/Hyprsunset.qml
@@ -7,11 +7,13 @@ Singleton {
     id: root
 
     property alias enabled: props.enabled
+    property alias temperature: props.temperature
 
     PersistentProperties {
         id: props
 
         property bool enabled
+        property int temperature: 2500
 
         reloadableId: "hyprsunset"
     }
@@ -19,20 +21,17 @@ Singleton {
     Process {
         id: hyprsunsetProcess
         running: false
+        command: root.enabled ?
+            ["hyprctl", "hyprsunset", "identity"] :
+            ["hyprctl", "hyprsunset", "temperature", root.temperature.toString()]
 
-        function updateCommand() {
-            if (root.enabled) {
-                command = ["hyprctl", "hyprsunset", "temperature", "2500"];
-            } else {
-                command = ["hyprctl", "hyprsunset", "identity"];
-            }
+        function execute() {
             running = true;
         }
     }
 
-    onEnabledChanged: {
-        hyprsunsetProcess.updateCommand();
-    }
+    onEnabledChanged: hyprsunsetProcess.execute()
+    onTemperatureChanged: if (root.enabled) hyprsunsetProcess.execute()
 
     IpcHandler {
         target: "hyprsunset"

--- a/services/Hyprsunset.qml
+++ b/services/Hyprsunset.qml
@@ -1,0 +1,56 @@
+pragma Singleton
+
+import Quickshell
+import Quickshell.Io
+
+Singleton {
+    id: root
+
+    property alias enabled: props.enabled
+
+    PersistentProperties {
+        id: props
+
+        property bool enabled
+
+        reloadableId: "hyprsunset"
+    }
+
+    Process {
+        id: hyprsunsetProcess
+        running: false
+
+        function updateCommand() {
+            if (root.enabled) {
+                command = ["hyprctl", "hyprsunset", "temperature", "2500"];
+            } else {
+                command = ["hyprctl", "hyprsunset", "identity"];
+            }
+            running = true;
+        }
+    }
+
+    onEnabledChanged: {
+        hyprsunsetProcess.updateCommand();
+    }
+
+    IpcHandler {
+        target: "hyprsunset"
+
+        function isEnabled(): bool {
+            return root.enabled;
+        }
+
+        function toggle(): void {
+            root.enabled = !root.enabled;
+        }
+
+        function enable(): void {
+            root.enabled = true;
+        }
+
+        function disable(): void {
+            root.enabled = false;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds another entry in the `bar` for allowing users toggle `hyprsunset`. I'm not sure if this is needed here, but I wrote this for my ease, and I am hoping someone might want this

<img width="77" height="148" alt="image" src="https://github.com/user-attachments/assets/8a85cd62-aca9-407d-86e8-3f7bdbe0ef8f" />
<img width="69" height="139" alt="image" src="https://github.com/user-attachments/assets/cfa1475e-34b9-44c9-9068-7a55cff8925f" />


The configuration looks as:
```js
{
  "bar": {
    "entries": [
      {
        "id": "hyprsunset",
        "enabled": true,
        "temperature": 2500 // set colour temperature
      }
    ],
  }
}
```

I request maintainers to review the code and let me know if there's a better way to achieve this.

Known Issues:
- If user manually toggles hyprsunset through commands or hyprsunset starts itself based on set config's(`hypr/hyprsunset.conf`) schedule, the active/inactive state doesn't update. I'm not sure how to achieve this. Thinking about listening to hyprland events somehow.