### PR TITLE
utilities: Added night light button that uses hyprsunset

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,7 +603,8 @@ default, you must create it manually.
             "kbLayoutChanged": true,
             "numLockChanged": true,
             "vpnChanged": true,
-            "nowPlaying": false
+            "nowPlaying": false,
+            "nighLight": true
         },
         "vpn": {
             "enabled": false,
@@ -614,6 +615,10 @@ default, you must create it manually.
                     "displayName": "Wireguard (Your VPN)"
                 }
             ]
+        },
+        "nightLight": {
+            "enabled": false,
+            "temperature": 4500
         }
     }
 }

--- a/config/UtilitiesConfig.qml
+++ b/config/UtilitiesConfig.qml
@@ -7,6 +7,7 @@ JsonObject {
     property Sizes sizes: Sizes {}
     property Toasts toasts: Toasts {}
     property Vpn vpn: Vpn {}
+    property NightLight nightLight: NightLight {}
 
     component Sizes: JsonObject {
         property int width: 430
@@ -25,10 +26,16 @@ JsonObject {
         property bool kbLayoutChanged: true
         property bool vpnChanged: true
         property bool nowPlaying: false
+        property bool nightLight: true
     }
 
     component Vpn: JsonObject {
         property bool enabled: false
         property list<var> provider: ["netbird"]
+    }
+
+    component NightLight: JsonObject {
+        property bool enabled: false
+        property int temperature: 4500
     }
 }

--- a/modules/utilities/cards/Toggles.qml
+++ b/modules/utilities/cards/Toggles.qml
@@ -13,6 +13,7 @@ StyledRect {
 
     required property var visibilities
     required property Item popouts
+    property bool additionalToggles: !VPN.enabled && !NightLight.enabled
 
     Layout.fillWidth: true
     implicitHeight: layout.implicitHeight + Appearance.padding.large * 2
@@ -32,11 +33,9 @@ StyledRect {
             font.pointSize: Appearance.font.size.normal
         }
 
-        GridLayout {
+        RowLayout {
             Layout.alignment: Qt.AlignHCenter
-            columns: (VPN.enabled || NightLight.enabled) ? 4 : 6
-            rowSpacing: Appearance.spacing.small
-            columnSpacing: Appearance.spacing.small
+            spacing: Appearance.spacing.small
 
             Toggle {
                 icon: "wifi"
@@ -73,6 +72,26 @@ StyledRect {
                     root.popouts.detach("network");
                 }
             }
+
+            Toggle {
+                icon: "gamepad"
+                checked: GameMode.enabled
+                visible: root.additionalToggles
+                onClicked: GameMode.enabled = !GameMode.enabled
+            }
+
+            Toggle {
+                icon: "notifications_off"
+                checked: Notifs.dnd
+                visible: root.additionalToggles
+                onClicked: Notifs.dnd = !Notifs.dnd
+            }
+        }
+
+        RowLayout {
+            Layout.alignment: Qt.AlignHCenter
+            spacing: Appearance.spacing.small
+            visible: VPN.enabled || NightLight.enabled
 
             Toggle {
                 icon: "gamepad"

--- a/modules/utilities/cards/Toggles.qml
+++ b/modules/utilities/cards/Toggles.qml
@@ -32,9 +32,11 @@ StyledRect {
             font.pointSize: Appearance.font.size.normal
         }
 
-        RowLayout {
+        GridLayout {
             Layout.alignment: Qt.AlignHCenter
-            spacing: Appearance.spacing.small
+            columns: (VPN.enabled || NightLight.enabled) ? 4 : 6
+            rowSpacing: Appearance.spacing.small
+            columnSpacing: Appearance.spacing.small
 
             Toggle {
                 icon: "wifi"
@@ -92,6 +94,12 @@ StyledRect {
                 onClicked: VPN.toggle()
             }
 
+            Toggle {
+                icon: "dark_mode"
+                checked: NightLight.on
+                visible: NightLight.enabled
+                onClicked: NightLight.toggle()
+            }
         }
     }
 

--- a/services/NightLight.qml
+++ b/services/NightLight.qml
@@ -1,0 +1,56 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import Caelestia
+import qs.config
+import qs.components.misc
+
+Singleton {
+    id: root
+
+    readonly property bool enabled: Config.utilities.nightLight.enabled
+    readonly property int temperature: Config.utilities.nightLight.temperature
+
+    property bool on: nightLightProcess.running
+
+    Process {
+        id: nightLightProcess
+        command: ["hyprsunset", "--temperature", root.temperature.toString()]
+        running: false 
+    }
+
+    function toggle() {
+        if (nightLightProcess.running) {
+            nightLightProcess.running = false;
+            if (Config.utilities.toasts.nightLight)
+                Toaster.toast(qsTr("Night Light"), qsTr("Disabled"), "dark_mode");
+        } else {
+            nightLightProcess.running = true;
+            if (Config.utilities.toasts.nightLight)
+                Toaster.toast(qsTr("Night Light"), qsTr("Enabled"), "dark_mode");
+        }
+    }
+
+    // Kills instances of hyprsunset not managed by Quickshell
+    Process {
+        id: startupCleaner
+        command: ["pkill", "hyprsunset"]
+    }
+    Component.onCompleted: {
+        if (enabled) {
+            startupCleaner.running = true;
+        }
+    }
+
+    Component.onDestruction: {
+        nightLightProcess.running = false;
+    }
+
+    CustomShortcut {
+        name: "nightLightToggle"
+        description: "Toggles Night Light"
+        onPressed: root.toggle()
+    }
+}


### PR DESCRIPTION
# Added Night Light Utility

Implemented a Night Light toggle in the Utilities panel using `hyprsunset`. 

## Features
- **Notifications:** Integrated with the Toaster system to notify the user when the mode is toggled.

<img width="435" height="179" alt="image" src="https://github.com/user-attachments/assets/632b19b8-bc02-4698-9b56-d6d25f4c0b3c" />

- **Configurable:** Uses `temperature` and `enabled` settings from the global configuration.
```
    "utilities": {
        "enabled": true,
        . . .,
        "nightLight": {
        	"enabled": true,
        	"temperature": 4500
        }
    }
```
- **Custom Shortcut.** Can run using `caelestia:nightLightToggle`
Example usage:
```
bind = Super, N, global, caelestia:nightLightToggle
```

## Dependencies
- `hyprsunset`

## Preview
<img width="406" height="112" alt="image" src="https://github.com/user-attachments/assets/e1c56090-1540-4680-8507-51990593e74e" />