### PR TITLE
feat: Add option to disable idle functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ default, you must create it manually.
             "criticalLevel": 3
         },
         "idle": {
+            "enabled": true,
             "lockBeforeSleep": true,
             "inhibitWhenAudio": true,
             "timeouts": [

--- a/config/GeneralConfig.qml
+++ b/config/GeneralConfig.qml
@@ -13,6 +13,7 @@ JsonObject {
     }
 
     component Idle: JsonObject {
+        property bool enabled: true
         property bool lockBeforeSleep: true
         property bool inhibitWhenAudio: true
         property list<var> timeouts: [

--- a/modules/IdleMonitors.qml
+++ b/modules/IdleMonitors.qml
@@ -42,7 +42,7 @@ Scope {
         IdleMonitor {
             required property var modelData
 
-            enabled: root.enabled && (modelData.enabled ?? true)
+            enabled: Config.general.idle.enabled && root.enabled && (modelData.enabled ?? true)
             timeout: modelData.timeout
             respectInhibitors: modelData.respectInhibitors ?? true
             onIsIdleChanged: root.handleIdleAction(isIdle ? modelData.idleAction : modelData.returnAction)

--- a/modules/utilities/Content.qml
+++ b/modules/utilities/Content.qml
@@ -18,7 +18,11 @@ Item {
         anchors.fill: parent
         spacing: Appearance.spacing.normal
 
-        IdleInhibit {}
+        IdleInhibit {
+            visible: Config.general.idle.enabled
+            Layout.preferredHeight: Config.general.idle.enabled ? implicitHeight : 0
+            Layout.fillHeight: Config.general.idle.enabled
+        }
 
         Record {
             props: root.props


### PR DESCRIPTION
This PR makes it possible to fully disable idle handling without editing individual timeouts and removes related UI when disabled.