### PR TITLE
feat: add translate module

### DIFF
--- a/config/LauncherConfig.qml
+++ b/config/LauncherConfig.qml
@@ -65,7 +65,7 @@ JsonObject {
         {
             name: "Translate",
             icon: "translate",
-            description: "Translate text using LibreTranslate",
+            description: "Translate text using Google Translate",
             command: ["autocomplete", "translate"],
             enabled: true,
             dangerous: false

--- a/config/LauncherConfig.qml
+++ b/config/LauncherConfig.qml
@@ -63,6 +63,14 @@ JsonObject {
             dangerous: false
         },
         {
+            name: "Translate",
+            icon: "translate",
+            description: "Translate text using LibreTranslate",
+            command: ["autocomplete", "translate"],
+            enabled: true,
+            dangerous: false
+        },
+        {
             name: "Transparency",
             icon: "opacity",
             description: "Change shell transparency",

--- a/modules/launcher/AppList.qml
+++ b/modules/launcher/AppList.qml
@@ -55,6 +55,20 @@ StyledListView {
             for (const action of ["calc", "scheme", "variant"])
                 if (text.startsWith(`${prefix}${action} `))
                     return action;
+            
+            if (text.startsWith(`${prefix}translate `)) {
+                const textAfterTranslate = text.slice(`${prefix}translate `.length);
+                
+                const hasCompleteLanguage = Translator.languages.some(l => 
+                    textAfterTranslate.toLowerCase().startsWith(l.name.toLowerCase() + " ")
+                );
+                
+                if (hasCompleteLanguage) {
+                    return "translate";
+                } else {
+                    return "language";
+                }
+            }
 
             return "actions";
         }
@@ -106,6 +120,37 @@ StyledListView {
             PropertyChanges {
                 model.values: M3Variants.query(search.text)
                 root.delegate: variantItem
+            }
+        },
+        State {
+            name: "language"
+
+            PropertyChanges {
+                model.values: {
+                    const textAfterTranslate = search.text.slice(`${Config.launcher.actionPrefix}translate `.length);
+                    
+                    if (textAfterTranslate.length === 0) {
+                        return [
+                            { name: "English", code: "en" },
+                            { name: "French", code: "fr" },
+                            { name: "Spanish", code: "es" },
+                            { name: "German", code: "de" },
+                            { name: "Italian", code: "it" }
+                        ];
+                    }
+                    return Translator.languages.filter(l => 
+                        l.name.toLowerCase().startsWith(textAfterTranslate.toLowerCase())
+                    ).slice(0, 5);
+                }
+                root.delegate: languageItem
+            }
+        },
+        State {
+            name: "translate"
+
+            PropertyChanges {
+                model.values: [0]
+                root.delegate: translateItem
             }
         }
     ]
@@ -251,6 +296,22 @@ StyledListView {
         id: variantItem
 
         VariantItem {
+            list: root
+        }
+    }
+
+    Component {
+        id: languageItem
+
+        LanguageItem {
+            list: root
+        }
+    }
+
+    Component {
+        id: translateItem
+
+        TranslateItem {
             list: root
         }
     }

--- a/modules/launcher/Content.qml
+++ b/modules/launcher/Content.qml
@@ -90,7 +90,8 @@ Item {
                         Wallpapers.setWallpaper(currentItem.modelData.path);
                         root.visibilities.launcher = false;
                     } else if (text.startsWith(Config.launcher.actionPrefix)) {
-                        if (text.startsWith(`${Config.launcher.actionPrefix}calc `))
+                        if (text.startsWith(`${Config.launcher.actionPrefix}calc `) || 
+                            text.startsWith(`${Config.launcher.actionPrefix}translate `))
                             currentItem.onClicked();
                         else
                             currentItem.modelData.onClicked(list.currentList);

--- a/modules/launcher/items/LanguageItem.qml
+++ b/modules/launcher/items/LanguageItem.qml
@@ -1,0 +1,124 @@
+import qs.components
+import qs.services
+import qs.config
+import "../services"
+import Quickshell
+import QtQuick
+import QtQuick.Layouts
+
+Item {
+    id: root
+
+    required property var list
+    required property var modelData
+
+    function onClicked(): void {
+        Translator.targetLanguage = modelData.code;
+        list.search.text = `${Config.launcher.actionPrefix}translate ${modelData.name} `;
+    }
+
+    implicitHeight: Config.launcher.sizes.itemHeight
+
+    anchors.left: parent?.left
+    anchors.right: parent?.right
+
+    StateLayer {
+        radius: Appearance.rounding.normal
+
+        function onClicked(): void {
+            root.onClicked();
+        }
+    }
+
+    RowLayout {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.margins: Appearance.padding.larger
+
+        spacing: Appearance.spacing.normal
+
+        MaterialIcon {
+            text: "language"
+            font.pointSize: Appearance.font.size.extraLarge
+            Layout.alignment: Qt.AlignVCenter
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
+            spacing: Appearance.spacing.small
+
+            StyledText {
+                text: qsTr("Select language")
+                color: Colours.palette.m3onSurfaceVariant
+                font.pointSize: Appearance.font.size.small
+                Layout.fillWidth: true
+            }
+
+            StyledText {
+                text: `${modelData.name} (${modelData.code})`
+                color: Colours.palette.m3onSurface
+                font.pointSize: Appearance.font.size.normal
+                Layout.fillWidth: true
+            }
+        }
+
+        StyledRect {
+            color: Colours.palette.m3tertiary
+            radius: Appearance.rounding.normal
+            clip: true
+
+            implicitWidth: (stateLayer.containsMouse ? label.implicitWidth + label.anchors.rightMargin : 0) + icon.implicitWidth + Appearance.padding.normal * 2
+            implicitHeight: Math.max(label.implicitHeight, icon.implicitHeight) + Appearance.padding.small * 2
+
+            Layout.alignment: Qt.AlignVCenter
+
+            StateLayer {
+                id: stateLayer
+
+                color: Colours.palette.m3onTertiary
+
+                function onClicked(): void {
+                    root.onClicked();
+                }
+            }
+
+            StyledText {
+                id: label
+
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.right: icon.left
+                anchors.rightMargin: Appearance.spacing.small
+
+                text: qsTr("Select")
+                color: Colours.palette.m3onTertiary
+                font.pointSize: Appearance.font.size.normal
+
+                opacity: stateLayer.containsMouse ? 1 : 0
+
+                Behavior on opacity {
+                    Anim {}
+                }
+            }
+
+            MaterialIcon {
+                id: icon
+
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.right: parent.right
+                anchors.rightMargin: Appearance.padding.normal
+
+                text: "arrow_forward"
+                color: Colours.palette.m3onTertiary
+                font.pointSize: Appearance.font.size.large
+            }
+
+            Behavior on implicitWidth {
+                Anim {
+                    easing.bezierCurve: Appearance.anim.curves.emphasized
+                }
+            }
+        }
+    }
+}

--- a/modules/launcher/items/TranslateItem.qml
+++ b/modules/launcher/items/TranslateItem.qml
@@ -1,0 +1,222 @@
+import qs.components
+import qs.services
+import qs.config
+import "../services"
+import Quickshell
+import QtQuick
+import QtQuick.Layouts
+
+Item {
+    id: root
+
+    required property var list
+    readonly property string text: {
+        const fullText = list.search.text.slice(`${Config.launcher.actionPrefix}translate `.length);
+
+        const matchedLanguage = Translator.languages.find(l =>
+            fullText.toLowerCase().startsWith(l.name.toLowerCase() + " ")
+        );
+
+        if (matchedLanguage) {
+            if (Translator.targetLanguage !== matchedLanguage.code) {
+                Translator.targetLanguage = matchedLanguage.code;
+            }
+            return fullText.slice(matchedLanguage.name.length + 1);
+        }
+
+        return "";
+    }
+
+    function onClicked(): void {
+        if (text.length > 0) {
+            Translator.translate(text, (result) => {
+                if (result.translatedText) {
+                    Quickshell.execDetached(["wl-copy", result.translatedText]);
+                }
+                root.list.visibilities.launcher = false;
+            });
+        }
+    }
+
+    implicitHeight: Config.launcher.sizes.itemHeight
+
+    anchors.left: parent?.left
+    anchors.right: parent?.right
+
+    StateLayer {
+        radius: Appearance.rounding.normal
+
+        function onClicked(): void {
+            root.onClicked();
+        }
+    }
+
+    RowLayout {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.margins: Appearance.padding.larger
+
+        spacing: Appearance.spacing.normal
+
+        MaterialIcon {
+            text: "translate"
+            font.pointSize: Appearance.font.size.extraLarge
+            Layout.alignment: Qt.AlignVCenter
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
+            spacing: Appearance.spacing.small
+
+            StyledText {
+                text: root.text.length > 0 ? root.text : qsTr("Type text to translate")
+                color: root.text.length > 0 ? Colours.palette.m3onSurface : Colours.palette.m3onSurfaceVariant
+                font.pointSize: Appearance.font.size.normal
+                elide: Text.ElideLeft
+                Layout.fillWidth: true
+            }
+
+            StyledText {
+                text: {
+                    if (root.text.length === 0) {
+                        return "";
+                    }
+                    if (Translator.isLoading) {
+                        return qsTr("Translating...");
+                    }
+                    if (Translator.error && Translator.error !== "") {
+                        return qsTr("Error: %1").arg(Translator.error);
+                    }
+                    if (Translator.lastTranslation && Translator.lastTranslation !== "") {
+                        return qsTr("Translation: %1").arg(Translator.lastTranslation);
+                    }
+                    return qsTr("Type text to translate");
+                }
+                color: {
+                    if (Translator.isLoading)
+                        return Colours.palette.m3onSurfaceVariant;
+                    if (Translator.error && Translator.error !== "")
+                        return Colours.palette.m3error;
+                    if (Translator.lastTranslation && Translator.lastTranslation !== "")
+                        return Colours.palette.m3primary;
+                    return Colours.palette.m3onSurfaceVariant;
+                }
+                font.pointSize: Appearance.font.size.normal
+                elide: Text.ElideLeft
+                Layout.fillWidth: true
+            }
+        }
+
+        StyledRect {
+            color: Translator.isLoading ? Colours.palette.m3surfaceContainer : Colours.palette.m3tertiary
+            radius: Appearance.rounding.normal
+            clip: true
+
+            implicitWidth: Translator.isLoading ?
+                (loadingIcon.implicitWidth + Appearance.padding.normal * 2) :
+                ((stateLayer.containsMouse ? label.implicitWidth + label.anchors.rightMargin : 0) + icon.implicitWidth + Appearance.padding.normal * 2)
+            implicitHeight: Math.max(label.implicitHeight, icon.implicitHeight, loadingIcon.implicitHeight) + Appearance.padding.small * 2
+
+            Layout.alignment: Qt.AlignVCenter
+
+            MaterialIcon {
+                id: loadingIcon
+                visible: Translator.isLoading
+                anchors.centerIn: parent
+                text: "sync"
+                color: Colours.palette.m3onSurfaceVariant
+                font.pointSize: Appearance.font.size.large
+
+                RotationAnimation on rotation {
+                    running: Translator.isLoading
+                    loops: Animation.Infinite
+                    from: 0
+                    to: 360
+                    duration: 1000
+                }
+            }
+
+            StateLayer {
+                id: stateLayer
+                visible: !Translator.isLoading
+
+                color: Colours.palette.m3onTertiary
+
+                function onClicked(): void {
+                    if (Translator.lastTranslation && Translator.lastTranslation !== "") {
+                        Quickshell.execDetached(["wl-copy", Translator.lastTranslation]);
+                        root.list.visibilities.launcher = false;
+                    }
+                }
+            }
+
+            StyledText {
+                id: label
+                visible: !Translator.isLoading
+
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.right: icon.left
+                anchors.rightMargin: Appearance.spacing.small
+
+                text: qsTr("Copy")
+                color: Colours.palette.m3onTertiary
+                font.pointSize: Appearance.font.size.normal
+
+                opacity: stateLayer.containsMouse ? 1 : 0
+
+                Behavior on opacity {
+                    Anim {}
+                }
+            }
+
+            MaterialIcon {
+                id: icon
+                visible: !Translator.isLoading
+
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.right: parent.right
+                anchors.rightMargin: Appearance.padding.normal
+
+                text: "content_copy"
+                color: Colours.palette.m3onTertiary
+                font.pointSize: Appearance.font.size.large
+            }
+
+            Behavior on implicitWidth {
+                Anim {
+                    easing.bezierCurve: Appearance.anim.curves.emphasized
+                }
+            }
+
+            Behavior on color {
+                ColorAnimation {
+                    duration: 200
+                }
+            }
+        }
+    }
+
+    Timer {
+        id: translateTimer
+        interval: 500
+        repeat: false
+
+        onTriggered: {
+            if (root.text.length > 0) {
+                Translator.translate(root.text, (result) => {});
+            }
+        }
+    }
+
+    onTextChanged: {
+        if (text.length > 0) {
+            translateTimer.restart();
+        } else {
+            translateTimer.stop();
+            Translator.lastTranslation = "";
+            Translator.error = "";
+        }
+    }
+}

--- a/modules/launcher/services/Translator.qml
+++ b/modules/launcher/services/Translator.qml
@@ -1,0 +1,193 @@
+pragma Singleton
+
+import ".."
+import qs.services
+import qs.config
+import qs.utils
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+Item {
+    id: root
+
+    property string sourceLanguage: "fr"
+    property string targetLanguage: ""
+    property string lastTranslation: ""
+    property bool isLoading: false
+    property string error: ""
+    
+    property list<var> languages: [
+        { name: "French", code: "fr" },
+        { name: "English", code: "en" },
+        { name: "Spanish", code: "es" },
+        { name: "German", code: "de" },
+        { name: "Italian", code: "it" },
+        { name: "Portuguese", code: "pt" },
+        { name: "Russian", code: "ru" },
+        { name: "Japanese", code: "ja" },
+        { name: "Chinese", code: "zh" },
+        { name: "Korean", code: "ko" },
+        { name: "Arabic", code: "ar" },
+        { name: "Dutch", code: "nl" },
+        { name: "Polish", code: "pl" },
+        { name: "Turkish", code: "tr" },
+        { name: "Swedish", code: "sv" },
+        { name: "Norwegian", code: "no" },
+        { name: "Danish", code: "da" },
+        { name: "Finnish", code: "fi" },
+        { name: "Czech", code: "cs" },
+        { name: "Hungarian", code: "hu" },
+        { name: "Romanian", code: "ro" },
+        { name: "Bulgarian", code: "bg" },
+        { name: "Croatian", code: "hr" },
+        { name: "Slovak", code: "sk" },
+        { name: "Slovenian", code: "sl" },
+        { name: "Estonian", code: "et" },
+        { name: "Latvian", code: "lv" },
+        { name: "Lithuanian", code: "lt" },
+        { name: "Greek", code: "el" },
+        { name: "Hebrew", code: "he" },
+        { name: "Thai", code: "th" },
+        { name: "Vietnamese", code: "vi" },
+        { name: "Indonesian", code: "id" },
+        { name: "Malay", code: "ms" },
+        { name: "Hindi", code: "hi" },
+        { name: "Bengali", code: "bn" },
+        { name: "Tamil", code: "ta" },
+        { name: "Telugu", code: "te" },
+        { name: "Marathi", code: "mr" },
+        { name: "Gujarati", code: "gu" },
+        { name: "Kannada", code: "kn" },
+        { name: "Malayalam", code: "ml" },
+        { name: "Punjabi", code: "pa" },
+        { name: "Urdu", code: "ur" },
+        { name: "Persian", code: "fa" },
+        { name: "Ukrainian", code: "uk" },
+        { name: "Belarusian", code: "be" },
+        { name: "Macedonian", code: "mk" },
+        { name: "Albanian", code: "sq" },
+        { name: "Serbian", code: "sr" },
+        { name: "Bosnian", code: "bs" },
+        { name: "Montenegrin", code: "me" },
+        { name: "Icelandic", code: "is" },
+        { name: "Irish", code: "ga" },
+        { name: "Welsh", code: "cy" },
+        { name: "Scottish Gaelic", code: "gd" },
+        { name: "Maltese", code: "mt" },
+        { name: "Basque", code: "eu" },
+        { name: "Catalan", code: "ca" },
+        { name: "Galician", code: "gl" }
+    ]
+
+    property PersistentProperties storage: PersistentProperties {
+        id: storage
+        reloadableId: "translator"
+        
+        property string sourceLanguage: "fr"
+        property string targetLanguage: ""
+    }
+
+    Component.onCompleted: {
+        sourceLanguage = storage.sourceLanguage;
+        targetLanguage = storage.targetLanguage;
+    }
+
+    onSourceLanguageChanged: {
+        if (sourceLanguage !== storage.sourceLanguage) {
+            storage.sourceLanguage = sourceLanguage;
+        }
+    }
+
+    onTargetLanguageChanged: {
+        if (targetLanguage !== storage.targetLanguage) {
+            storage.targetLanguage = targetLanguage;
+        }
+    }
+
+    function translate(text, callback) {
+        if (!text || text.trim().length === 0) {
+            lastTranslation = "";
+            error = "";
+            if (callback) callback({ translatedText: "", alternatives: [] });
+            return;
+        }
+
+        if (!targetLanguage || targetLanguage === "") {
+            error = "No target language selected";
+            if (callback) callback({ translatedText: "", alternatives: [], error: error });
+            return;
+        }
+
+        isLoading = true;
+        error = "";
+
+        const encodedText = encodeURIComponent(text);
+        const url = `https://translate.google.com/translate_a/single?client=gtx&sl=auto&tl=${targetLanguage}&dt=t&q=${encodedText}`;
+
+        translateProc.command = [
+            "/usr/bin/curl", "-s", "-X", "GET", url
+        ];
+        translateProc.running = true;
+    }
+
+    function swapLanguages() {
+        const temp = sourceLanguage;
+        sourceLanguage = targetLanguage;
+        targetLanguage = temp;
+    }
+
+    function autoDetectLanguage(text) {
+        return sourceLanguage;
+    }
+
+    Process {
+        id: translateProc
+
+        stdout: StdioCollector {
+            onStreamFinished: {
+                isLoading = false;
+                
+                const translation = text.trim();
+                if (translation && translation !== "null" && translation !== "") {
+                    try {
+                        const response = JSON.parse(translation);
+                        if (response && response[0] && response[0][0] && response[0][0][0]) {
+                            lastTranslation = response[0][0][0];
+                            error = "";
+                        } else {
+                            error = "Invalid response format";
+                            lastTranslation = "";
+                        }
+                    } catch (e) {
+                        error = "Parse error: " + e.message;
+                        lastTranslation = "";
+                    }
+                } else {
+                    error = "No translation received";
+                    lastTranslation = "";
+                }
+            }
+        }
+
+        stderr: StdioCollector {
+            onStreamFinished: {
+                if (text.trim() !== "") {
+                    isLoading = false;
+                    error = "Network error: " + text;
+                    lastTranslation = "";
+                }
+            }
+        }
+
+        onExited: code => {
+            if (code !== 0) {
+                isLoading = false;
+                if (!error) {
+                    error = "Process failed with exit code: " + code;
+                    lastTranslation = "";
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a new Google Translate integration to the launcher, allowing users to translate text directly from the launcher UI. The changes introduce a new translate command, user interface components for language selection and translation, and a service for performing translations using Google Translate. The implementation includes error handling, persistent language preferences, and clipboard integration.

**Translate feature integration:**

* Added a new "Translate" command to the launcher configuration, making translation available as a launcher action (`config/LauncherConfig.qml`).
* Implemented a new singleton service `Translator.qml` that handles language selection, translation requests to Google Translate, persistent language preferences, and error handling (`modules/launcher/services/Translator.qml`).

**Launcher UI and workflow changes:**

* Updated the launcher action parsing logic to recognize and route translate commands, including language selection and translation states (`modules/launcher/AppList.qml`).
* Added new UI states and list item delegates for language selection (`LanguageItem.qml`) and translation display/interaction (`TranslateItem.qml`), including real-time feedback and clipboard copy functionality (`modules/launcher/AppList.qml`, `modules/launcher/items/LanguageItem.qml`, `modules/launcher/items/TranslateItem.qml`). [[1]](diffhunk://#diff-1463cb908450272ed89e87f377d45d32d5ca22108eb4a6ed1edc8eafff4545c3R124-R154) [[2]](diffhunk://#diff-75a246918e124be1c099c97341047485d22784e1a3f939158c74a674e638bdf5R1-R124) [[3]](diffhunk://#diff-96ef7b0c8a55aadda3db3b6255bc9433fdf3e73afb5ef9935133eb11318a318eR1-R222) [[4]](diffhunk://#diff-1463cb908450272ed89e87f377d45d32d5ca22108eb4a6ed1edc8eafff4545c3R302-R317)

**Launcher command handling:**

* Modified launcher content handling to ensure that the new translate command is correctly triggered and processed alongside existing commands (`modules/launcher/Content.qml`).


https://github.com/user-attachments/assets/0b58532e-2b28-47d2-8271-0584959e2230