### PR TITLE
Added find_package and link_library_target for Qt6Quick

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 
 set(DISTRIBUTOR "Unset" CACHE STRING "Distributor")
 set(ENABLE_MODULES "extras;plugin;shell" CACHE STRING "Modules to build/install")
-set(INSTALL_LIBDIR "usr/lib/caelestia" CACHE STRING "Library install dir")
-set(INSTALL_QMLDIR "usr/lib/qt6/qml" CACHE STRING "QML install dir")
+include(GNUInstallDirs)
+set(INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/caelestia" CACHE STRING "Library install dir")
+set(INSTALL_QMLDIR "${CMAKE_INSTALL_LIBDIR}/qt6/qml" CACHE STRING "QML install dir")
 set(INSTALL_QSCONFDIR "etc/xdg/quickshell/caelestia" CACHE STRING "Quickshell config install dir")
 
 add_compile_options(

--- a/plugin/src/Caelestia/CMakeLists.txt
+++ b/plugin/src/Caelestia/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Core Qml Gui Concurrent Sql)
+find_package(Qt6 REQUIRED COMPONENTS Core Qml Gui Concurrent Sql Quick)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(Qalculate IMPORTED_TARGET libqalculate REQUIRED)
 pkg_check_modules(Pipewire IMPORTED_TARGET libpipewire-0.3 REQUIRED)
@@ -53,4 +53,5 @@ target_link_libraries(caelestia PRIVATE
     PkgConfig::Pipewire
     PkgConfig::Aubio
     PkgConfig::Cava
+    Qt::Quick
 )


### PR DESCRIPTION
This change helps building the package on distros that splits libraries into multiple packages like OpenMandriva. 