### PR TITLE
fix(background): fix black screen caused by async Loader

### DIFF
--- a/modules/background/Background.qml
+++ b/modules/background/Background.qml
@@ -8,48 +8,52 @@ import Quickshell
 import Quickshell.Wayland
 import QtQuick
 
-Loader {
-    asynchronous: true
-    active: Config.background.enabled
+Variants {
+    model: Quickshell.screens
 
-    sourceComponent: Variants {
-        model: Quickshell.screens
+    StyledWindow {
+        id: win
+        required property ShellScreen modelData
 
-        StyledWindow {
-            id: win
+        screen: modelData
+        name: "background"
+        WlrLayershell.exclusionMode: ExclusionMode.Ignore
+        WlrLayershell.layer: WlrLayer.Background
+        color: "black"
 
-            required property ShellScreen modelData
+        anchors.top: true
+        anchors.bottom: true
+        anchors.left: true
+        anchors.right: true
 
-            screen: modelData
-            name: "background"
-            WlrLayershell.exclusionMode: ExclusionMode.Ignore
-            WlrLayershell.layer: WlrLayer.Background
-            color: "black"
+        Loader {
+            active: Config.background.enabled
+            asynchronous: true
 
-            anchors.top: true
-            anchors.bottom: true
-            anchors.left: true
-            anchors.right: true
+            anchors.fill: parent
 
-            Wallpaper {
-                id: wallpaper
-            }
-
-            Visualiser {
+            sourceComponent: Item {
                 anchors.fill: parent
-                screen: win.modelData
-                wallpaper: wallpaper
-            }
 
-            Loader {
-                anchors.right: parent.right
-                anchors.bottom: parent.bottom
-                anchors.margins: Appearance.padding.large
+                Wallpaper {
+                    id: wallpaper
+                }
 
-                active: Config.background.desktopClock.enabled
-                asynchronous: true
+                Visualiser {
+                    anchors.fill: parent
+                    screen: win.modelData
+                    wallpaper: wallpaper
+                }
 
-                source: "DesktopClock.qml"
+                Loader {
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                    anchors.margins: Appearance.padding.large
+
+                    active: Config.background.desktopClock.enabled
+                    asynchronous: true
+                    source: "DesktopClock.qml"
+                }
             }
         }
     }


### PR DESCRIPTION
Fix a black screen issue caused by creating the background layer-shell window asynchronously.

Layer-shell surfaces must be instantiated synchronously to ensure the correct layer is applied on the initial Wayland commit. The window content (wallpaper and visual elements) continues to load asynchronously, preserving startup performance. 

This issue appears to be triggered by recent Qt Declarative updates,where internal changes to the QML engine affect the timing of asynchronous component instantiation.Although no application-level API changes are involved,behavioral differences in QML loading and binding evaluation can cause layer-shell windows created asynchronously to miss the initial Wayland commit.

fixes https://github.com/caelestia-dots/shell/issues/1074