### PR TITLE
Make Bluetooth device sort order stable

### DIFF
--- a/modules/bar/popouts/Bluetooth.qml
+++ b/modules/bar/popouts/Bluetooth.qml
@@ -61,7 +61,7 @@ ColumnLayout {
 
     Repeater {
         model: ScriptModel {
-            values: [...Bluetooth.devices.values].sort((a, b) => (b.connected - a.connected) || (b.paired - a.paired)).slice(0, 5)
+            values: [...Bluetooth.devices.values].sort((a, b) => (b.connected - a.connected) || (b.paired - a.paired) || a.name.localeCompare(b.name)).slice(0, 5)
         }
 
         RowLayout {

--- a/modules/controlcenter/bluetooth/DeviceList.qml
+++ b/modules/controlcenter/bluetooth/DeviceList.qml
@@ -147,7 +147,7 @@ ColumnLayout {
         model: ScriptModel {
             id: deviceModel
 
-            values: [...Bluetooth.devices.values].sort((a, b) => (b.connected - a.connected) || (b.paired - a.paired))
+            values: [...Bluetooth.devices.values].sort((a, b) => (b.connected - a.connected) || (b.paired - a.paired) || a.name.localeCompare(b.name))
         }
 
         Layout.fillWidth: true


### PR DESCRIPTION
Right now, aside from paired/connected being first, there's no consistent sort order for the Bluetooth device list. With lots of devices it's hard to find the one I want, and then they can move around randomly while the panel is open.