### PR TITLE
copy screenshot to clipboard

### DIFF
--- a/modules/areapicker/AreaPicker.qml
+++ b/modules/areapicker/AreaPicker.qml
@@ -12,6 +12,7 @@ Scope {
 
         property bool freeze
         property bool closing
+        property bool clipboardOnly
 
         Variants {
             model: Quickshell.screens
@@ -51,12 +52,28 @@ Scope {
         function open(): void {
             root.freeze = false;
             root.closing = false;
+            root.clipboardOnly = false;
             root.activeAsync = true;
         }
 
         function openFreeze(): void {
             root.freeze = true;
             root.closing = false;
+            root.clipboardOnly = false;
+            root.activeAsync = true;
+        }
+
+        function openClip(): void {
+            root.freeze = false;
+            root.closing = false;
+            root.clipboardOnly = true;
+            root.activeAsync = true;
+        }
+
+        function openFreezeClip(): void {
+            root.freeze = true;
+            root.closing = false;
+            root.clipboardOnly = true;
             root.activeAsync = true;
         }
     }
@@ -67,6 +84,7 @@ Scope {
         onPressed: {
             root.freeze = false;
             root.closing = false;
+            root.clipboardOnly = false;
             root.activeAsync = true;
         }
     }
@@ -77,6 +95,29 @@ Scope {
         onPressed: {
             root.freeze = true;
             root.closing = false;
+            root.clipboardOnly = false;
+            root.activeAsync = true;
+        }
+    }
+
+    CustomShortcut {
+        name: "screenshotClip"
+        description: "Open screenshot tool (clipboard)"
+        onPressed: {
+            root.freeze = false;
+            root.closing = false;
+            root.clipboardOnly = true;
+            root.activeAsync = true;
+        }
+    }
+
+    CustomShortcut {
+        name: "screenshotFreezeClip"
+        description: "Open screenshot tool (freeze mode, clipboard)"
+        onPressed: {
+            root.freeze = true;
+            root.closing = false;
+            root.clipboardOnly = true;
             root.activeAsync = true;
         }
     }

--- a/modules/areapicker/Picker.qml
+++ b/modules/areapicker/Picker.qml
@@ -73,7 +73,14 @@ MouseArea {
 
     function save(): void {
         const tmpfile = Qt.resolvedUrl(`/tmp/caelestia-picker-${Quickshell.processId}-${Date.now()}.png`);
-        CUtils.saveItem(screencopy, tmpfile, Qt.rect(Math.ceil(rsx), Math.ceil(rsy), Math.floor(sw), Math.floor(sh)), path => Quickshell.execDetached(["swappy", "-f", path]));
+        CUtils.saveItem(screencopy, tmpfile, Qt.rect(Math.ceil(rsx), Math.ceil(rsy), Math.floor(sw), Math.floor(sh)), path => {
+            if (root.loader.clipboardOnly) {
+                Quickshell.execDetached(["sh", "-c", "wl-copy --type image/png < " + path]);
+                Quickshell.execDetached(["notify-send", "-a", "caelestia-cli", "-i", path, "Screenshot taken", "Screenshot copied to clipboard"]);
+            } else {
+                Quickshell.execDetached(["swappy", "-f", path]);
+            }
+        });
         closeAnim.start();
     }
 


### PR DESCRIPTION
added screenshotClip and screenshotFreezeClip to allow directly copying screenshots to clipboard instead of having it open in swappy and clicking copy 
based on #758 