### PR TITLE
serivces/IdleInhibitor: replace systemd-inhibit process with quickshell's IdleInhibitor

### DIFF
--- a/services/IdleInhibitor.qml
+++ b/services/IdleInhibitor.qml
@@ -2,6 +2,7 @@ pragma Singleton
 
 import Quickshell
 import Quickshell.Io
+import Quickshell.Wayland
 
 Singleton {
     id: root
@@ -23,9 +24,21 @@ Singleton {
         reloadableId: "idleInhibitor"
     }
 
-    Process {
-        running: root.enabled
-        command: ["systemd-inhibit", "--what=idle", "--who=caelestia-shell", "--why=Idle inhibitor active", "--mode=block", "sleep", "inf"]
+    // A non-visible PanelWindow required by IdleInhibitor
+    PanelWindow {
+        id: win
+
+        anchors.left: true
+        width: 0
+        height: 0
+
+        aboveWindows: false
+        WlrLayershell.exclusionMode: ExclusionMode.Ignore
+    }
+
+    IdleInhibitor {
+        enabled: root.enabled
+        window: win
     }
 
     IpcHandler {


### PR DESCRIPTION
This PR replaces the `systemd-inhibit` process in the IdleInhibitor service with Quickshell's IdleInhibitor type.

[IdleInhibitor type](https://github.com/quickshell-mirror/quickshell/blob/master/src/wayland/idle_inhibit/inhibitor.hpp) is not in the documentations but It's usable.