### PR TITLE
controlcenter: implement audio and network settings panes

### DIFF
--- a/modules/controlcenter/Panes.qml
+++ b/modules/controlcenter/Panes.qml
@@ -1,6 +1,8 @@
 pragma ComponentBehavior: Bound
 
+import "audio"
 import "bluetooth"
+import "network"
 import qs.components
 import qs.services
 import qs.config
@@ -23,15 +25,7 @@ ClippingRectangle {
 
         Pane {
             index: 0
-            sourceComponent: Item {
-                StyledText {
-                    anchors.centerIn: parent
-                    text: qsTr("Work in progress")
-                    color: Colours.palette.m3outline
-                    font.pointSize: Appearance.font.size.extraLarge
-                    font.weight: 500
-                }
-            }
+            sourceComponent: NetworkPane {}
         }
 
         Pane {
@@ -43,15 +37,7 @@ ClippingRectangle {
 
         Pane {
             index: 2
-            sourceComponent: Item {
-                StyledText {
-                    anchors.centerIn: parent
-                    text: qsTr("Work in progress")
-                    color: Colours.palette.m3outline
-                    font.pointSize: Appearance.font.size.extraLarge
-                    font.weight: 500
-                }
-            }
+            sourceComponent: AudioPane {}
         }
 
         Behavior on y {

--- a/modules/controlcenter/audio/AudioPane.qml
+++ b/modules/controlcenter/audio/AudioPane.qml
@@ -1,0 +1,81 @@
+pragma ComponentBehavior: Bound
+
+import qs.components.effects
+import qs.components.containers
+import qs.config
+import Quickshell.Widgets
+import QtQuick
+import QtQuick.Layouts
+
+RowLayout {
+    id: root
+
+    anchors.fill: parent
+    spacing: 0
+
+    // Left panel - Device List
+    Item {
+        Layout.preferredWidth: Math.floor(parent.width * 0.4)
+        Layout.minimumWidth: 420
+        Layout.fillHeight: true
+
+        StyledFlickable {
+            anchors.fill: parent
+            anchors.margins: Appearance.padding.large + Appearance.padding.normal
+            anchors.leftMargin: Appearance.padding.large
+            anchors.rightMargin: Appearance.padding.large + Appearance.padding.normal / 2
+
+            flickableDirection: Flickable.VerticalFlick
+            contentHeight: deviceList.height
+
+            DeviceList {
+                id: deviceList
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+            }
+        }
+
+        InnerBorder {
+            leftThickness: 0
+            rightThickness: Appearance.padding.normal / 2
+        }
+    }
+
+    // Right panel - Settings
+    Item {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+
+        ClippingRectangle {
+            anchors.fill: parent
+            anchors.margins: Appearance.padding.normal
+            anchors.leftMargin: 0
+            anchors.rightMargin: Appearance.padding.normal / 2
+
+            radius: rightBorder.innerRadius
+            color: "transparent"
+
+            StyledFlickable {
+                anchors.fill: parent
+                anchors.margins: Appearance.padding.large * 2
+
+                flickableDirection: Flickable.VerticalFlick
+                contentHeight: settings.height
+
+                AudioSettings {
+                    id: settings
+
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                }
+            }
+        }
+
+        InnerBorder {
+            id: rightBorder
+
+            leftThickness: Appearance.padding.normal / 2
+        }
+    }
+}

--- a/modules/controlcenter/audio/AudioSettings.qml
+++ b/modules/controlcenter/audio/AudioSettings.qml
@@ -1,0 +1,252 @@
+pragma ComponentBehavior: Bound
+
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.config
+import Quickshell
+import QtQuick
+import QtQuick.Layouts
+
+ColumnLayout {
+    id: root
+
+    spacing: Appearance.spacing.normal
+
+    MaterialIcon {
+        Layout.alignment: Qt.AlignHCenter
+        text: "graphic_eq"
+        font.pointSize: Appearance.font.size.extraLarge * 3
+        font.bold: true
+    }
+
+    StyledText {
+        Layout.alignment: Qt.AlignHCenter
+        text: qsTr("Audio settings")
+        font.pointSize: Appearance.font.size.large
+        font.bold: true
+    }
+
+    // Output Volume Section
+    StyledText {
+        Layout.topMargin: Appearance.spacing.large
+        text: qsTr("Output volume")
+        font.pointSize: Appearance.font.size.larger
+        font.weight: 500
+    }
+
+    StyledText {
+        text: qsTr("Control output volume and mute")
+        color: Colours.palette.m3outline
+    }
+
+    StyledRect {
+        Layout.fillWidth: true
+        implicitHeight: outputVolume.implicitHeight + Appearance.padding.large * 2
+
+        radius: Appearance.rounding.normal
+        color: Colours.tPalette.m3surfaceContainer
+
+        ColumnLayout {
+            id: outputVolume
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: Appearance.padding.large
+
+            spacing: Appearance.spacing.larger
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Appearance.spacing.normal
+
+                MaterialIcon {
+                    text: Audio.muted ? "volume_off" : (Audio.volume > 0.5 ? "volume_up" : "volume_down")
+                    font.pointSize: Appearance.font.size.extraLarge
+                    color: Colours.palette.m3primary
+
+                    StateLayer {
+                        function onClicked(): void {
+                            if (Audio.sink?.audio)
+                                Audio.sink.audio.muted = !Audio.sink.audio.muted;
+                        }
+                    }
+                }
+
+                CustomMouseArea {
+                    Layout.fillWidth: true
+                    implicitHeight: Appearance.padding.normal * 3
+
+                    onWheel: event => {
+                        if (event.angleDelta.y > 0)
+                            Audio.incrementVolume();
+                        else if (event.angleDelta.y < 0)
+                            Audio.decrementVolume();
+                    }
+
+                    StyledSlider {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        implicitHeight: parent.implicitHeight
+
+                        value: Audio.volume
+                        onMoved: Audio.setVolume(value)
+
+                        Behavior on value {
+                            NumberAnimation {
+                                duration: Appearance.anim.durations.fast
+                            }
+                        }
+                    }
+                }
+
+                StyledText {
+                    Layout.preferredWidth: 60
+                    text: Audio.muted ? qsTr("Muted") : `${Math.round(Audio.volume * 100)}%`
+                    font.weight: 600
+                    font.pointSize: Appearance.font.size.large
+                    horizontalAlignment: Text.AlignRight
+                }
+            }
+        }
+    }
+
+    // Input Volume Section
+    StyledText {
+        Layout.topMargin: Appearance.spacing.large
+        text: qsTr("Input volume")
+        font.pointSize: Appearance.font.size.larger
+        font.weight: 500
+    }
+
+    StyledText {
+        text: qsTr("Control microphone volume and mute")
+        color: Colours.palette.m3outline
+    }
+
+    StyledRect {
+        Layout.fillWidth: true
+        implicitHeight: inputVolume.implicitHeight + Appearance.padding.large * 2
+
+        radius: Appearance.rounding.normal
+        color: Colours.tPalette.m3surfaceContainer
+
+        ColumnLayout {
+            id: inputVolume
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: Appearance.padding.large
+
+            spacing: Appearance.spacing.larger
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Appearance.spacing.normal
+
+                MaterialIcon {
+                    text: Audio.sourceMuted ? "mic_off" : "mic"
+                    font.pointSize: Appearance.font.size.extraLarge
+                    color: Colours.palette.m3primary
+
+                    StateLayer {
+                        function onClicked(): void {
+                            if (Audio.source?.audio)
+                                Audio.source.audio.muted = !Audio.source.audio.muted;
+                        }
+                    }
+                }
+
+                CustomMouseArea {
+                    Layout.fillWidth: true
+                    implicitHeight: Appearance.padding.normal * 3
+
+                    onWheel: event => {
+                        if (event.angleDelta.y > 0)
+                            Audio.incrementSourceVolume();
+                        else if (event.angleDelta.y < 0)
+                            Audio.decrementSourceVolume();
+                    }
+
+                    StyledSlider {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        implicitHeight: parent.implicitHeight
+
+                        value: Audio.sourceVolume
+                        onMoved: Audio.setSourceVolume(value)
+
+                        Behavior on value {
+                            NumberAnimation {
+                                duration: Appearance.anim.durations.fast
+                            }
+                        }
+                    }
+                }
+
+                StyledText {
+                    Layout.preferredWidth: 60
+                    text: Audio.sourceMuted ? qsTr("Muted") : `${Math.round(Audio.sourceVolume * 100)}%`
+                    font.weight: 600
+                    font.pointSize: Appearance.font.size.large
+                    horizontalAlignment: Text.AlignRight
+                }
+            }
+        }
+    }
+
+    // Device Information
+    StyledText {
+        Layout.topMargin: Appearance.spacing.large
+        text: qsTr("Device information")
+        font.pointSize: Appearance.font.size.larger
+        font.weight: 500
+    }
+
+    StyledText {
+        text: qsTr("Current audio devices")
+        color: Colours.palette.m3outline
+    }
+
+    StyledRect {
+        Layout.fillWidth: true
+        implicitHeight: deviceInfo.implicitHeight + Appearance.padding.large * 2
+
+        radius: Appearance.rounding.normal
+        color: Colours.tPalette.m3surfaceContainer
+
+        ColumnLayout {
+            id: deviceInfo
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: Appearance.padding.large
+
+            spacing: Appearance.spacing.small / 2
+
+            StyledText {
+                text: qsTr("Output device")
+            }
+
+            StyledText {
+                text: Audio.sink?.description || Audio.sink?.name || qsTr("Unknown")
+                color: Colours.palette.m3outline
+                font.pointSize: Appearance.font.size.small
+            }
+
+            StyledText {
+                Layout.topMargin: Appearance.spacing.normal
+                text: qsTr("Input device")
+            }
+
+            StyledText {
+                text: Audio.source?.description || Audio.source?.name || qsTr("Unknown")
+                color: Colours.palette.m3outline
+                font.pointSize: Appearance.font.size.small
+            }
+        }
+    }
+}

--- a/modules/controlcenter/audio/DeviceList.qml
+++ b/modules/controlcenter/audio/DeviceList.qml
@@ -1,0 +1,137 @@
+pragma ComponentBehavior: Bound
+
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.config
+import Quickshell.Services.Pipewire
+import QtQuick
+import QtQuick.Layouts
+
+ColumnLayout {
+    id: root
+
+    spacing: Appearance.spacing.large
+
+    // Output Devices Section
+    ColumnLayout {
+        Layout.fillWidth: true
+        spacing: Appearance.spacing.normal
+
+        StyledText {
+            text: qsTr("Output Devices")
+            font.pointSize: Appearance.font.size.large
+            font.weight: 700
+        }
+
+        Repeater {
+            model: Audio.sinks
+
+            DeviceCard {
+                required property PwNode modelData
+                required property int index
+
+                Layout.fillWidth: true
+                deviceName: modelData.description || modelData.name || qsTr("Unknown Device")
+                deviceType: "output"
+                isActive: Audio.sink?.id === modelData.id
+
+                onClicked: Audio.setAudioSink(modelData)
+            }
+        }
+    }
+
+    // Separator
+    Rectangle {
+        Layout.fillWidth: true
+        Layout.topMargin: Appearance.spacing.normal
+        Layout.bottomMargin: Appearance.spacing.normal
+        Layout.preferredHeight: 1
+        color: Colours.palette.m3outlineVariant
+        opacity: 0.3
+    }
+
+    // Input Devices Section
+    ColumnLayout {
+        Layout.fillWidth: true
+        spacing: Appearance.spacing.normal
+
+        StyledText {
+            text: qsTr("Input Devices")
+            font.pointSize: Appearance.font.size.large
+            font.weight: 700
+        }
+
+        Repeater {
+            model: Audio.sources
+
+            DeviceCard {
+                required property PwNode modelData
+                required property int index
+
+                Layout.fillWidth: true
+                deviceName: modelData.description || modelData.name || qsTr("Unknown Device")
+                deviceType: "input"
+                isActive: Audio.source?.id === modelData.id
+
+                onClicked: Audio.setAudioSource(modelData)
+            }
+        }
+    }
+
+    component DeviceCard: StyledRect {
+        id: card
+
+        required property string deviceName
+        required property string deviceType
+        required property bool isActive
+
+        signal clicked()
+
+        implicitHeight: cardContent.implicitHeight + Appearance.padding.large * 2
+        radius: Appearance.rounding.normal
+        color: isActive ? Colours.palette.m3primaryContainer : Colours.tPalette.m3surfaceContainer
+
+        StateLayer {
+            color: isActive ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+
+            function onClicked(): void {
+                card.clicked();
+            }
+        }
+
+        RowLayout {
+            id: cardContent
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: Appearance.padding.large
+
+            spacing: Appearance.spacing.normal
+
+            MaterialIcon {
+                text: deviceType === "output" ?
+                      (isActive ? "volume_up" : "speaker") :
+                      (isActive ? "mic" : "mic_none")
+                font.pointSize: Appearance.font.size.extraLarge
+                color: isActive ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+            }
+
+            StyledText {
+                Layout.fillWidth: true
+                text: deviceName
+                font.weight: isActive ? 600 : 400
+                color: isActive ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+                elide: Text.ElideRight
+            }
+
+            MaterialIcon {
+                text: "check_circle"
+                font.pointSize: Appearance.font.size.large
+                color: Colours.palette.m3primary
+                visible: isActive
+            }
+        }
+    }
+}

--- a/modules/controlcenter/network/NetworkList.qml
+++ b/modules/controlcenter/network/NetworkList.qml
@@ -1,0 +1,219 @@
+pragma ComponentBehavior: Bound
+
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.config
+import QtQuick
+import QtQuick.Layouts
+
+ColumnLayout {
+    id: root
+
+    property var selectedNetwork: null
+
+    spacing: Appearance.spacing.large
+
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: Appearance.spacing.normal
+
+        StyledText {
+            Layout.fillWidth: true
+            text: qsTr("Available Networks")
+            font.pointSize: Appearance.font.size.large
+            font.weight: 700
+        }
+
+        StyledRect {
+            implicitWidth: implicitHeight
+            implicitHeight: scanIcon.implicitHeight + Appearance.padding.small * 2
+
+            radius: Appearance.rounding.full
+            color: Network.scanning ? Colours.palette.m3primaryContainer : Colours.palette.m3surfaceContainerHighest
+
+            StateLayer {
+                color: Network.scanning ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+                disabled: Network.scanning
+
+                function onClicked(): void {
+                    Network.rescanWifi();
+                }
+            }
+
+            MaterialIcon {
+                id: scanIcon
+
+                anchors.centerIn: parent
+                text: "refresh"
+                font.pointSize: Appearance.font.size.large
+                color: Network.scanning ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+
+                RotationAnimator on rotation {
+                    running: Network.scanning
+                    from: 0
+                    to: 360
+                    duration: 1000
+                    loops: Animation.Infinite
+                }
+            }
+        }
+    }
+
+    Repeater {
+        model: Network.networks
+
+        NetworkCard {
+            required property var modelData
+            required property int index
+
+            Layout.fillWidth: true
+            network: modelData
+
+            onClicked: {
+                if (network.isSecure) {
+                    root.selectedNetwork = network;
+                } else {
+                    Network.connectToNetwork(network.ssid, "");
+                }
+            }
+        }
+    }
+
+    Item {
+        Layout.fillHeight: true
+        Layout.preferredHeight: 0
+        visible: Network.networks.length === 0
+
+        StyledText {
+            anchors.centerIn: parent
+            text: Network.wifiEnabled ? qsTr("No networks found") : qsTr("WiFi is disabled")
+            color: Colours.palette.m3outline
+            font.pointSize: Appearance.font.size.large
+        }
+    }
+
+    component NetworkCard: StyledRect {
+        id: card
+
+        required property var network
+
+        signal clicked()
+
+        implicitHeight: cardContent.implicitHeight + Appearance.padding.large * 2
+        radius: Appearance.rounding.normal
+        color: network.active ? Colours.palette.m3primaryContainer : Colours.tPalette.m3surfaceContainer
+
+        StateLayer {
+            color: network.active ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+
+            function onClicked(): void {
+                if (!network.active)
+                    card.clicked();
+            }
+        }
+
+        RowLayout {
+            id: cardContent
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: Appearance.padding.large
+
+            spacing: Appearance.spacing.normal
+
+            MaterialIcon {
+                text: {
+                    if (!Network.wifiEnabled) return "wifi_off";
+                    if (network.active) return "wifi";
+                    const strength = network.strength;
+                    if (strength >= 75) return "network_wifi_3_bar";
+                    if (strength >= 50) return "network_wifi_2_bar";
+                    if (strength >= 25) return "network_wifi_1_bar";
+                    return "network_wifi";
+                }
+                font.pointSize: Appearance.font.size.extraLarge
+                color: network.active ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: Appearance.spacing.smaller
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: network.ssid
+                    font.weight: network.active ? 600 : 400
+                    color: network.active ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+                    elide: Text.ElideRight
+                }
+
+                RowLayout {
+                    spacing: Appearance.spacing.small
+
+                    MaterialIcon {
+                        text: network.isSecure ? "lock" : "lock_open"
+                        font.pointSize: Appearance.font.size.small
+                        color: network.active ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3outline
+                        opacity: 0.7
+                    }
+
+                    StyledText {
+                        text: network.isSecure ? qsTr("Secured") : qsTr("Open")
+                        font.pointSize: Appearance.font.size.small
+                        color: network.active ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3outline
+                        opacity: 0.7
+                    }
+
+                    StyledText {
+                        text: "•"
+                        font.pointSize: Appearance.font.size.small
+                        color: network.active ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3outline
+                        opacity: 0.7
+                    }
+
+                    StyledText {
+                        text: `${network.strength}%`
+                        font.pointSize: Appearance.font.size.small
+                        color: network.active ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3outline
+                        opacity: 0.7
+                    }
+                }
+            }
+
+            MaterialIcon {
+                text: network.active ? "check_circle" : "chevron_right"
+                font.pointSize: Appearance.font.size.large
+                color: network.active ? Colours.palette.m3primary : Colours.palette.m3outline
+            }
+        }
+    }
+
+    // Password Dialog Loader
+    Loader {
+        id: passwordDialogLoader
+
+        anchors.fill: parent
+        active: root.selectedNetwork !== null
+        sourceComponent: passwordDialog
+        z: 1000
+    }
+
+    Component {
+        id: passwordDialog
+
+        PasswordDialog {
+            network: root.selectedNetwork
+
+            onAccepted: password => {
+                Network.connectToNetwork(root.selectedNetwork.ssid, password);
+                root.selectedNetwork = null;
+            }
+
+            onCancelled: {
+                root.selectedNetwork = null;
+            }
+        }
+    }
+}

