### PR TITLE
feat: Add frequency-based sorting for applications

### DIFF
--- a/modules/launcher/ContentList.qml
+++ b/modules/launcher/ContentList.qml
@@ -1,5 +1,6 @@
 pragma ComponentBehavior: Bound
 
+import "services"
 import qs.components
 import qs.services
 import qs.config
@@ -81,6 +82,17 @@ Item {
 
         anchors.left: parent.left
         anchors.right: parent.right
+
+        Connections {
+            target: root.visibilities
+            function onLauncherChanged() {
+                if (root.visibilities.launcher && appList.item) {
+                    if (appList.item.state === "apps") {
+                        appList.item.state = appList.item.state;
+                    }
+                }
+            }
+        }
 
         sourceComponent: AppList {
             search: root.search
@@ -170,3 +182,4 @@ Item {
         }
     }
 }
+


### PR DESCRIPTION

<img width="683" height="613" alt="image" src="https://github.com/user-attachments/assets/2d1a0546-1cd6-4bb6-b263-2fdf6c29d920" />

### This PR sorts the application list by launch frequency, showing the most used apps first.

* Tracks the launch count for each application and stores it persistently.
* The default, empty-search view is now sorted by frequency.
* This change does not affect the relevancy ranking of search results.

_This is my first time using QML, so any feedback on the implementation is appreciated!_