### PR TITLE
feat: configurable max volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ default, you must create it manually.
     },
     "services": {
         "audioIncrement": 0.1,
+        "maxVolume": 1.0,
         "defaultPlayer": "Spotify",
         "gpuType": "",
         "playerAliases": [{ "from": "com.github.th_ch.youtube_music", "to": "YT Music" }],

--- a/components/controls/FilledSlider.qml
+++ b/components/controls/FilledSlider.qml
@@ -11,8 +11,11 @@ Slider {
     required property string icon
     property real oldValue
     property bool initialized
+    property real maxValue: 1.0
 
     orientation: Qt.Vertical
+    from: 0
+    to: maxValue
 
     background: StyledRect {
         color: Colours.tPalette.m3surfaceContainer

--- a/config/ServiceConfig.qml
+++ b/config/ServiceConfig.qml
@@ -8,6 +8,7 @@ JsonObject {
     property string gpuType: ""
     property int visualiserBars: 45
     property real audioIncrement: 0.1
+    property real maxVolume: 1.0
     property bool smartScheme: true
     property string defaultPlayer: "Spotify"
     property list<var> playerAliases: [

--- a/modules/osd/Content.qml
+++ b/modules/osd/Content.qml
@@ -46,6 +46,7 @@ Item {
 
                 icon: Icons.getVolumeIcon(value, root.muted)
                 value: root.volume
+                maxValue: Config.services.maxVolume
                 onMoved: Audio.setVolume(value)
             }
         }
@@ -70,6 +71,7 @@ Item {
 
                     icon: Icons.getMicVolumeIcon(value, root.sourceMuted)
                     value: root.sourceVolume
+                    maxValue: Config.services.maxVolume
                     onMoved: Audio.setSourceVolume(value)
                 }
             }

--- a/services/Audio.qml
+++ b/services/Audio.qml
@@ -44,7 +44,7 @@ Singleton {
     function setVolume(newVolume: real): void {
         if (sink?.ready && sink?.audio) {
             sink.audio.muted = false;
-            sink.audio.volume = Math.max(0, Math.min(1, newVolume));
+            sink.audio.volume = Math.max(0, Math.min(Config.services.maxVolume, newVolume));
         }
     }
 
@@ -59,7 +59,7 @@ Singleton {
     function setSourceVolume(newVolume: real): void {
         if (source?.ready && source?.audio) {
             source.audio.muted = false;
-            source.audio.volume = Math.max(0, Math.min(1, newVolume));
+            source.audio.volume = Math.max(0, Math.min(Config.services.maxVolume, newVolume));
         }
     }
 


### PR DESCRIPTION
Supporting more than 100% volume in audio service and components as per requested at https://github.com/caelestia-dots/shell/issues/720

Easypeasy to just set and forget in the `shell.json`
```
"services": {
        ...
        "maxVolume": 1.5,
        ...
    },
```