### PR TITLE
Move shell to overlay layer and implement adaptive border thickness for fullscreen windows

### DIFF
--- a/config/BorderConfig.qml
+++ b/config/BorderConfig.qml
@@ -2,5 +2,10 @@ import Quickshell.Io
 
 JsonObject {
     property int thickness: Appearance.padding.normal
+    property int fullscreenThickness: 0
     property int rounding: Appearance.rounding.large
+
+    function effectiveThickness(hasFullscreen: bool): int {
+        return hasFullscreen ? fullscreenThickness : thickness;
+    }
 }

--- a/modules/background/Visualiser.qml
+++ b/modules/background/Visualiser.qml
@@ -40,7 +40,7 @@ Item {
             id: content
 
             anchors.fill: parent
-            anchors.margins: Config.border.thickness
+            anchors.margins: Visibilities.getBorderThickness(root.screen)
             anchors.leftMargin: Visibilities.bars.get(root.screen).exclusiveZone + Appearance.spacing.small * Config.background.visualiser.spacing
 
             Side {}

--- a/modules/bar/BarWrapper.qml
+++ b/modules/bar/BarWrapper.qml
@@ -12,10 +12,11 @@ Item {
     required property ShellScreen screen
     required property PersistentProperties visibilities
     required property BarPopouts.Wrapper popouts
+    required property int borderThickness
 
     readonly property int padding: Math.max(Appearance.padding.smaller, Config.border.thickness)
     readonly property int contentWidth: Config.bar.sizes.innerWidth + padding * 2
-    readonly property int exclusiveZone: Config.bar.persistent || visibilities.bar ? contentWidth : Config.border.thickness
+    readonly property int exclusiveZone: Config.bar.persistent || visibilities.bar ? contentWidth : borderThickness
     readonly property bool shouldBeVisible: Config.bar.persistent || visibilities.bar || isHovered
     property bool isHovered
 
@@ -31,8 +32,8 @@ Item {
         content.item?.handleWheel(y, angleDelta);
     }
 
-    visible: width > Config.border.thickness
-    implicitWidth: Config.border.thickness
+    visible: width > borderThickness
+    implicitWidth: borderThickness
 
     states: State {
         name: "visible"

--- a/modules/drawers/Backgrounds.qml
+++ b/modules/drawers/Backgrounds.qml
@@ -16,9 +16,10 @@ Shape {
 
     required property Panels panels
     required property Item bar
+    required property int borderThickness
 
     anchors.fill: parent
-    anchors.margins: Config.border.thickness
+    anchors.margins: borderThickness
     anchors.leftMargin: bar.implicitWidth
     preferredRendererType: Shape.CurveRenderer
 

--- a/modules/drawers/Border.qml
+++ b/modules/drawers/Border.qml
@@ -10,6 +10,7 @@ Item {
     id: root
 
     required property Item bar
+    required property int borderThickness
 
     anchors.fill: parent
 
@@ -36,7 +37,7 @@ Item {
 
         Rectangle {
             anchors.fill: parent
-            anchors.margins: Config.border.thickness
+            anchors.margins: root.borderThickness
             anchors.leftMargin: root.bar.implicitWidth
             radius: Config.border.rounding
         }

--- a/modules/drawers/Exclusions.qml
+++ b/modules/drawers/Exclusions.qml
@@ -10,6 +10,7 @@ Scope {
 
     required property ShellScreen screen
     required property Item bar
+    required property int borderThickness
 
     ExclusionZone {
         anchors.left: true
@@ -18,20 +19,24 @@ Scope {
 
     ExclusionZone {
         anchors.top: true
+        exclusiveZone: root.borderThickness
     }
 
     ExclusionZone {
         anchors.right: true
+        exclusiveZone: root.borderThickness
     }
 
     ExclusionZone {
         anchors.bottom: true
+        exclusiveZone: root.borderThickness
     }
 
     component ExclusionZone: StyledWindow {
+        required property int exclusiveZone
+
         screen: root.screen
         name: "border-exclusion"
-        exclusiveZone: Config.border.thickness
         mask: Region {}
         implicitWidth: 1
         implicitHeight: 1

--- a/modules/drawers/Interactions.qml
+++ b/modules/drawers/Interactions.qml
@@ -12,6 +12,7 @@ CustomMouseArea {
     required property PersistentProperties visibilities
     required property Panels panels
     required property Item bar
+    required property int borderThickness
 
     property point dragStart
     property bool dashboardShortcutActive
@@ -19,7 +20,7 @@ CustomMouseArea {
     property bool utilitiesShortcutActive
 
     function withinPanelHeight(panel: Item, x: real, y: real): bool {
-        const panelY = Config.border.thickness + panel.y;
+        const panelY = borderThickness + panel.y;
         return y >= panelY - Config.border.rounding && y <= panelY + panel.height + Config.border.rounding;
     }
 
@@ -37,11 +38,11 @@ CustomMouseArea {
     }
 
     function inTopPanel(panel: Item, x: real, y: real): bool {
-        return y < Config.border.thickness + panel.y + panel.height && withinPanelWidth(panel, x, y);
+        return y < borderThickness + panel.y + panel.height && withinPanelWidth(panel, x, y);
     }
 
     function inBottomPanel(panel: Item, x: real, y: real): bool {
-        return y > root.height - Config.border.thickness - panel.height - Config.border.rounding && withinPanelWidth(panel, x, y);
+        return y > root.height - borderThickness - panel.height - Config.border.rounding && withinPanelWidth(panel, x, y);
     }
 
     function onWheel(event: WheelEvent): void {

--- a/modules/drawers/Panels.qml
+++ b/modules/drawers/Panels.qml
@@ -17,6 +17,7 @@ Item {
     required property ShellScreen screen
     required property PersistentProperties visibilities
     required property Item bar
+    required property int borderThickness
 
     readonly property alias osd: osd
     readonly property alias notifications: notifications
@@ -29,7 +30,7 @@ Item {
     readonly property alias sidebar: sidebar
 
     anchors.fill: parent
-    anchors.margins: Config.border.thickness
+    anchors.margins: borderThickness
     anchors.leftMargin: bar.implicitWidth
 
     Osd.Wrapper {
@@ -96,7 +97,7 @@ Item {
             if (isDetached)
                 return (root.height - nonAnimHeight) / 2;
 
-            const off = currentCenter - Config.border.thickness - nonAnimHeight / 2;
+            const off = currentCenter - root.borderThickness - nonAnimHeight / 2;
             const diff = root.height - Math.floor(off + nonAnimHeight);
             if (diff < 0)
                 return off + diff;

--- a/modules/launcher/WallpaperList.qml
+++ b/modules/launcher/WallpaperList.qml
@@ -22,10 +22,10 @@ PathView {
         if (!screen)
             return 0;
 
-        // Screen width - 4x outer rounding - 2x max side thickness (cause centered)
-        const barMargins = Math.max(Config.border.thickness, panels.bar.implicitWidth);
+        const borderThickness = Visibilities.getBorderThickness(screen);
+        const barMargins = Math.max(borderThickness, panels.bar.implicitWidth);
         let outerMargins = 0;
-        if (panels.popouts.hasCurrent && panels.popouts.currentCenter + panels.popouts.nonAnimHeight / 2 > screen.height - content.implicitHeight - Config.border.thickness * 2)
+        if (panels.popouts.hasCurrent && panels.popouts.currentCenter + panels.popouts.nonAnimHeight / 2 > screen.height - content.implicitHeight - borderThickness * 2)
             outerMargins = panels.popouts.nonAnimWidth;
         if ((visibilities.utilities || visibilities.sidebar) && panels.utilities.implicitWidth > outerMargins)
             outerMargins = panels.utilities.implicitWidth;

--- a/modules/launcher/Wrapper.qml
+++ b/modules/launcher/Wrapper.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 
 import qs.components
+import qs.services
 import qs.config
 import Quickshell
 import QtQuick
@@ -16,7 +17,7 @@ Item {
     property int contentHeight
 
     readonly property real maxHeight: {
-        let max = screen.height - Config.border.thickness * 2 - Appearance.spacing.large;
+        let max = screen.height - Visibilities.getBorderThickness(screen) * 2 - Appearance.spacing.large;
         if (visibilities.dashboard)
             max -= panels.dashboard.nonAnimHeight;
         return max;

--- a/modules/notifications/Content.qml
+++ b/modules/notifications/Content.qml
@@ -41,7 +41,7 @@ Item {
             }
         }
 
-        return Math.min((QsWindow.window?.screen?.height ?? 0) - Config.border.thickness * 2, height + padding * 2);
+        return Math.min((QsWindow.window?.screen?.height ?? 0) - Visibilities.getBorderThickness(QsWindow.window?.screen) * 2, height + padding * 2);
     }
 
     ClippingWrapperRectangle {

--- a/modules/utilities/RecordingDeleteModal.qml
+++ b/modules/utilities/RecordingDeleteModal.qml
@@ -24,6 +24,8 @@ Loader {
     sourceComponent: MouseArea {
         id: deleteConfirmation
 
+        readonly property int borderThickness: Visibilities.getBorderThickness(QsWindow.window?.screen)
+
         property string path
 
         Component.onCompleted: path = root.props.recordingConfirmDelete
@@ -34,8 +36,8 @@ Loader {
         Item {
             anchors.fill: parent
             anchors.margins: -Appearance.padding.large
-            anchors.rightMargin: -Appearance.padding.large - Config.border.thickness
-            anchors.bottomMargin: -Appearance.padding.large - Config.border.thickness
+            anchors.rightMargin: -Appearance.padding.large - deleteConfirmation.borderThickness
+            anchors.bottomMargin: -Appearance.padding.large - deleteConfirmation.borderThickness
             opacity: 0.5
 
             StyledRect {
@@ -53,7 +55,7 @@ Loader {
 
                 ShapePath {
                     startX: -Config.border.rounding * 2
-                    startY: shape.height - Config.border.thickness
+                    startY: shape.height - deleteConfirmation.borderThickness
                     strokeWidth: 0
                     fillGradient: LinearGradient {
                         orientation: LinearGradient.Horizontal
@@ -81,7 +83,7 @@ Loader {
                     }
                     PathLine {
                         relativeX: 0
-                        relativeY: Config.border.rounding + Config.border.thickness
+                        relativeY: Config.border.rounding + deleteConfirmation.borderThickness
                     }
                     PathLine {
                         relativeX: -Config.border.rounding * 2
@@ -90,7 +92,7 @@ Loader {
                 }
 
                 ShapePath {
-                    startX: shape.width - Config.border.rounding - Config.border.thickness
+                    startX: shape.width - Config.border.rounding - deleteConfirmation.borderThickness
                     strokeWidth: 0
                     fillGradient: LinearGradient {
                         orientation: LinearGradient.Vertical
@@ -118,7 +120,7 @@ Loader {
                         relativeY: -Config.border.rounding
                     }
                     PathLine {
-                        relativeX: Config.border.thickness
+                        relativeX: deleteConfirmation.borderThickness
                         relativeY: 0
                     }
                     PathLine {

--- a/services/Visibilities.qml
+++ b/services/Visibilities.qml
@@ -5,6 +5,7 @@ import Quickshell
 Singleton {
     property var screens: new Map()
     property var bars: new Map()
+    property var borderThickness: new Map()
 
     function load(screen: ShellScreen, visibilities: var): void {
         screens.set(Hypr.monitorFor(screen), visibilities);
@@ -12,5 +13,9 @@ Singleton {
 
     function getForActive(): PersistentProperties {
         return screens.get(Hypr.focusedMonitor);
+    }
+
+    function getBorderThickness(screen: ShellScreen): int {
+        return borderThickness.get(screen) ?? Config.border.thickness;
     }
 }


### PR DESCRIPTION
This commit makes the shell live in the overlay layer, so now all UI elements stay visible even when an app goes fullscreen.

Since the shell is now always on top, I added a new config option called fullscreenThickness to make borders thinner when a fullscreen window is detected. This keeps the shell from covering too much of the screen while still keeping round borders.

https://github.com/user-attachments/assets/c4fb4c6a-7315-4c0f-a4a2-6fea67833670

