### PR TITLE
Simulate variable expansion so $HOME works

### DIFF
--- a/utils/Paths.qml
+++ b/utils/Paths.qml
@@ -28,7 +28,7 @@ Singleton {
     }
 
     function absolutePath(path: string): string {
-        return toLocalFile(path.replace("~", home));
+        return toLocalFile(path.replace(/~|(\$({?)HOME(}?))+/, home));
     }
 
     function shortenHome(path: string): string {


### PR DESCRIPTION
Supporting `~` is great, but I tried both `${HOME}` and `$HOME` before getting to that one... let's support all three.