### PR TITLE
feat: Add compact mode to tray icons

### DIFF
--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -73,6 +73,7 @@ JsonObject {
     component Tray: JsonObject {
         property bool background: false
         property bool recolour: false
+        property bool compact: false
         property list<var> iconSubs: []
     }
 

--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -38,12 +38,31 @@ ColumnLayout {
                 popouts.hasCurrent = true;
             }
         } else if (id === "tray") {
-            const index = Math.floor(((y - top) / itemHeight) * item.items.count);
-            const trayItem = item.items.itemAt(index);
-            if (trayItem) {
-                popouts.currentName = `traymenu${index}`;
-                popouts.currentCenter = Qt.binding(() => trayItem.mapToItem(root, 0, trayItem.implicitHeight / 2).y);
-                popouts.hasCurrent = true;
+            const trayContainer = item.children.find(child => child.objectName === "layout" || child.spacing !== undefined);
+            const compactIndicator = item.children.find(child => child.objectName === "compactIndicator");
+            
+            if (trayContainer) {
+                const localY = mapToItem(trayContainer, 0, y).y;
+                
+                if (compactIndicator && compactIndicator.visible) {
+                    const indicatorY = mapToItem(item, 0, y).y;
+                    const indicatorTop = compactIndicator.y;
+                    const indicatorBottom = compactIndicator.y + compactIndicator.height;
+                    
+                    if (indicatorY >= indicatorTop && indicatorY <= indicatorBottom) {
+                        return; // Don't show any menu when hovering the indicator
+                    }
+                }
+                
+                const trayItem = trayContainer.childAt(trayContainer.width / 2, localY);
+                if (trayItem && trayItem.modelData && trayItem.enabled) {
+                    const index = Array.from({length: item.items.count}, (_, i) => item.items.itemAt(i)).indexOf(trayItem);
+                    if (index >= 0) {
+                        popouts.currentName = `traymenu${index}`;
+                        popouts.currentCenter = Qt.binding(() => trayItem.mapToItem(root, 0, trayItem.implicitHeight / 2).y);
+                        popouts.hasCurrent = true;
+                    }
+                }
             }
         } else if (id === "activeWindow") {
             popouts.currentName = id.toLowerCase();

--- a/modules/bar/components/Tray.qml
+++ b/modules/bar/components/Tray.qml
@@ -3,26 +3,118 @@ import qs.services
 import qs.config
 import Quickshell.Services.SystemTray
 import QtQuick
+import QtQuick.Shapes
 
 StyledRect {
     id: root
 
     readonly property alias items: items
+    property bool isExpanded: !Config.bar.tray.compact || mouseArea.containsMouse
+    
 
     clip: true
-    visible: width > 0 && height > 0 // To avoid warnings about being visible with no size
+    visible: width > 0 && height > 0
 
     implicitWidth: Config.bar.sizes.innerWidth
-    implicitHeight: layout.implicitHeight + (Config.bar.tray.background ? Appearance.padding.normal : Appearance.padding.small) * 2
+    implicitHeight: {
+        if (Config.bar.tray.compact) {
+            return layout.implicitHeight + 20 + Appearance.padding.normal * 2 + Appearance.spacing.small + Appearance.padding.small + 30;
+        }
+        return layout.implicitHeight + (Config.bar.tray.background ? Appearance.padding.normal : Appearance.padding.small) * 2;
+    }
 
     color: Qt.alpha(Colours.tPalette.m3surfaceContainer, Config.bar.tray.background ? Colours.tPalette.m3surfaceContainer.a : 0)
     radius: Appearance.rounding.full
 
+    MouseArea {
+        id: mouseArea
+        anchors.fill: parent
+        hoverEnabled: Config.bar.tray.compact
+        acceptedButtons: Qt.NoButton
+    }
+
+    Rectangle {
+        id: compactIndicator
+        objectName: "compactIndicator"
+        visible: Config.bar.tray.compact
+        z: -1
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: Appearance.padding.small
+
+        width: Config.bar.sizes.innerWidth
+        height: 20
+
+        color: Colours.palette.m3surfaceContainer
+        opacity: 0.9
+        radius: 10
+
+        Shape {
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: 6
+            width: 10
+            height: 8
+            rotation: mouseArea.containsMouse ? 180 : 0
+            transformOrigin: Item.Center
+
+            ShapePath {
+                strokeColor: Colours.palette.m3onSurface
+                strokeWidth: 1.5
+                fillColor: "transparent"
+
+                startX: 2
+                startY: 6
+
+                PathLine { x: 5; y: 3 }
+                PathLine { x: 8; y: 6 }
+            }
+
+            Behavior on rotation {
+                Anim {
+                    duration: Appearance.anim.durations.small
+                    easing.bezierCurve: Appearance.anim.curves.standardDecel
+                }
+            }
+        }
+    }
+
+    Rectangle {
+        id: expandedBackground
+        visible: Config.bar.tray.compact && root.isExpanded
+        z: -1
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: layout.top
+        anchors.bottom: layout.bottom
+        anchors.topMargin: -Appearance.padding.small
+        anchors.bottomMargin: -Appearance.padding.small
+
+        width: Config.bar.sizes.innerWidth
+
+        color: Colours.palette.m3surfaceContainer
+        opacity: 0.9
+        radius: Appearance.rounding.normal
+
+        Behavior on opacity {
+            Anim {
+                duration: Appearance.anim.durations.normal
+                easing.bezierCurve: Appearance.anim.curves.standardDecel
+            }
+        }
+    }
+
     Column {
         id: layout
+        objectName: "layout"
+        z: 1
 
-        anchors.centerIn: parent
-        spacing: Appearance.spacing.small
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: Config.bar.tray.compact ? undefined : parent.verticalCenter
+        anchors.bottom: Config.bar.tray.compact ? compactIndicator.top : undefined
+        anchors.bottomMargin: Config.bar.tray.compact ? Appearance.spacing.normal : 0
+        spacing: Appearance.spacing.normal
 
         add: Transition {
             Anim {
@@ -49,9 +141,61 @@ StyledRect {
 
             model: SystemTray.items
 
-            TrayItem {}
+            TrayItem {
+                required property int index
+                property bool animationComplete: false
+                
+                opacity: root.isExpanded ? 1 : 0
+                enabled: root.isExpanded && animationComplete
+                transform: Translate {
+                    y: root.isExpanded ? 0 : 30
+                    
+                    Behavior on y {
+                        SequentialAnimation {
+                            PauseAnimation {
+                                duration: index * 50
+                            }
+                            Anim {
+                                duration: Appearance.anim.durations.normal
+                                easing.bezierCurve: Appearance.anim.curves.standardDecel
+                            }
+                        }
+                    }
+                }
+
+                Behavior on opacity {
+                    SequentialAnimation {
+                        PauseAnimation {
+                            duration: index * 50
+                        }
+                        Anim {
+                            duration: Appearance.anim.durations.normal
+                            easing.bezierCurve: Appearance.anim.curves.standardDecel
+                        }
+                    }
+                }
+                
+                Timer {
+                    id: enableTimer
+                    interval: index * 50 + Appearance.anim.durations.normal
+                    repeat: false
+                    running: root.isExpanded
+                    onTriggered: animationComplete = true
+                }
+                
+                Connections {
+                    target: root
+                    function onIsExpandedChanged() {
+                        if (!root.isExpanded) {
+                            animationComplete = false;
+                            enableTimer.stop();
+                        }
+                    }
+                }
+            }
         }
     }
+
 
     Behavior on implicitWidth {
         Anim {
@@ -60,8 +204,6 @@ StyledRect {
     }
 
     Behavior on implicitHeight {
-        Anim {
-            easing.bezierCurve: Appearance.anim.curves.emphasized
-        }
+        enabled: false
     }
 }


### PR DESCRIPTION
This pull request introduces a new "compact" mode for the tray component in the bar, adding UI elements and logic to support a more streamlined, expandable tray experience. The changes span configuration, tray rendering, interaction handling, and animation for tray items.

* close https://github.com/caelestia-dots/shell/discussions/255

**Tray Compact Mode Implementation**

* Added a new `compact` property to the tray configuration in `BarConfig.qml`, enabling the compact tray mode.
* Updated `Tray.qml` to support compact mode, including:
  * Logic for expanding/collapsing the tray based on mouse hover, and calculation of implicit height to accommodate new UI elements.
  * Introduction of a `compactIndicator` rectangle and an animated arrow shape to visually indicate expandable state; an `expandedBackground` rectangle for visual clarity when expanded.
  * Adjusted layout anchoring and spacing to support new compact mode visuals.

**Tray Item Animation and Interaction**

* Modified the tray item rendering to animate each item’s appearance when expanding, with staggered opacity and position transitions, and enabled interaction only after its animation completes.
* Added logic to reset item animation state when the tray collapses, ensuring proper interaction and visual feedback.

**Menu Interaction Logic**

* Updated menu popout logic in `Bar.qml` to account for the compact indicator, preventing menu popups when hovering over the indicator and ensuring correct tray item selection in compact mode.

```
{
  "bar": {
    "tray": {
      "background": false,
      "recolour": false,
      "compact": true,
      "iconSubs": []
    }
  }
}
```


https://github.com/user-attachments/assets/cbce1a74-1cd4-4b6b-a9a7-4de9ff62be52


