### PR TITLE
toasts: add toast for media track change

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,7 @@ default, you must create it manually.
             "kbLayoutChanged": true,
             "numLockChanged": true,
             "vpnChanged": true,
+            "nowPlaying": false
         },
         "vpn": {
             "enabled": false,

--- a/config/UtilitiesConfig.qml
+++ b/config/UtilitiesConfig.qml
@@ -24,6 +24,7 @@ JsonObject {
         property bool numLockChanged: true
         property bool kbLayoutChanged: true
         property bool vpnChanged: true
+        property bool nowPlaying: false
     }
 
     component Vpn: JsonObject {

--- a/services/Players.qml
+++ b/services/Players.qml
@@ -5,6 +5,8 @@ import qs.config
 import Quickshell
 import Quickshell.Io
 import Quickshell.Services.Mpris
+import QtQml
+import Caelestia
 
 Singleton {
     id: root
@@ -16,6 +18,19 @@ Singleton {
     function getIdentity(player: MprisPlayer): string {
         const alias = Config.services.playerAliases.find(a => a.from === player.identity);
         return alias?.to ?? player.identity;
+    }
+
+    Connections {
+        target: active
+
+        function onPostTrackChanged() {
+            if (!Config.utilities.toasts.nowPlaying) {
+                return;
+            }
+            if (active.trackArtist != "" && active.trackTitle != "") {
+                Toaster.toast(qsTr("Now Playing"), qsTr("%1 - %2").arg(active.trackArtist).arg(active.trackTitle), "music_note");
+            }
+        }
     }
 
     PersistentProperties {


### PR DESCRIPTION
Adds a simple toast message whenever tracks change. I couldn't find a better way to do this in the QML code, but maybe there is a better way to do this. Note that the weird "- Jellyfin" message seems to be a jellyfin quirk, and I couldn't find a way to fix it.

Demo:
https://github.com/user-attachments/assets/b077c17c-1376-4261-9b88-6bcd055863e8