### PR TITLE
feat: Allow bar and dash clocks to display seconds

### DIFF
--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -116,6 +116,7 @@ JsonObject {
         property bool background: false
         property bool showDate: false
         property bool showIcon: true
+        property bool showSeconds: false
     }
 
     component Sizes: JsonObject {

--- a/config/Config.qml
+++ b/config/Config.qml
@@ -204,7 +204,8 @@ Singleton {
             clock: {
                 background: bar.clock.background,
                 showDate: bar.clock.showDate,
-                showIcon: bar.clock.showIcon
+                showIcon: bar.clock.showIcon,
+                showSeconds: bar.clock.showSeconds
             },
             entries: bar.entries,
             excludedScreens: bar.excludedScreens
@@ -225,6 +226,7 @@ Singleton {
             mediaUpdateInterval: dashboard.mediaUpdateInterval,
             resourceUpdateInterval: dashboard.resourceUpdateInterval,
             dragThreshold: dashboard.dragThreshold,
+            showClockSeconds: dashboard.showClockSeconds,
             performance: {
                 showBattery: dashboard.performance.showBattery,
                 showGpu: dashboard.performance.showGpu,

--- a/config/DashboardConfig.qml
+++ b/config/DashboardConfig.qml
@@ -10,6 +10,7 @@ JsonObject {
     property bool showMedia: true
     property bool showPerformance: true
     property bool showWeather: true
+    property bool showClockSeconds: false
     property Sizes sizes: Sizes {}
     property Performance performance: Performance {}
 

--- a/modules/bar/components/Clock.qml
+++ b/modules/bar/components/Clock.qml
@@ -65,7 +65,7 @@ StyledRect {
 
             horizontalAlignment: StyledText.AlignHCenter
             text: {
-                if(Config.bar.clock.showSeconds)
+                if (Config.bar.clock.showSeconds)
                     return Time.format(Config.services.useTwelveHourClock ? "hh\nmm\nss\A" : "hh\nmm\nss");
 
                 return Time.format(Config.services.useTwelveHourClock ? "hh\nmm\nA" : "hh\nmm");

--- a/modules/bar/components/Clock.qml
+++ b/modules/bar/components/Clock.qml
@@ -59,10 +59,17 @@ StyledRect {
         }
 
         StyledText {
+            id: time
+
             anchors.horizontalCenter: parent.horizontalCenter
 
             horizontalAlignment: StyledText.AlignHCenter
-            text: Time.format(Config.services.useTwelveHourClock ? "hh\nmm\nA" : "hh\nmm")
+            text: {
+                if(Config.bar.clock.showSeconds)
+                    return Time.format(Config.services.useTwelveHourClock ? "hh\nmm\nss\A" : "hh\nmm\nss");
+
+                return Time.format(Config.services.useTwelveHourClock ? "hh\nmm\nA" : "hh\nmm");
+            }
             font.pointSize: Appearance.font.size.smaller
             font.family: Appearance.font.family.mono
             color: root.colour

--- a/modules/dashboard/dash/DateTime.qml
+++ b/modules/dashboard/dash/DateTime.qml
@@ -43,7 +43,7 @@ Item {
 
         StyledText {
             Layout.topMargin: -(font.pointSize * 0.4)
-            Layout.bottomMargin: Config.dashboard.showClockSeconds ? -(font.pointSize * 0.4) : unset
+            Layout.bottomMargin: Config.dashboard.showClockSeconds ? -(font.pointSize * 0.4) : 0
             Layout.alignment: Qt.AlignHCenter
             text: Time.minuteStr
             color: Colours.palette.m3secondary

--- a/modules/dashboard/dash/DateTime.qml
+++ b/modules/dashboard/dash/DateTime.qml
@@ -9,6 +9,10 @@ import qs.config
 Item {
     id: root
 
+    readonly property string timeFormat12: Config.dashboard.showClockSeconds ? "hh:mm:ss:A" : "hh:mm:A"
+    readonly property string timeFormat24: Config.dashboard.showClockSeconds ? "hh:mm:ss" : "hh:mm"
+    readonly property list<string> timeComponents: Time.format(Config.services.useTwelveHourClock ? timeFormat12 : timeFormat24).split(":")
+
     anchors.top: parent.top
     anchors.bottom: parent.bottom
     implicitWidth: Config.dashboard.sizes.dateTimeWidth
@@ -51,11 +55,42 @@ Item {
             asynchronous: true
             Layout.alignment: Qt.AlignHCenter
 
+            active: Config.dashboard.showClockSeconds
+            visible: active
+
+            sourceComponent: StyledText {
+                Layout.alignment: Qt.AlignHCenter
+                text: "•••"
+                color: Colours.palette.m3primary
+                font.pointSize: Appearance.font.size.extraLarge * 0.9
+                font.family: Appearance.font.family.clock
+            }
+        }
+
+        Loader {
+            Layout.alignment: Qt.AlignHCenter
+
+            active: Config.dashboard.showClockSeconds
+            visible: active
+
+            sourceComponent: StyledText {
+                Layout.alignment: Qt.AlignHCenter
+                text: root.timeComponents[2]
+                color: Colours.palette.m3secondary
+                font.pointSize: Appearance.font.size.extraLarge
+                font.family: Appearance.font.family.clock
+                font.weight: 600
+            }
+        }
+
+        Loader {
+            Layout.alignment: Qt.AlignHCenter
+
             active: Config.services.useTwelveHourClock
             visible: active
 
             sourceComponent: StyledText {
-                text: Time.amPmStr
+                text: Config.dashboard.showClockSeconds ? root.timeComponents[3] : root.timeComponents[2] ?? ""
                 color: Colours.palette.m3primary
                 font.pointSize: Appearance.font.size.large
                 font.family: Appearance.font.family.clock

--- a/modules/dashboard/dash/DateTime.qml
+++ b/modules/dashboard/dash/DateTime.qml
@@ -69,6 +69,7 @@ Item {
 
         Loader {
             Layout.alignment: Qt.AlignHCenter
+            Layout.topMargin: -(Appearance.font.size.extraLarge * 0.4)
 
             active: Config.dashboard.showClockSeconds
             visible: active

--- a/modules/dashboard/dash/DateTime.qml
+++ b/modules/dashboard/dash/DateTime.qml
@@ -43,6 +43,7 @@ Item {
 
         StyledText {
             Layout.topMargin: -(font.pointSize * 0.4)
+            Layout.bottomMargin: Config.dashboard.showClockSeconds ? -(font.pointSize * 0.4) : unset
             Layout.alignment: Qt.AlignHCenter
             text: Time.minuteStr
             color: Colours.palette.m3secondary
@@ -59,7 +60,6 @@ Item {
             visible: active
 
             sourceComponent: StyledText {
-                Layout.alignment: Qt.AlignHCenter
                 text: "•••"
                 color: Colours.palette.m3primary
                 font.pointSize: Appearance.font.size.extraLarge * 0.9
@@ -74,7 +74,6 @@ Item {
             visible: active
 
             sourceComponent: StyledText {
-                Layout.alignment: Qt.AlignHCenter
                 text: root.timeComponents[2]
                 color: Colours.palette.m3secondary
                 font.pointSize: Appearance.font.size.extraLarge


### PR DESCRIPTION
Fixes #990

I intentionally chose to make the bar and dash clocks separate settings. The only issue at the moment is in the padding/margins for the dash. The padding on the seconds is larger than the padding on the minutes, and I can't figure out why.

<img width="122" height="320" alt="image" src="https://github.com/user-attachments/assets/8f0eb432-1229-4f23-b4f8-b9340dc094e9" />
