### PR TITLE
background: extensive animated image support

### DIFF
--- a/components/images/CachingImage.qml
+++ b/components/images/CachingImage.qml
@@ -3,19 +3,96 @@ import Caelestia.Internal
 import Quickshell
 import QtQuick
 
-Image {
+Item {
     id: root
 
     property alias path: manager.path
 
-    asynchronous: true
-    fillMode: Image.PreserveAspectCrop
+    property url source: ""
+    property size sourceSize: Qt.size(0, 0)
+
+    property int fillMode: Image.PreserveAspectCrop
+    property bool smooth: true
+    property bool asynchronous: true
+
+    property bool playbackEnabled: true
+    property bool pauseWhenHidden: true
+
+    readonly property bool animated: manager.animated
+    readonly property Item contentItem: loader.status === Loader.Ready ? loader.item : null
+    readonly property int status: contentItem ? contentItem.status : Image.Null
+
+    implicitWidth: 0
+    implicitHeight: 0
+
+    function restart(): void {
+        if (!animated || !contentItem || !("currentFrame" in contentItem))
+            return;
+
+        contentItem.currentFrame = 0;
+    }
+
+    function updateAnimatedPause(): void {
+        if (!animated || !contentItem || !("paused" in contentItem))
+            return;
+
+        const shouldPause = !playbackEnabled || (pauseWhenHidden && !visible);
+        if (contentItem.paused !== shouldPause)
+            contentItem.paused = shouldPause;
+    }
+
+    onPlaybackEnabledChanged: updateAnimatedPause()
+    onPauseWhenHiddenChanged: updateAnimatedPause()
+    onVisibleChanged: updateAnimatedPause()
+    onAnimatedChanged: updateAnimatedPause()
 
     Connections {
         target: QsWindow.window
 
         function onDevicePixelRatioChanged(): void {
-            manager.updateSource();
+            if (!manager.animated)
+                manager.updateSource();
+        }
+    }
+
+    Loader {
+        id: loader
+
+        anchors.fill: parent
+        active: !!root.path
+        asynchronous: true
+
+        sourceComponent: manager.animated ? animatedComponent : staticComponent
+
+        onStatusChanged: {
+            if (status === Loader.Ready)
+                root.updateAnimatedPause();
+        }
+    }
+
+    Component {
+        id: staticComponent
+
+        Image {
+            anchors.fill: parent
+            asynchronous: root.asynchronous
+            fillMode: root.fillMode
+            smooth: root.smooth
+            source: root.source
+            sourceSize: root.sourceSize
+        }
+    }
+
+    Component {
+        id: animatedComponent
+
+        AnimatedImage {
+            anchors.fill: parent
+            cache: false
+            fillMode: root.fillMode
+            smooth: root.smooth
+            source: root.source
+            sourceSize: root.sourceSize
         }
     }
 

--- a/components/images/CachingImage.qml
+++ b/components/images/CachingImage.qml
@@ -17,6 +17,7 @@ Item {
 
     property bool playbackEnabled: true
     property bool pauseWhenHidden: true
+    property bool preferAnimated: true
 
     readonly property bool animated: manager.animated
     readonly property Item contentItem: loader.status === Loader.Ready ? loader.item : null
@@ -50,7 +51,7 @@ Item {
         target: QsWindow.window
 
         function onDevicePixelRatioChanged(): void {
-            if (!manager.animated)
+            if (!manager.animated || !root.preferAnimated)
                 manager.updateSource();
         }
     }
@@ -62,7 +63,7 @@ Item {
         active: !!root.path
         asynchronous: true
 
-        sourceComponent: manager.animated ? animatedComponent : staticComponent
+        sourceComponent: manager.animated && root.preferAnimated ? animatedComponent : staticComponent
 
         onStatusChanged: {
             if (status === Loader.Ready)
@@ -101,5 +102,6 @@ Item {
 
         item: root
         cacheDir: Qt.resolvedUrl(Paths.imagecache)
+        preferAnimated: root.preferAnimated
     }
 }

--- a/components/images/CachingImage.qml
+++ b/components/images/CachingImage.qml
@@ -56,6 +56,19 @@ Item {
         }
     }
 
+    Image {
+        id: animatedPlaceholder
+
+        anchors.fill: parent
+        asynchronous: root.asynchronous
+        cache: false
+        fillMode: root.fillMode
+        smooth: root.smooth
+        visible: manager.animated && root.preferAnimated && root.source && (!root.contentItem || root.contentItem.status !== Image.Ready)
+        source: root.source
+        sourceSize: root.sourceSize
+    }
+
     Loader {
         id: loader
 

--- a/modules/background/Background.qml
+++ b/modules/background/Background.qml
@@ -9,8 +9,12 @@ import Quickshell.Wayland
 import QtQuick
 
 Loader {
+    id: backgroundLoader
+
     asynchronous: true
     active: Config.background.enabled
+
+    property var lock
 
     sourceComponent: Variants {
         model: Quickshell.screens
@@ -33,6 +37,7 @@ Loader {
 
             Wallpaper {
                 id: wallpaper
+                sessionLock: backgroundLoader.lock ? backgroundLoader.lock.lock : null
             }
 
             Visualiser {

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -12,7 +12,8 @@ Item {
     id: root
 
     property string source: Wallpapers.current
-    property Image current: one
+    property CachingImage current: one
+    readonly property Item imageItem: (current && current.contentItem) ? current.contentItem : null
 
     anchors.fill: parent
 
@@ -122,10 +123,19 @@ Item {
 
         opacity: 0
         scale: Wallpapers.showPreview ? 1 : 0.8
+        playbackEnabled: root.current === img
 
         onStatusChanged: {
-            if (status === Image.Ready)
-                root.current = this;
+            if (status === Image.Ready) root.current = this;
+        }
+
+        Connections {
+            target: root
+
+            function onCurrentChanged(): void {
+                if (root.current === img && img.animated)
+                    img.restart();
+            }
         }
 
         states: State {

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -14,6 +14,8 @@ Item {
     property string source: Wallpapers.current
     property CachingImage current: one
     readonly property Item imageItem: (current && current.contentItem) ? current.contentItem : null
+    property var sessionLock: null
+    readonly property bool sessionLocked: sessionLock ? sessionLock.secure : false
 
     anchors.fill: parent
 
@@ -113,20 +115,37 @@ Item {
         id: img
 
         function update(): void {
-            if (path === root.source)
+            if (!root.source) return;
+
+            if (path === root.source) {
                 root.current = this;
-            else
-                path = root.source;
+                return;
+            }
+
+            const target = root.source;
+            path = target;
+
+            if (img.animated) {
+                Qt.callLater(() => {
+                    if (img.path === target && root.source === target)
+                        root.current = img;
+                });
+            }
         }
 
         anchors.fill: parent
 
         opacity: 0
         scale: Wallpapers.showPreview ? 1 : 0.8
-        playbackEnabled: root.current === img
+        playbackEnabled: root.current === img && !root.sessionLocked
 
         onStatusChanged: {
             if (status === Image.Ready) root.current = this;
+        }
+
+        onPlaybackEnabledChanged: {
+            if (root.current === img && img.animated && playbackEnabled)
+                img.restart();
         }
 
         Connections {

--- a/modules/launcher/items/WallpaperItem.qml
+++ b/modules/launcher/items/WallpaperItem.qml
@@ -67,6 +67,7 @@ Item {
         CachingImage {
             path: root.modelData.path
             smooth: !root.PathView.view.moving
+            playbackEnabled: false
 
             anchors.fill: parent
         }

--- a/modules/launcher/items/WallpaperItem.qml
+++ b/modules/launcher/items/WallpaperItem.qml
@@ -13,6 +13,9 @@ Item {
     required property FileSystemEntry modelData
     required property PersistentProperties visibilities
 
+    // Play the animated wallpaper preview?
+    property bool animatePreview: false
+
     scale: 0.5
     opacity: 0
     z: PathView.z ?? 0
@@ -67,7 +70,8 @@ Item {
         CachingImage {
             path: root.modelData.path
             smooth: !root.PathView.view.moving
-            playbackEnabled: false
+            preferAnimated: root.animatePreview
+            playbackEnabled: root.animatePreview
 
             anchors.fill: parent
         }

--- a/plugin/src/Caelestia/Internal/cachingimagemanager.cpp
+++ b/plugin/src/Caelestia/Internal/cachingimagemanager.cpp
@@ -100,6 +100,19 @@ void CachingImageManager::setPath(const QString& path) {
     }
 }
 
+void CachingImageManager::setPreferAnimated(bool preferAnimated) {
+    if (m_preferAnimated == preferAnimated) {
+        return;
+    }
+
+    m_preferAnimated = preferAnimated;
+    emit preferAnimatedChanged();
+
+    if (!m_path.isEmpty()) {
+        updateSource(m_path);
+    }
+}
+
 void CachingImageManager::updateSource() {
     updateSource(m_path);
 }
@@ -115,7 +128,9 @@ void CachingImageManager::updateSource(const QString& path) {
         emit animatedChanged();
     }
 
-    if (animated) {
+    const bool useAnimation = animated && m_preferAnimated;
+
+    if (useAnimation) {
         const QSize size = effectiveSize();
 
         if (!m_item || !size.width() || !size.height()) {
@@ -205,12 +220,6 @@ QUrl CachingImageManager::cachePath() const {
 
 void CachingImageManager::createCache(
     const QString& path, const QString& cache, const QString& fillMode, const QSize& size) const {
-    // Main thread is fast as fuk boiiii
-    if (isAnimated(path)) {
-        qDebug() << "CachingImageManager::createCache: skip animated" << path;
-        return;
-    }
-
     QThreadPool::globalInstance()->start([path, cache, fillMode, size] {
         QImage image(path);
 

--- a/plugin/src/Caelestia/Internal/cachingimagemanager.hpp
+++ b/plugin/src/Caelestia/Internal/cachingimagemanager.hpp
@@ -16,10 +16,13 @@ class CachingImageManager : public QObject {
     Q_PROPERTY(QString path READ path WRITE setPath NOTIFY pathChanged)
     Q_PROPERTY(QUrl cachePath READ cachePath NOTIFY cachePathChanged)
 
+    Q_PROPERTY(bool animated READ animated NOTIFY animatedChanged)
+
 public:
     explicit CachingImageManager(QObject* parent = nullptr)
         : QObject(parent)
-        , m_item(nullptr) {}
+        , m_item(nullptr)
+        , m_animated(false) {}
 
     [[nodiscard]] QQuickItem* item() const;
     void setItem(QQuickItem* item);
@@ -32,6 +35,8 @@ public:
 
     [[nodiscard]] QUrl cachePath() const;
 
+    [[nodiscard]] bool animated() const { return m_animated; }
+
     Q_INVOKABLE void updateSource();
     Q_INVOKABLE void updateSource(const QString& path);
 
@@ -42,6 +47,7 @@ signals:
     void pathChanged();
     void cachePathChanged();
     void usingCacheChanged();
+    void animatedChanged();
 
 private:
     QString m_shaPath;
@@ -52,6 +58,8 @@ private:
     QString m_path;
     QUrl m_cachePath;
 
+    bool m_animated;
+
     QMetaObject::Connection m_widthConn;
     QMetaObject::Connection m_heightConn;
 
@@ -59,6 +67,8 @@ private:
     [[nodiscard]] QSize effectiveSize() const;
 
     void createCache(const QString& path, const QString& cache, const QString& fillMode, const QSize& size) const;
+
+    [[nodiscard]] static bool isAnimated(const QString& path);
     [[nodiscard]] static QString sha256sum(const QString& path);
 };
 

--- a/plugin/src/Caelestia/Internal/cachingimagemanager.hpp
+++ b/plugin/src/Caelestia/Internal/cachingimagemanager.hpp
@@ -17,6 +17,7 @@ class CachingImageManager : public QObject {
     Q_PROPERTY(QUrl cachePath READ cachePath NOTIFY cachePathChanged)
 
     Q_PROPERTY(bool animated READ animated NOTIFY animatedChanged)
+    Q_PROPERTY(bool preferAnimated READ preferAnimated WRITE setPreferAnimated NOTIFY preferAnimatedChanged)
 
 public:
     explicit CachingImageManager(QObject* parent = nullptr)
@@ -36,6 +37,8 @@ public:
     [[nodiscard]] QUrl cachePath() const;
 
     [[nodiscard]] bool animated() const { return m_animated; }
+    [[nodiscard]] bool preferAnimated() const { return m_preferAnimated; }
+    void setPreferAnimated(bool preferAnimated);
 
     Q_INVOKABLE void updateSource();
     Q_INVOKABLE void updateSource(const QString& path);
@@ -48,6 +51,7 @@ signals:
     void cachePathChanged();
     void usingCacheChanged();
     void animatedChanged();
+    void preferAnimatedChanged();
 
 private:
     QString m_shaPath;
@@ -59,6 +63,7 @@ private:
     QUrl m_cachePath;
 
     bool m_animated;
+    bool m_preferAnimated = true;
 
     QMetaObject::Connection m_widthConn;
     QMetaObject::Connection m_heightConn;

--- a/services/Brightness.qml
+++ b/services/Brightness.qml
@@ -180,14 +180,8 @@ Singleton {
                         monitor.vcpMax = 100; // Apple path writes 0..100
                         monitor.brightness = val / 101; // keep original behavior
                     } else if (monitor.isDdc) {
-                        // ddcutil getvcp 10 --brief ends with "... cur max"
-                        const cur = nums.at(-2);
-                        const max = nums.at(-1);
-                        // If parsing succeeds, use reported max; otherwise keep 250 fallback.
-                        if (!isNaN(max)) monitor.vcpMax = max;
-                        monitor.brightness = (!isNaN(cur) && !isNaN(monitor.vcpMax) && monitor.vcpMax > 0)
-                            ? cur / monitor.vcpMax
-                            : 0;
+                        const [, , , cur, max] = text.split(" ");
+                        monitor.brightness = parseInt(cur) / parseInt(max);
                     } else {
                         // brightnessctl path: our echo prints ... <cur> <max> at the end
                         const cur = nums.at(-2) ?? 0;

--- a/shell.qml
+++ b/shell.qml
@@ -10,12 +10,14 @@ import "modules/lock"
 import Quickshell
 
 ShellRoot {
-    Background {}
-    Drawers {}
-    AreaPicker {}
     Lock {
         id: lock
     }
+    Background {
+        lock: lock
+    }
+    Drawers {}
+    AreaPicker {}
 
     Shortcuts {}
     BatteryMonitor {}

--- a/utils/Images.qml
+++ b/utils/Images.qml
@@ -3,8 +3,8 @@ pragma Singleton
 import Quickshell
 
 Singleton {
-    readonly property list<string> validImageTypes: ["jpeg", "png", "webp", "tiff", "svg"]
-    readonly property list<string> validImageExtensions: ["jpg", "jpeg", "png", "webp", "tif", "tiff", "svg"]
+    readonly property list<string> validImageTypes: ["jpeg", "png", "webp", "tiff", "svg", "gif"]
+    readonly property list<string> validImageExtensions: ["jpg", "jpeg", "png", "webp", "tif", "tiff", "svg", "gif"]
 
     function isValidImageByName(name: string): bool {
         return validImageExtensions.some(t => name.endsWith(`.${t}`));


### PR DESCRIPTION
https://github.com/user-attachments/assets/6d5dfccb-be47-4f72-bcfc-2bb47c43a05b

## Summary
- Support for animated wallpapers along with caching support.
- Wallpaper picker lazy-loads previews without blocking.
- Preview viewport thumbnails could opt in / out of animation, defaulted to off.
- Playback on / off support, currently pausing playback on lock, and resumes after unlock.
- The related `cli` PR is here: https://github.com/caelestia-dots/cli/pull/68

## Changes
- `cachingimagemanager.hpp` + `cachingimagemanager.cpp` + `CachingImage.qml` reworked to show cached static frame 0 while animated frames decode.
  - Because of `CachingImage.qml` change, gifs are now also supported for `.face` (profile avatar). See video above when I lock my screen, I am using the same gif as the background, but they are unrelated, and you could use anything you would like for the profile avatar.
  - If we should guard against it being used for UI icons, let me know.
- `WallpaperList.qml` addition to drive previews off immediately after index changes, scrolling to animated images will show a static preview right away.
- `modules/background/Wallpaper.qml + Background.qml` populated with lock scope and gates playback pause/resume upon lock/unlock.

## Testing
- `QT_LOGGING_TO_CONSOLE=1 quickshell -c caelestia` when I had the logs to launch wallpaper picker, picking the animated wallpaper and set it, then watch the playback pause kick in while locked, and resumed after unlock.
- Scrolling through the wallpaper selection viewport without selecting, landing on animated images will immediately kick off the preview (could use more testing).

## Known issues:
- Like static images, the caching of the thumbnail sometimes show an empty black rectangle, caching part should receive attention.