### PR TITLE
background: fix the desktop audio visualiser from lagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ default, you must create it manually.
         },
         "enabled": true,
         "visualiser": {
-            "blur": false,
+            "smoothing": 0.6,
             "enabled": false,
             "autoHide": true,
             "rounding": 1,

--- a/config/BackgroundConfig.qml
+++ b/config/BackgroundConfig.qml
@@ -12,7 +12,7 @@ JsonObject {
     component Visualiser: JsonObject {
         property bool enabled: false
         property bool autoHide: true
-        property bool blur: false
+        property real smoothing: 0.6
         property real rounding: 1
         property real spacing: 1
     }

--- a/modules/background/Visualiser.qml
+++ b/modules/background/Visualiser.qml
@@ -75,7 +75,7 @@ Item {
 
             property var displayValues: Array(barCount * 2).fill(0)
 
-            property real smoothing: Math.max(0.01, Math.min(1, 32 / Appearance.anim.durations.small))
+            property real smoothing: 1 - (0.95 * Config.background.visualiser.smoothing)
 
             function drawRoundedRect(ctx, x, y, w, h, r) {
                 r = Math.min(r, w / 2, h / 2);


### PR DESCRIPTION
Makes the desktop audio visualiser run faster than before

Changes:
* The bars now all render inside of a canvas using a custom rectangle drawer function

Side Effects:
* The bars dont blur the background behind it

Heres a before and after of the change:

https://github.com/user-attachments/assets/00d54616-c941-4aca-8ccf-3d5bbdec0ce5


https://github.com/user-attachments/assets/677f4ca9-b7a7-4e08-8562-8f6155054821

