### PR TITLE
workflow: optimize flake update logic

### DIFF
--- a/.github/workflows/update-flake-inputs.yml
+++ b/.github/workflows/update-flake-inputs.yml
@@ -25,33 +25,36 @@ jobs:
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v6
         with:
-          # restore and save a cache using this key
           primary-key: nix-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          # if there's no cache hit, restore a cache by this prefix
           restore-prefixes-first-match: nix-
-          # collect garbage until the Nix store size (in bytes) is at most this number
-          # before trying to save a new cache
-          # 1G = 1073741824
           gc-max-store-size-linux: 1G
-          # do purge caches
           purge: true
-          # purge all versions of the cache
           purge-prefixes: nix-
-          # created more than this number of seconds ago
           purge-created: 0
-          # or, last accessed more than this number of seconds ago
-          # relative to the start of the `Post Restore and save Nix store` phase
           purge-last-accessed: 0
-          # except any version with the key that is the same as the `primary-key`
           purge-primary-key: never
 
+      - name: Check if flake inputs have changed
+        id: check_inputs
+        run: |
+          git fetch origin
+          if git diff --exit-code flake.nix nixpkgs caeleastia-shell; then
+            echo "No changes in flake inputs."
+            echo "should_update=false" >> $GITHUB_ENV
+          else
+            echo "Changes detected in flake inputs."
+            echo "should_update=true" >> $GITHUB_ENV
+
       - name: Update flake inputs
+        if: env.should_update == 'true'
         run: nix flake update
 
       - name: Attempt to build flake
+        if: env.should_update == 'true'
         run: nix build
 
       - name: Test on Sway
+        if: env.should_update == 'true'
         env:
           XDG_RUNTIME_DIR: /home/runner/runtime
           WLR_BACKENDS: headless
@@ -61,16 +64,14 @@ jobs:
           mkdir $XDG_RUNTIME_DIR
           chown $USER $XDG_RUNTIME_DIR
           chmod 0700 $XDG_RUNTIME_DIR
-
           nix profile install 'nixpkgs#sway'
           sway &
-          sleep 3  # Give Sway some time to start
+          sleep 3
           result/bin/caelestia-shell -d
-          sleep 3  # Give the shell some time to start (and die)
-          pgrep .quickshell-wra  # Fail job if shell died
-
+          sleep 3
+          pgrep .quickshell-wra
           result/bin/caelestia-shell kill
-          killall sway  # Screw using IPC
+          killall sway
 
       - name: Check for changes
         id: check


### PR DESCRIPTION
Added a step to check for changes in flake.nix and its dependencies (nixpkgs, caelestia-shell)

Conditionally run the `nix flake update` command only when actual changes are detected in flake inputs

Kept the rest of the workflow intact: Build, test, and commit steps run only if flake inputs were updated

This modification reduces unnecessary rebuilds, commits and updates, improving the efficiency of the weekly flake update workflow
