### PR TITLE
launcher: add Settings action to open controlCenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,14 @@ default, you must create it manually.
                 "command": ["systemctl", "suspend-then-hibernate"],
                 "enabled": true,
                 "dangerous": false
+            },
+            {
+                "name": "Settings",
+                "icon": "settings",
+                "description": "Configure the shell",
+                "command": ["caelestia", "shell", "controlCenter", "open"],
+                "enabled": true,
+                "dangerous": false
             }
         ],
         "dragThreshold": 50,

--- a/config/LauncherConfig.qml
+++ b/config/LauncherConfig.qml
@@ -133,6 +133,14 @@ JsonObject {
             command: ["systemctl", "suspend-then-hibernate"],
             enabled: true,
             dangerous: false
+        },
+        {
+            name: "Settings",
+            icon: "settings",
+            description: "Configure the shell",
+            command: ["caelestia", "shell", "controlCenter", "open"],
+            enabled: true,
+            dangerous: false
         }
     ]
 }


### PR DESCRIPTION
## Added Settings action to Launcher

> This PR addresses #1081 reqeuest for settings in launcher

1. Edited the README.md example configuration to include the Settings launcher
2. Included the Settings action in the LauncherConfig.qml

<img width="667" height="165" alt="image" src="https://github.com/user-attachments/assets/35359f29-a969-4a54-b6c8-f40c0e8439bb" />
