### PR TITLE
Added volume buttons for Media on the lockscreen

### DIFF
--- a/modules/lock/Media.qml
+++ b/modules/lock/Media.qml
@@ -110,6 +110,14 @@ Item {
             spacing: Appearance.spacing.large
 
             PlayerControl {
+                icon: "volume_down"
+
+                function onClicked(): void {
+                    Audio.decrementVolume();
+                }
+            }
+
+            PlayerControl {
                 icon: "skip_previous"
 
                 function onClicked(): void {
@@ -137,6 +145,14 @@ Item {
                 function onClicked(): void {
                     if (Players.active?.canGoNext)
                         Players.active.next();
+                }
+            }
+
+            PlayerControl {
+                icon: "volume_up"
+
+                function onClicked(): void {
+                    Audio.incrementVolume();
                 }
             }
         }


### PR DESCRIPTION
Added volume down and volume up button on the lockscreen, as keybinds assigned in Hyprland won't work during lockscreen due to the input focus being on the password field, so I figured adding two theme-coherent buttons next to the three buttons already existed in the media would be a good idea.