### PR TITLE
fix: resolve floating-point comparison warnings in compiler

### DIFF
--- a/plugin/src/Caelestia/beattracker.cpp
+++ b/plugin/src/Caelestia/beattracker.cpp
@@ -3,6 +3,8 @@
 #include "audiocollector.hpp"
 #include "audioprovider.hpp"
 #include <aubio/aubio.h>
+#include <cmath>
+#include <limits>
 
 namespace caelestia {
 
@@ -54,7 +56,7 @@ void BeatProcessor::process() {
     m_collector->readChunk(m_in->data);
 
     aubio_tempo_do(m_tempo, m_in, m_out);
-    if (m_out->data[0] != 0.0f) {
+    if (std::abs(m_out->data[0]) > std::numeric_limits<float>::epsilon()) {
         emit beat(aubio_tempo_get_bpm(m_tempo));
     }
 }

--- a/plugin/src/Caelestia/cutils.cpp
+++ b/plugin/src/Caelestia/cutils.cpp
@@ -6,6 +6,8 @@
 #include <qfileinfo.h>
 #include <qqmlengine.h>
 #include <qthreadpool.h>
+#include <cmath>
+#include <limits>
 
 namespace caelestia {
 
@@ -47,7 +49,7 @@ void CUtils::saveItem(QQuickItem* target, const QUrl& path, const QRect& rect, Q
 
     auto scaledRect = rect;
     const qreal scale = target->window()->devicePixelRatio();
-    if (rect.isValid() && scale != 1.0) {
+    if (rect.isValid() && std::abs(scale - 1.0) > std::numeric_limits<qreal>::epsilon()) {
         scaledRect =
             QRectF(rect.left() * scale, rect.top() * scale, rect.width() * scale, rect.height() * scale).toRect();
     }


### PR DESCRIPTION
### Fix floating-point comparison warnings
Got some compiler warnings about unsafe float comparisons while building, so I fixed them up.

**What I changed:**
- Replaced != and == with proper epsilon comparisons in a couple places
- Added the necessary includes for std::abs and std::numeric_limits
- Fixed warnings in beattracker.cpp and cutils.cpp

**Why:**
Floating point math can have tiny rounding errors, so direct equality checks are unreliable. Using epsilon comparisons is the proper way to handle this.

**Testing:**
Builds clean now without any warnings. No functional changes, just better code safety.