### PR TITLE
fix: Battery charging logic for Tray and Lock

### DIFF
--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -235,7 +235,7 @@ StyledRect {
                     }
 
                     const perc = UPower.displayDevice.percentage;
-                    const charging = !(UPower.displayDevice.state === 2);
+                    const charging = UPower.displayDevice.state === UPowerDeviceState.Charging;
                     if (perc === 1)
                         return charging ? "battery_charging_full" : "battery_full";
                     let level = Math.floor(perc * 7);

--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -235,7 +235,7 @@ StyledRect {
                     }
 
                     const perc = UPower.displayDevice.percentage;
-                    const charging = !UPower.onBattery;
+                    const charging = !(UPower.displayDevice.state === 2);
                     if (perc === 1)
                         return charging ? "battery_charging_full" : "battery_full";
                     let level = Math.floor(perc * 7);

--- a/modules/lock/Fetch.qml
+++ b/modules/lock/Fetch.qml
@@ -114,7 +114,7 @@ ColumnLayout {
                 active: UPower.displayDevice.isLaptopBattery
 
                 sourceComponent: FetchText {
-                    text: `BATT: ${UPower.displayDevice.state === UPowerDeviceState.Discharging ? "" : "(+) "}${Math.round(UPower.displayDevice.percentage * 100)}%`
+                    text: `BATT: ${UPower.displayDevice.state === UPowerDeviceState.Charging ? "(+) " : ""}${Math.round(UPower.displayDevice.percentage * 100)}%`
                 }
             }
         }

--- a/modules/lock/Fetch.qml
+++ b/modules/lock/Fetch.qml
@@ -114,7 +114,7 @@ ColumnLayout {
                 active: UPower.displayDevice.isLaptopBattery
 
                 sourceComponent: FetchText {
-                    text: `BATT: ${UPower.onBattery ? "" : "(+) "}${Math.round(UPower.displayDevice.percentage * 100)}%`
+                    text: `BATT: ${UPower.displayDevice.state === 2 ? "" : "(+) "}${Math.round(UPower.displayDevice.percentage * 100)}%`
                 }
             }
         }

--- a/modules/lock/Fetch.qml
+++ b/modules/lock/Fetch.qml
@@ -114,7 +114,7 @@ ColumnLayout {
                 active: UPower.displayDevice.isLaptopBattery
 
                 sourceComponent: FetchText {
-                    text: `BATT: ${UPower.displayDevice.state === 2 ? "" : "(+) "}${Math.round(UPower.displayDevice.percentage * 100)}%`
+                    text: `BATT: ${UPower.displayDevice.state === UPowerDeviceState.Discharging ? "" : "(+) "}${Math.round(UPower.displayDevice.percentage * 100)}%`
                 }
             }
         }


### PR DESCRIPTION
previously the logic used `UPower.onBattery`. I changed it to use `UPower.displayDevice.state === 2`.

on my laptop (ASUS G16 Zephyrus), `UPower.onBattery` would return false even after unplugging the charger, which means that the battery icon would still be the "charging" icon after unplugging.

using the explicit `displayDevice.state` enum fixes this for both the system tray and the lock screen fetch logic

docs:
[UPower.displayDevice.state](https://quickshell.org/docs/master/types/Quickshell.Services.UPower/UPowerDeviceState/)