### PR TITLE
BatteryMonitor.qml : fix toast text for charger unplugged

### DIFF
--- a/modules/BatteryMonitor.qml
+++ b/modules/BatteryMonitor.qml
@@ -15,7 +15,7 @@ Scope {
         function onOnBatteryChanged(): void {
             if (UPower.onBattery) {
                 if (Config.utilities.toasts.chargingChanged)
-                    Toaster.toast(qsTr("Charger unplugged"), qsTr("Battery is now on AC"), "power_off");
+                    Toaster.toast(qsTr("Charger unplugged"), qsTr("Battery is discharging"), "power_off");
             } else {
                 if (Config.utilities.toasts.chargingChanged)
                     Toaster.toast(qsTr("Charger plugged in"), qsTr("Battery is charging"), "power");


### PR DESCRIPTION
When the charger is unplugged, the notification text incorrectly states that "Battery is now on AC"

This commit changes the message to "Battery is discharging" when the UPower.onBattery property is true