### PR TITLE
Docs update for the new showWifi config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ default, you must create it manually.
             "showKbLayout": false,
             "showMicrophone": false,
             "showNetwork": true,
+            "showWifi": true,
             "showLockStatus": true
         },
         "tray": {
@@ -681,7 +682,7 @@ The module automatically adds Caelestia shell to the path with **full functional
 
 ### Need help or support?
 
-You can join the community Discord server for assistance and discussion:  
+You can join the community Discord server for assistance and discussion:
 https://discord.gg/BGDCFCmMBk
 
 ### My screen is flickering, help pls!


### PR DESCRIPTION
I expected at least one change request on the `showWifi` option, so didn't include this in the initial PR. Given it's in git but not stable, that might not have been a bad thing... but here's a docs update to add that option to the example config in the readme.