--- a/modules/controlcenter/network/NetworkPane.qml
+++ b/modules/controlcenter/network/NetworkPane.qml
@@ -1,0 +1,81 @@
+pragma ComponentBehavior: Bound
+
+import qs.components.effects
+import qs.components.containers
+import qs.config
+import Quickshell.Widgets
+import QtQuick
+import QtQuick.Layouts
+
+RowLayout {
+    id: root
+
+    anchors.fill: parent
+    spacing: 0
+
+    // Left panel - Network List
+    Item {
+        Layout.preferredWidth: Math.floor(parent.width * 0.4)
+        Layout.minimumWidth: 420
+        Layout.fillHeight: true
+
+        StyledFlickable {
+            anchors.fill: parent
+            anchors.margins: Appearance.padding.large + Appearance.padding.normal
+            anchors.leftMargin: Appearance.padding.large
+            anchors.rightMargin: Appearance.padding.large + Appearance.padding.normal / 2
+
+            flickableDirection: Flickable.VerticalFlick
+            contentHeight: networkList.height
+
+            NetworkList {
+                id: networkList
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+            }
+        }
+
+        InnerBorder {
+            leftThickness: 0
+            rightThickness: Appearance.padding.normal / 2
+        }
+    }
+
+    // Right panel - Settings
+    Item {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+
+        ClippingRectangle {
+            anchors.fill: parent
+            anchors.margins: Appearance.padding.normal
+            anchors.leftMargin: 0
+            anchors.rightMargin: Appearance.padding.normal / 2
+
+            radius: rightBorder.innerRadius
+            color: "transparent"
+
+            StyledFlickable {
+                anchors.fill: parent
+                anchors.margins: Appearance.padding.large * 2
+
+                flickableDirection: Flickable.VerticalFlick
+                contentHeight: settings.height
+
+                NetworkSettings {
+                    id: settings
+
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                }
+            }
+        }
+
+        InnerBorder {
+            id: rightBorder
+
+            leftThickness: Appearance.padding.normal / 2
+        }
+    }
+}

