### PR TITLE
Add support for disabling wifi icon when ethernet is active

### DIFF
--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -96,6 +96,7 @@ JsonObject {
         property bool showMicrophone: false
         property bool showKbLayout: false
         property bool showNetwork: true
+        property bool showWifi: true
         property bool showBluetooth: true
         property bool showBattery: true
         property bool showLockStatus: true

--- a/config/Config.qml
+++ b/config/Config.qml
@@ -201,6 +201,7 @@ Singleton {
                 showMicrophone: bar.status.showMicrophone,
                 showKbLayout: bar.status.showKbLayout,
                 showNetwork: bar.status.showNetwork,
+                showWifi: bar.status.showWifi,
                 showBluetooth: bar.status.showBluetooth,
                 showBattery: bar.status.showBattery,
                 showLockStatus: bar.status.showLockStatus

--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -143,7 +143,7 @@ StyledRect {
         // Network icon
         WrappedLoader {
             name: "network"
-            active: Config.bar.status.showNetwork
+            active: Config.bar.status.showNetwork && (! Nmcli.activeEthernet || Config.bar.status.showWifi)
 
             sourceComponent: MaterialIcon {
                 animate: true

--- a/modules/controlcenter/taskbar/TaskbarPane.qml
+++ b/modules/controlcenter/taskbar/TaskbarPane.qml
@@ -27,6 +27,7 @@ Item {
     property bool showMicrophone: Config.bar.status.showMicrophone ?? true
     property bool showKbLayout: Config.bar.status.showKbLayout ?? false
     property bool showNetwork: Config.bar.status.showNetwork ?? true
+    property bool showWifi: Config.bar.status.showWifi ?? true
     property bool showBluetooth: Config.bar.status.showBluetooth ?? true
     property bool showBattery: Config.bar.status.showBattery ?? true
     property bool showLockStatus: Config.bar.status.showLockStatus ?? true
@@ -69,6 +70,7 @@ Item {
         Config.bar.status.showMicrophone = root.showMicrophone;
         Config.bar.status.showKbLayout = root.showKbLayout;
         Config.bar.status.showNetwork = root.showNetwork;
+        Config.bar.status.showWifi = root.showWifi;
         Config.bar.status.showBluetooth = root.showBluetooth;
         Config.bar.status.showBattery = root.showBattery;
         Config.bar.status.showLockStatus = root.showLockStatus;
@@ -176,7 +178,7 @@ Item {
 
                     ConnectedButtonGroup {
                         rootItem: root
-                        
+
                         options: [
                             {
                                 label: qsTr("Speakers"),
@@ -207,6 +209,14 @@ Item {
                                 propertyName: "showNetwork",
                                 onToggled: function(checked) {
                                     root.showNetwork = checked;
+                                    root.saveConfig();
+                                }
+                            },
+                            {
+                                label: qsTr("Wifi"),
+                                propertyName: "showWifi",
+                                onToggled: function(checked) {
+                                    root.showWifi = checked;
                                     root.saveConfig();
                                 }
                             },
@@ -437,7 +447,7 @@ Item {
 
                             ConnectedButtonGroup {
                                 rootItem: root
-                                
+
                                 options: [
                                     {
                                         label: qsTr("Workspaces"),
@@ -525,7 +535,7 @@ Item {
 
                                 SliderInput {
                                     Layout.fillWidth: true
-                                    
+
                                     label: qsTr("Drag threshold")
                                     value: root.dragThreshold
                                     from: 0
@@ -534,7 +544,7 @@ Item {
                                     validator: IntValidator { bottom: 0; top: 100 }
                                     formatValueFunction: (val) => Math.round(val).toString()
                                     parseValueFunction: (text) => parseInt(text)
-                                    
+
                                     onValueModified: (newValue) => {
                                         root.dragThreshold = Math.round(newValue);
                                         root.saveConfig();
@@ -598,7 +608,7 @@ Item {
 
                             ConnectedButtonGroup {
                                 rootItem: root
-                                
+
                                 options: [
                                     {
                                         label: qsTr("Background"),


### PR DESCRIPTION
This changes the status icon behavior for the wifi icon such that if ethernet is active it is hidden unless the (default) option `showWifi` is set to `false`.