### PR TITLE
fix(dashboard): Media.qml warnings due to stricter updated Qt6 checks

### DIFF
--- a/modules/dashboard/Media.qml
+++ b/modules/dashboard/Media.qml
@@ -323,7 +323,7 @@ Item {
                 id: playerSelector
 
                 disabled: !Players.list.length
-                active: Players.active ? (menuItems.find(m => m.modelData === Players.active) ?? menuItems[0]) : null
+                active: menuItems.find(m => m.modelData === Players.active) ?? menuItems[0] ?? null
                 menu.onItemSelected: item => Players.manualActive = item.modelData
 
                 menuItems: playerList.instances


### PR DESCRIPTION
This PR resolves a persistent 'Unable to assign [undefined] to bool/object' warnings in modules/dashboard/Media.qml that occur when no media player is active ('Players.active' is undefined)

The warnings were caused by the recent Qt6 6.10.1-1 update which has stricter checks and affected properties that expect a boolean or a safe object reference receiving 'undefined' instead

The following properties were made explicit:

    visible property for id: album
    enabled property for id: slider
    checked property for PlayerControl
    playing property for AnimatedImage
    active property for playerSelector

These changes are purely defensive and do not impact the functionality of the media dashboard
