### PR TITLE
nix/hm: prevent generation of configuration file when config is empty

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -68,7 +68,7 @@ in {
         };
         extraConfig = mkOption {
           type = types.str;
-          default = "{}";
+          default = "";
           description = "Caelestia CLI extra configs written to cli.json";
         };
       };
@@ -121,9 +121,14 @@ in {
             (lib.recursiveUpdate c.settings)
             builtins.toJSON
           ];
+        shouldGenerate = c: c.extraConfig != "" || c.settings != {};
       in {
-        "caelestia/shell.json".text = mkConfig cfg;
-        "caelestia/cli.json".text = mkConfig cfg.cli;
+        "caelestia/shell.json" = lib.mkIf (shouldGenerate cfg) {
+          text = mkConfig cfg;
+        };
+        "caelestia/cli.json" = lib.mkIf (shouldGenerate cfg.cli) {
+          text = mkConfig cfg.cli;
+        };
       };
 
       home.packages = [shell] ++ lib.optional cfg.cli.enable cli;


### PR DESCRIPTION
Allow users to manually manage their `shell.json` / `cli.json` when using this Home Manager module.