### PR TITLE
fix(launcher): include subfolder name in wallpaper search

### DIFF
--- a/services/Wallpapers.qml
+++ b/services/Wallpapers.qml
@@ -39,6 +39,7 @@ Searcher {
     }
 
     list: wallpapers.entries
+    key: "path"
     useFuzzy: Config.launcher.useFuzzy.wallpapers
     extraOpts: useFuzzy ? ({}) : ({
             forward: false


### PR DESCRIPTION
A recent change made searches match only file names, so searching for a folder/subfolder name no longer returned results.
This PR includes subfolder names in the search.