### PR TITLE
fix: brightness doesn't update when changed using keyboard or brightnessctl

### DIFF
--- a/services/Brightness.qml
+++ b/services/Brightness.qml
@@ -184,6 +184,13 @@ Singleton {
             }
         }
 
+        readonly property Timer pollTimer: Timer {
+            interval: 100
+            repeat: true
+            running: true
+            onTriggered: initBrightness()
+        }
+
         function setBrightness(value: real): void {
             value = Math.max(0, Math.min(1, value));
             const rounded = Math.round(value * 100);


### PR DESCRIPTION
There've been this issue where my brightness doesn't get synced with the osd slider. I found out that if I update bightness using keybinds which uses brightnessctl at the end, it doesn't update the brightness, so this change reinitialize the brightness every 0.1 second to get the latest brightness. please lemme know if I can do it any other way.


https://github.com/user-attachments/assets/160f435e-ce1f-46c8-87f3-bb07e8e49913

