### PR TITLE
feat: added shortcut and toast notification for users who set utiliti…

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ default, you must create it manually.
             "numLockChanged": true,
             "vpnChanged": true,
             "nowPlaying": false
+            "caffeineChanged": true
         },
         "vpn": {
             "enabled": false,

--- a/config/UtilitiesConfig.qml
+++ b/config/UtilitiesConfig.qml
@@ -25,6 +25,7 @@ JsonObject {
         property bool kbLayoutChanged: true
         property bool vpnChanged: true
         property bool nowPlaying: false
+        property bool caffeineChanged: true
     }
 
     component Vpn: JsonObject {

--- a/modules/Shortcuts.qml
+++ b/modules/Shortcuts.qml
@@ -50,6 +50,12 @@ Scope {
         }
     }
 
+    CustomShortcut {  
+         name: "caffeine"  
+         description: "Toggle caffeine mode"  
+         onPressed: IdleInhibitor.enabled = !IdleInhibitor.enabled  
+    }
+
     CustomShortcut {
         name: "launcher"
         description: "Toggle launcher"

--- a/services/Notifs.qml
+++ b/services/Notifs.qml
@@ -17,6 +17,7 @@ Singleton {
     readonly property list<Notif> notClosed: list.filter(n => !n.closed)
     readonly property list<Notif> popups: list.filter(n => n.popup)
     property alias dnd: props.dnd
+    property bool caffeine: IdleInhibitor.enabled
 
     property bool loaded
 
@@ -28,6 +29,16 @@ Singleton {
             Toaster.toast(qsTr("Do not disturb enabled"), qsTr("Popup notifications are now disabled"), "do_not_disturb_on");
         else
             Toaster.toast(qsTr("Do not disturb disabled"), qsTr("Popup notifications are now enabled"), "do_not_disturb_off");
+    }
+
+    onCaffeineChanged: {
+        if (!Config.utilities.toasts.caffeineChanged)
+            return;
+        
+        if (caffeine)
+            Toaster.toast(qsTr("Caffeine mode enabled"), qsTr("Preventing sleep mode"), "emoji_food_beverage");
+        else
+            Toaster.toast(qsTr("Caffeine mode disabled"), qsTr("Normal power management"), "local_cafe");
     }
 
     onListChanged: {


### PR DESCRIPTION
## Summary
This PR makes the **Caffeine** feature more accessible for users who have the `Utilities` setting set to `false`.

## Changes
- Added a **keyboard shortcut** to toggle Caffeine.
- Added a **toast notification** when Caffeine is enabled or disabled.
- It can be made active or deactivated from the **shell.json** file.

## Motivation
Previously, users who had `Utilities` disabled could not manually toggle the Caffeine feature.  
This PR improves the user experience by providing a shortcut and a clear visual indicator of the Caffeine state.

## Screenshots
Toast notification example:
<img width="395" height="56" alt="image" src="https://github.com/user-attachments/assets/952248f3-4d2b-4642-b767-11c8c0eb3c2a" />
<img width="394" height="51" alt="image" src="https://github.com/user-attachments/assets/1f414bbe-4eb1-4850-8d2a-f8bd47b43c1c" />


## Additional Note
- In **Hyprland**, you can define the keybind like this:
  `bindd = ALT + SHIFT, C, Toggle Caffeine, global, caelestia:caffeine`
   or
  `bind = ALT + SHIFT, C, global, caelestia:caffeine`