### PR TITLE
nix: fix build error with libcava

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -22,6 +22,7 @@
   quickshell,
   aubio,
   libcava,
+  fftw,
   pipewire,
   xkeyboard-config,
   cmake,
@@ -86,7 +87,7 @@
     };
 
     nativeBuildInputs = [cmake ninja pkg-config];
-    buildInputs = [qt6.qtbase qt6.qtdeclarative qt6.qtmultimedia libqalculate pipewire aubio libcava];
+    buildInputs = [qt6.qtbase qt6.qtdeclarative qt6.qtmultimedia libqalculate pipewire aubio libcava fftw];
 
     dontWrapQtApps = true;
     cmakeFlags =


### PR DESCRIPTION
libcava failing with fftw3.h not found, giving errors in the build. It seems to me fftw had to be in libcava's propagatedBuildInputs but anyway this is a fix