### PR TITLE
utilities: fix fullscreen record

### DIFF
--- a/services/Recorder.qml
+++ b/services/Recorder.qml
@@ -15,7 +15,7 @@ Singleton {
     property bool needsStop
     property bool needsPause
 
-    function start(extraArgs: list<string>): void {
+    function start(extraArgs = []): void {
         needsStart = true;
         startArgs = extraArgs;
         checkProc.running = true;


### PR DESCRIPTION
## Fixes the issue for the fullscreen record bug in utilities

> This resolves the issue of #927. 

In `services/Recorder.qml` change the parameter for  `start()` function to this:

```
    function start(extraArgs = []): void {
```

This ensures that  recording fullscreen (which passes an empty argument) works since it assumes that if there is no argument passed, `extraArgs` will be empty which is what is required by the `Process` that handles the recording. 