### PR TITLE
Fixed trailing comma in README example shell config

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ default, you must create it manually.
             "gameModeChanged": true,
             "kbLayoutChanged": true,
             "numLockChanged": true,
-            "vpnChanged": true,
+            "vpnChanged": true
         },
         "vpn": {
             "enabled": false,


### PR DESCRIPTION
The `vpnChanged` line in the example shell config had a trailing comma, which caused Caelestia to fail to parse the file. This change removes the comma so the example JSON loads correctly.