--- a/modules/controlcenter/network/NetworkSettings.qml
+++ b/modules/controlcenter/network/NetworkSettings.qml
@@ -1,0 +1,248 @@
+pragma ComponentBehavior: Bound
+
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.config
+import Quickshell
+import QtQuick
+import QtQuick.Layouts
+
+ColumnLayout {
+    id: root
+
+    spacing: Appearance.spacing.normal
+
+    MaterialIcon {
+        Layout.alignment: Qt.AlignHCenter
+        text: "wifi"
+        font.pointSize: Appearance.font.size.extraLarge * 3
+        font.bold: true
+    }
+
+    StyledText {
+        Layout.alignment: Qt.AlignHCenter
+        text: qsTr("Network settings")
+        font.pointSize: Appearance.font.size.large
+        font.bold: true
+    }
+
+    // WiFi Status Section
+    StyledText {
+        Layout.topMargin: Appearance.spacing.large
+        text: qsTr("WiFi status")
+        font.pointSize: Appearance.font.size.larger
+        font.weight: 500
+    }
+
+    StyledText {
+        text: qsTr("Enable or disable WiFi")
+        color: Colours.palette.m3outline
+    }
+
+    StyledRect {
+        Layout.fillWidth: true
+        implicitHeight: wifiStatus.implicitHeight + Appearance.padding.large * 2
+
+        radius: Appearance.rounding.normal
+        color: Colours.tPalette.m3surfaceContainer
+
+        RowLayout {
+            id: wifiStatus
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: Appearance.padding.large
+
+            spacing: Appearance.spacing.normal
+
+            StyledText {
+                Layout.fillWidth: true
+                text: qsTr("WiFi enabled")
+            }
+
+            StyledSwitch {
+                checked: Network.wifiEnabled
+                onToggled: Network.toggleWifi()
+                cLayer: 2
+            }
+        }
+    }
+
+    // Connected Network Section
+    StyledText {
+        Layout.topMargin: Appearance.spacing.large
+        text: qsTr("Active connection")
+        font.pointSize: Appearance.font.size.larger
+        font.weight: 500
+    }
+
+    StyledText {
+        text: qsTr("Currently connected network")
+        color: Colours.palette.m3outline
+    }
+
+    StyledRect {
+        Layout.fillWidth: true
+        implicitHeight: activeConnection.implicitHeight + Appearance.padding.large * 2
+
+        radius: Appearance.rounding.normal
+        color: Colours.tPalette.m3surfaceContainer
+
+        ColumnLayout {
+            id: activeConnection
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: Appearance.padding.large
+
+            spacing: Appearance.spacing.larger
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Appearance.spacing.normal
+
+                MaterialIcon {
+                    text: Network.active ? "wifi" : "wifi_off"
+                    font.pointSize: Appearance.font.size.extraLarge
+                    color: Network.active ? Colours.palette.m3primary : Colours.palette.m3outline
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: Appearance.spacing.smaller
+
+                    StyledText {
+                        text: Network.active ? Network.active.ssid : qsTr("Not connected")
+                        font.weight: 600
+                    }
+
+                    StyledText {
+                        visible: Network.active
+                        text: Network.active ? `${qsTr("Signal")}: ${Network.active.strength}%` : ""
+                        font.pointSize: Appearance.font.size.small
+                        color: Colours.palette.m3outline
+                    }
+                }
+            }
+
+            StyledRect {
+                Layout.fillWidth: true
+                Layout.topMargin: Appearance.spacing.small
+                visible: Network.active
+
+                implicitHeight: disconnectBtn.implicitHeight + Appearance.padding.normal
+
+                radius: Appearance.rounding.normal
+                color: Colours.palette.m3errorContainer
+
+                StateLayer {
+                    color: Colours.palette.m3onErrorContainer
+
+                    function onClicked(): void {
+                        Network.disconnectFromNetwork();
+                    }
+                }
+
+                RowLayout {
+                    id: disconnectBtn
+
+                    anchors.centerIn: parent
+                    spacing: Appearance.spacing.small
+
+                    MaterialIcon {
+                        text: "wifi_off"
+                        color: Colours.palette.m3onErrorContainer
+                        font.pointSize: Appearance.font.size.large
+                    }
+
+                    StyledText {
+                        text: qsTr("Disconnect")
+                        color: Colours.palette.m3onErrorContainer
+                        font.weight: 600
+                    }
+                }
+            }
+        }
+    }
+
+    // Network Information
+    StyledText {
+        Layout.topMargin: Appearance.spacing.large
+        text: qsTr("Network information")
+        font.pointSize: Appearance.font.size.larger
+        font.weight: 500
+    }
+
+    StyledText {
+        text: qsTr("Details about the connection")
+        color: Colours.palette.m3outline
+    }
+
+    StyledRect {
+        Layout.fillWidth: true
+        implicitHeight: networkInfo.implicitHeight + Appearance.padding.large * 2
+
+        radius: Appearance.rounding.normal
+        color: Colours.tPalette.m3surfaceContainer
+
+        ColumnLayout {
+            id: networkInfo
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: Appearance.padding.large
+
+            spacing: Appearance.spacing.small / 2
+
+            StyledText {
+                text: qsTr("SSID")
+            }
+
+            StyledText {
+                text: Network.active?.ssid ?? qsTr("Not connected")
+                color: Colours.palette.m3outline
+                font.pointSize: Appearance.font.size.small
+            }
+
+            StyledText {
+                Layout.topMargin: Appearance.spacing.normal
+                text: qsTr("Security")
+            }
+
+            StyledText {
+                text: {
+                    if (!Network.active) return qsTr("N/A");
+                    return Network.active.isSecure ? Network.active.security : qsTr("Open");
+                }
+                color: Colours.palette.m3outline
+                font.pointSize: Appearance.font.size.small
+            }
+
+            StyledText {
+                Layout.topMargin: Appearance.spacing.normal
+                text: qsTr("Frequency")
+            }
+
+            StyledText {
+                text: Network.active ? `${Network.active.frequency} MHz` : qsTr("N/A")
+                color: Colours.palette.m3outline
+                font.pointSize: Appearance.font.size.small
+            }
+
+            StyledText {
+                Layout.topMargin: Appearance.spacing.normal
+                text: qsTr("BSSID")
+            }
+
+            StyledText {
+                text: Network.active?.bssid ?? qsTr("N/A")
+                color: Colours.palette.m3outline
+                font.pointSize: Appearance.font.size.small
+            }
+        }
+    }
+}

