### PR TITLE
fixes session logout and hibernate buttons in example shell.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ default, you must create it manually.
         "enabled": true,
         "vimKeybinds": false,
         "commands": {
-            "logout": ["pkill", "-KILL", "-u", "$(whoami)"],
+            "logout": ["bash", "-c", "pkill -KILL -u $(whoami)"],
             "shutdown": ["systemctl", "poweroff"],
             "hibernate": ["systemctl", "sleep"],
             "reboot": ["systemctl", "reboot"]


### PR DESCRIPTION
I know that the `shell.json` technically needs to be manually created but in most cases it's best for example code to work out of box with a fresh installation. This makes it so the logout and hibernate buttons work with the default packages installed by `install.fish`.