### PR TITLE
feat: Add openExpanded config property for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ default, you must create it manually.
         "clearThreshold": 0.3,
         "defaultExpireTimeout": 5000,
         "expandThreshold": 20,
+        "openExpanded": false,
         "expire": false
     },
     "osd": {

--- a/config/NotifsConfig.qml
+++ b/config/NotifsConfig.qml
@@ -7,6 +7,7 @@ JsonObject {
     property int expandThreshold: 20
     property bool actionOnClick: false
     property int groupPreviewNum: 3
+    property bool openExpanded: false // Show the notifichation in expanded state when opening
     property Sizes sizes: Sizes {}
 
     component Sizes: JsonObject {

--- a/modules/notifications/Notification.qml
+++ b/modules/notifications/Notification.qml
@@ -18,7 +18,7 @@ StyledRect {
     readonly property bool hasImage: modelData.image.length > 0
     readonly property bool hasAppIcon: modelData.appIcon.length > 0
     readonly property int nonAnimHeight: summary.implicitHeight + (root.expanded ? appName.height + body.height + actions.height + actions.anchors.topMargin : bodyPreview.height) + inner.anchors.margins * 2
-    property bool expanded
+    property bool expanded: Config.notifs.openExpanded
 
     color: root.modelData.urgency === NotificationUrgency.Critical ? Colours.palette.m3secondaryContainer : Colours.tPalette.m3surfaceContainer
     radius: Appearance.rounding.normal


### PR DESCRIPTION
If set in the configuration, the notifications are opened in the expanded state, displaying the full notification text.