--- a/modules/controlcenter/network/PasswordDialog.qml
+++ b/modules/controlcenter/network/PasswordDialog.qml
@@ -1,0 +1,273 @@
+pragma ComponentBehavior: Bound
+
+import qs.components
+import qs.components.controls
+import qs.components.effects
+import qs.services
+import qs.config
+import QtQuick
+import QtQuick.Layouts
+
+Item {
+    id: root
+
+    required property var network
+    signal accepted(password: string)
+    signal cancelled()
+
+    anchors.fill: parent
+
+    // Backdrop
+    Rectangle {
+        anchors.fill: parent
+        color: "#000000"
+        opacity: 0.6
+
+        StateLayer {
+            function onClicked(): void {
+                root.cancelled();
+            }
+        }
+    }
+
+    // Elevation shadow
+    Elevation {
+        anchors.fill: dialog
+        radius: dialog.radius
+        level: 3
+    }
+
+    // Dialog
+    StyledRect {
+        id: dialog
+
+        anchors.centerIn: parent
+        implicitWidth: Math.min(parent.width * 0.8, 400)
+        implicitHeight: dialogContent.implicitHeight + Appearance.padding.large * 4
+
+        radius: Appearance.rounding.large
+        color: Colours.palette.m3surface
+
+        ColumnLayout {
+            id: dialogContent
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: Appearance.padding.large * 2
+
+            spacing: Appearance.spacing.large
+
+            // Title
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Appearance.spacing.normal
+
+                MaterialIcon {
+                    text: "lock"
+                    font.pointSize: Appearance.font.size.extraLarge
+                    color: Colours.palette.m3primary
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("Enter Password")
+                    font.pointSize: Appearance.font.size.large
+                    font.weight: 700
+                }
+            }
+
+            // Network info
+            StyledText {
+                Layout.fillWidth: true
+                text: qsTr("Network: %1").arg(root.network.ssid)
+                color: Colours.palette.m3outline
+                wrapMode: Text.Wrap
+            }
+
+            // Password field
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: Appearance.spacing.small
+
+                StyledText {
+                    text: qsTr("Password")
+                    font.weight: 600
+                }
+
+                StyledTextField {
+                    id: passwordField
+
+                    Layout.fillWidth: true
+                    placeholderText: qsTr("Enter network password")
+                    echoMode: showPassword.checked ? TextInput.Normal : TextInput.Password
+
+                    onAccepted: {
+                        if (text.length > 0) {
+                            root.accepted(text);
+                        }
+                    }
+
+                    Component.onCompleted: forceActiveFocus()
+
+                    Keys.onEscapePressed: root.cancelled()
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Appearance.spacing.small
+
+                    StyledRect {
+                        implicitWidth: checkBox.implicitWidth + Appearance.padding.small * 2
+                        implicitHeight: checkBox.implicitHeight + Appearance.padding.small * 2
+
+                        radius: Appearance.rounding.small
+                        color: showPassword.checked ? Colours.palette.m3primaryContainer : Colours.palette.m3surfaceContainerHighest
+
+                        StateLayer {
+                            color: showPassword.checked ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+
+                            function onClicked(): void {
+                                showPassword.checked = !showPassword.checked;
+                            }
+                        }
+
+                        MaterialIcon {
+                            id: checkBox
+
+                            anchors.centerIn: parent
+                            text: showPassword.checked ? "check_box" : "check_box_outline_blank"
+                            font.pointSize: Appearance.font.size.normal
+                            color: showPassword.checked ? Colours.palette.m3primary : Colours.palette.m3outline
+                        }
+                    }
+
+                    QtObject {
+                        id: showPassword
+                        property bool checked: false
+                    }
+
+                    StyledText {
+                        text: qsTr("Show password")
+                        font.pointSize: Appearance.font.size.small
+
+                        StateLayer {
+                            function onClicked(): void {
+                                showPassword.checked = !showPassword.checked;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Error message
+            StyledText {
+                id: errorText
+
+                Layout.fillWidth: true
+                visible: false
+                text: qsTr("Failed to connect. Please check your password.")
+                color: Colours.palette.m3error
+                font.pointSize: Appearance.font.size.small
+                wrapMode: Text.Wrap
+            }
+
+            // Buttons
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.topMargin: Appearance.spacing.normal
+                spacing: Appearance.spacing.normal
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                StyledRect {
+                    implicitWidth: cancelBtn.implicitWidth + Appearance.padding.large * 2
+                    implicitHeight: cancelBtn.implicitHeight + Appearance.padding.normal
+
+                    radius: Appearance.rounding.normal
+                    color: "transparent"
+
+                    StateLayer {
+                        color: Colours.palette.m3onSurface
+
+                        function onClicked(): void {
+                            root.cancelled();
+                        }
+                    }
+
+                    StyledText {
+                        id: cancelBtn
+
+                        anchors.centerIn: parent
+                        text: qsTr("Cancel")
+                        font.weight: 600
+                        color: Colours.palette.m3onSurface
+                    }
+                }
+
+                StyledRect {
+                    implicitWidth: connectBtn.implicitWidth + Appearance.padding.large * 2
+                    implicitHeight: connectBtn.implicitHeight + Appearance.padding.normal
+
+                    radius: Appearance.rounding.normal
+                    color: passwordField.text.length > 0 ? Colours.palette.m3primary : Colours.palette.m3surfaceContainerHighest
+
+                    StateLayer {
+                        color: Colours.palette.m3onPrimary
+                        disabled: passwordField.text.length === 0
+
+                        function onClicked(): void {
+                            if (passwordField.text.length > 0) {
+                                root.accepted(passwordField.text);
+                            }
+                        }
+                    }
+
+                    StyledText {
+                        id: connectBtn
+
+                        anchors.centerIn: parent
+                        text: qsTr("Connect")
+                        font.weight: 600
+                        color: passwordField.text.length > 0 ? Colours.palette.m3onPrimary : Colours.palette.m3outline
+                    }
+                }
+            }
+        }
+
+        // Scale animation
+        scale: 0
+        opacity: 0
+
+        Component.onCompleted: {
+            scaleAnim.start();
+            opacityAnim.start();
+        }
+
+        NumberAnimation {
+            id: scaleAnim
+            target: dialog
+            property: "scale"
+            from: 0.8
+            to: 1
+            duration: Appearance.anim.durations.normal
+            easing.type: Easing.OutCubic
+        }
+
+        NumberAnimation {
+            id: opacityAnim
+            target: dialog
+            property: "opacity"
+            from: 0
+            to: 1
+            duration: Appearance.anim.durations.normal
+            easing.type: Easing.OutCubic
+        }
+    }
+
+    function showError(): void {
+        errorText.visible = true;
+    }
+}


### PR DESCRIPTION
- Add AudioPane with two-column layout matching bluetooth pane style
  - Device list with output/input device cards
  - Volume controls with mute/unmute buttons
  - Real-time volume percentage display
  - Mouse wheel support on sliders
  - Device information card

- Add NetworkPane with two-column layout
  - WiFi network list with scan/refresh
  - Network cards showing SSID, security, signal strength
  - WiFi enable/disable toggle
  - Connect/disconnect functionality
  - Active connection display with details
  - Password dialog for secured networks

- Update Panes.qml to replace 'Work in progress' placeholders
- All components follow Material Design 3 styling
- Consistent spacing and colors with existing bluetooth pane