### PR TITLE
fix(DesktopClock): use clock font for the desktop clock font family

### DIFF
--- a/modules/background/DesktopClock.qml
+++ b/modules/background/DesktopClock.qml
@@ -12,6 +12,7 @@ Item {
 
         anchors.centerIn: parent
         text: Time.format(Config.services.useTwelveHourClock ? "hh:mm:ss A" : "hh:mm:ss")
+        font.family: Appearance.font.family.clock
         font.pointSize: Appearance.font.size.extraLarge
         font.bold: true
     }


### PR DESCRIPTION
I wanted to make the DesktopClock stop twitching around when the character width of the number changes. Then I noticed, that the `Appearance.font.family.clock` isn't used by the DesktopClock.
This PR fixes that.