### PR TITLE
nix: fix module org.kde.kirigami not installed

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -27,13 +27,14 @@
   xkeyboard-config,
   cmake,
   ninja,
+  kdePackages,
   pkg-config,
   caelestia-cli,
   debug ? false,
   withCli ? false,
   extraRuntimeDeps ? [],
 }: let
-  version = "1.0.0";
+  version = "1.4.1";
 
   runtimeDeps =
     [
@@ -111,7 +112,7 @@ in
     src = ./..;
 
     nativeBuildInputs = [cmake ninja makeWrapper qt6.wrapQtAppsHook];
-    buildInputs = [quickshell extras plugin xkeyboard-config qt6.qtbase];
+    buildInputs = [quickshell extras plugin xkeyboard-config qt6.qtbase kdePackages.kirigami];
     propagatedBuildInputs = runtimeDeps;
 
     cmakeFlags =
@@ -133,6 +134,7 @@ in
     postInstall = ''
       makeWrapper ${quickshell}/bin/qs $out/bin/caelestia-shell \
       	--prefix PATH : "${lib.makeBinPath runtimeDeps}" \
+        --prefix QML_IMPORT_PATH : "${kdePackages.kirigami}/lib"\
       	--set FONTCONFIG_FILE "${fontconfig}" \
       	--set CAELESTIA_LIB_DIR ${extras}/lib \
         --set CAELESTIA_XKB_RULES_PATH ${xkeyboard-config}/share/xkeyboard-config-2/rules/base.lst \


### PR DESCRIPTION
Fix for Caelestia shell on NixOS with error "module 'org.kde.kirigami' is not installed". Edited the nix/default.nix file to use QML_IMPORT_PATH of kdePackages.kirigami to resolve the issue. 

I tried using the INSTALL_QMLDIR in caelestia-shell.extras but could not get it to work therefore appended it caelestia-shell main package.
 
<img width="924" height="379" alt="image" src="https://github.com/user-attachments/assets/de8200f2-1654-4379-a400-ed6a1bfa0384" />
