### PR TITLE
feat: audio device changed toasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,7 +567,11 @@ default, you must create it manually.
     },
     "utilities": {
         "enabled": true,
-        "maxToasts": 4
+        "maxToasts": 4,
+        "toasts": {
+            "audioOutputChanged": true,
+            "audioInputChanged": true
+        }
     }
 }
 ```

--- a/config/UtilitiesConfig.qml
+++ b/config/UtilitiesConfig.qml
@@ -5,15 +5,14 @@ JsonObject {
     property int maxToasts: 4
 
     property Sizes sizes: Sizes {}
-    property AudioToasts audioToasts: AudioToasts {}
+    property Toasts toasts: Toasts {}
 
     component Sizes: JsonObject {
         property int width: 430
     }
 
-    component AudioToasts: JsonObject {
-        property bool outputEnabled: true
-        property bool inputEnabled: true
-        property int timeout: 3000
+    component Toasts: JsonObject {
+        property bool audioOutputChanged: true
+        property bool audioInputChanged: true
     }
 }


### PR DESCRIPTION
Small addition of toasts whenever the default device changes, behaving like charger plug/unplug.
_Not sure if this was already planned, or if there's plans to change thing surrounding toasts seeing as they're new_

<img width="543" height="275" alt="image" src="https://github.com/user-attachments/assets/1bf09b20-00cc-4fe2-87ed-c329d37d244d" />
