### PR TITLE
controlcenter: add 150% max volume toggle

### DIFF
--- a/components/controls/FilledSlider.qml
+++ b/components/controls/FilledSlider.qml
@@ -15,37 +15,19 @@ Slider {
     orientation: Qt.Vertical
 
     background: StyledRect {
-        color: Colours.layer(Colours.palette.m3surfaceContainer, 2)
+        color: root.value >= 1.01 ? Colours.palette.m3tertiary : Colours.layer(Colours.palette.m3surfaceContainer, 2)
         radius: Appearance.rounding.full
 
-        // Normal range filled (0-100%)
+        // Filled section (active)
         StyledRect {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.bottom: parent.bottom
 
-            implicitHeight: Math.min(parent.height - root.handle.y, parent.height * (1.0 / root.to))
+            implicitHeight: parent.height - root.handle.y
 
             color: Colours.palette.m3secondary
             radius: parent.radius
-            topLeftRadius: root.value > 1.0 ? 0 : parent.radius
-            topRightRadius: root.value > 1.0 ? 0 : parent.radius
-        }
-
-        // Boost range filled (100-150%) - different color
-        StyledRect {
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.bottom: parent.bottom
-            anchors.bottomMargin: parent.height * (1.0 / root.to)
-
-            visible: root.value > 1.01 && implicitHeight > 1
-            implicitHeight: Math.max(0, parent.height - root.handle.y - parent.height * (1.0 / root.to))
-
-            color: Colours.palette.m3tertiary
-            radius: parent.radius
-            bottomLeftRadius: 0
-            bottomRightRadius: 0
         }
     }
 

--- a/components/controls/FilledSlider.qml
+++ b/components/controls/FilledSlider.qml
@@ -18,15 +18,34 @@ Slider {
         color: Colours.layer(Colours.palette.m3surfaceContainer, 2)
         radius: Appearance.rounding.full
 
+        // Normal range filled (0-100%)
         StyledRect {
             anchors.left: parent.left
             anchors.right: parent.right
+            anchors.bottom: parent.bottom
 
-            y: root.handle.y
-            implicitHeight: parent.height - y
+            implicitHeight: Math.min(parent.height - root.handle.y, parent.height * (1.0 / root.to))
 
             color: Colours.palette.m3secondary
             radius: parent.radius
+            topLeftRadius: root.value > 1.0 ? 0 : parent.radius
+            topRightRadius: root.value > 1.0 ? 0 : parent.radius
+        }
+
+        // Boost range filled (100-150%) - different color
+        StyledRect {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: parent.height * (1.0 / root.to)
+
+            visible: root.value > 1.01 && implicitHeight > 1
+            implicitHeight: Math.max(0, parent.height - root.handle.y - parent.height * (1.0 / root.to))
+
+            color: Colours.palette.m3tertiary
+            radius: parent.radius
+            bottomLeftRadius: 0
+            bottomRightRadius: 0
         }
     }
 

--- a/config/ServiceConfig.qml
+++ b/config/ServiceConfig.qml
@@ -9,7 +9,7 @@ JsonObject {
     property int visualiserBars: 45
     property real audioIncrement: 0.1
     property real brightnessIncrement: 0.1
-    property real maxVolume: 1.0
+    property real maxVolume: 1.5
     property bool smartScheme: true
     property string defaultPlayer: "Spotify"
     property list<var> playerAliases: [

--- a/modules/bar/popouts/Audio.qml
+++ b/modules/bar/popouts/Audio.qml
@@ -96,11 +96,27 @@ Item {
                 anchors.right: parent.right
                 implicitHeight: parent.implicitHeight
 
+                from: 0
+                to: Config.services.maxVolume
                 value: Audio.volume
                 onMoved: Audio.setVolume(value)
 
+                Connections {
+                    target: Config.services
+                    function onMaxVolumeChanged() {
+                        to = Config.services.maxVolume;
+                    }
+                }
+
                 Behavior on value {
                     Anim {}
+                }
+
+                Behavior on to {
+                    Anim {
+                        duration: Appearance.anim.durations.normal
+                        easing.bezierCurve: Appearance.anim.curves.standard
+                    }
                 }
             }
         }

--- a/modules/bar/popouts/Audio.qml
+++ b/modules/bar/popouts/Audio.qml
@@ -10,6 +10,7 @@ import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
 import "../../controlcenter/network"
+import "../../controlcenter/audio"
 
 Item {
     id: root
@@ -91,7 +92,7 @@ Item {
                     Audio.decrementVolume();
             }
 
-            StyledSlider {
+            VolumeSlider {
                 anchors.left: parent.left
                 anchors.right: parent.right
                 implicitHeight: parent.implicitHeight
@@ -106,10 +107,6 @@ Item {
                     function onMaxVolumeChanged() {
                         to = Config.services.maxVolume;
                     }
-                }
-
-                Behavior on value {
-                    Anim {}
                 }
 
                 Behavior on to {

--- a/modules/controlcenter/audio/AudioPane.qml
+++ b/modules/controlcenter/audio/AudioPane.qml
@@ -251,39 +251,6 @@ Item {
                             Item {
                                 Layout.fillWidth: true
                             }
-
-                            ToggleButton {
-                                toggled: Config.services.maxVolume >= 1.5
-                                icon: "volume_up"
-                                accent: "Tertiary"
-                                iconSize: Appearance.font.size.normal
-                                horizontalPadding: Appearance.padding.normal
-                                verticalPadding: Appearance.padding.smaller
-                                tooltip: qsTr("Enable 150% max volume")
-
-                                onClicked: {
-                                    if (toggled) {
-                                        // Toggling off: clamp volumes to 1.0 if they exceed it
-                                        if (Audio.volume > 1.0) {
-                                            Audio.setVolume(1.0);
-                                        }
-                                        if (Audio.sourceVolume > 1.0) {
-                                            Audio.setSourceVolume(1.0);
-                                        }
-                                        // Clamp stream volumes
-                                        for (let i = 0; i < Audio.streams.length; i++) {
-                                            const stream = Audio.streams[i];
-                                            if (stream?.audio && stream.audio.volume > 1.0) {
-                                                Audio.setStreamVolume(stream, 1.0);
-                                            }
-                                        }
-                                        Config.services.maxVolume = 1.0;
-                                    } else {
-                                        // Toggling on: set max volume to 1.5
-                                        Config.services.maxVolume = 1.5;
-                                    }
-                                }
-                            }
                         }
 
                         StyledText {
@@ -402,7 +369,7 @@ Item {
                                     }
                                 }
 
-                                StyledSlider {
+                                VolumeSlider {
                                     id: outputVolumeSlider
                                     Layout.fillWidth: true
                                     implicitHeight: Appearance.padding.normal * 3
@@ -551,7 +518,7 @@ Item {
                                     }
                                 }
 
-                                StyledSlider {
+                                VolumeSlider {
                                     id: inputVolumeSlider
                                     Layout.fillWidth: true
                                     implicitHeight: Appearance.padding.normal * 3
@@ -714,7 +681,7 @@ Item {
                                             }
                                         }
 
-                                        StyledSlider {
+                                        VolumeSlider {
                                             Layout.fillWidth: true
                                             implicitHeight: Appearance.padding.normal * 3
 

--- a/modules/controlcenter/audio/VolumeSlider.qml
+++ b/modules/controlcenter/audio/VolumeSlider.qml
@@ -10,11 +10,10 @@ Slider {
     wheelEnabled: true
 
     background: Item {
-        readonly property real normalRangeEnd: root.availableWidth * (1.0 / root.to)
         readonly property real trackMargin: root.implicitHeight / 3
         readonly property real handleOffset: root.implicitHeight / 6
         
-        // Normal range filled (0-100%)
+        // Filled section (active)
         StyledRect {
             anchors.top: parent.top
             anchors.bottom: parent.bottom
@@ -22,33 +21,15 @@ Slider {
             anchors.topMargin: parent.trackMargin
             anchors.bottomMargin: parent.trackMargin
 
-            implicitWidth: Math.min(root.handle.x - parent.handleOffset, parent.normalRangeEnd)
+            implicitWidth: root.handle.x - parent.handleOffset
 
             color: Colours.palette.m3primary
             radius: Appearance.rounding.full
-            topRightRadius: root.value > 1.0 ? 0 : Appearance.rounding.full
-            bottomRightRadius: root.value > 1.0 ? 0 : Appearance.rounding.full
+            topRightRadius: root.implicitHeight / 15
+            bottomRightRadius: root.implicitHeight / 15
         }
 
-        // Boost range filled (100-150%) - different color
-        StyledRect {
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            anchors.left: parent.left
-            anchors.leftMargin: parent.normalRangeEnd
-            anchors.topMargin: parent.trackMargin
-            anchors.bottomMargin: parent.trackMargin
-
-            visible: root.value > 1.0
-            implicitWidth: root.handle.x - parent.handleOffset - parent.normalRangeEnd
-
-            color: Colours.palette.m3tertiary
-            radius: Appearance.rounding.full
-            topLeftRadius: 0
-            bottomLeftRadius: 0
-        }
-
-        // Unfilled track
+        // Unfilled track (rail) - changes color when above 100%
         StyledRect {
             anchors.top: parent.top
             anchors.bottom: parent.bottom
@@ -58,7 +39,7 @@ Slider {
 
             implicitWidth: parent.width - root.handle.x - root.handle.implicitWidth - parent.handleOffset
 
-            color: Colours.palette.m3surfaceContainerHighest
+            color: root.value >= 1.01 ? Colours.palette.m3tertiary : Colours.palette.m3surfaceContainerHighest
             radius: Appearance.rounding.full
             topLeftRadius: root.implicitHeight / 15
             bottomLeftRadius: root.implicitHeight / 15
@@ -71,7 +52,7 @@ Slider {
         implicitWidth: root.implicitHeight / 4.5
         implicitHeight: root.implicitHeight
 
-        color: root.value > 1.0 ? Colours.palette.m3tertiary : Colours.palette.m3primary
+        color: Colours.palette.m3primary
         radius: Appearance.rounding.full
 
         MouseArea {

--- a/modules/controlcenter/audio/VolumeSlider.qml
+++ b/modules/controlcenter/audio/VolumeSlider.qml
@@ -1,0 +1,89 @@
+import qs.components
+import qs.services
+import qs.config
+import QtQuick
+import QtQuick.Templates
+
+Slider {
+    id: root
+
+    wheelEnabled: true
+
+    background: Item {
+        readonly property real normalRangeEnd: root.availableWidth * (1.0 / root.to)
+        readonly property real trackMargin: root.implicitHeight / 3
+        readonly property real handleOffset: root.implicitHeight / 6
+        
+        // Normal range filled (0-100%)
+        StyledRect {
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            anchors.topMargin: parent.trackMargin
+            anchors.bottomMargin: parent.trackMargin
+
+            implicitWidth: Math.min(root.handle.x - parent.handleOffset, parent.normalRangeEnd)
+
+            color: Colours.palette.m3primary
+            radius: Appearance.rounding.full
+            topRightRadius: root.value > 1.0 ? 0 : Appearance.rounding.full
+            bottomRightRadius: root.value > 1.0 ? 0 : Appearance.rounding.full
+        }
+
+        // Boost range filled (100-150%) - different color
+        StyledRect {
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            anchors.leftMargin: parent.normalRangeEnd
+            anchors.topMargin: parent.trackMargin
+            anchors.bottomMargin: parent.trackMargin
+
+            visible: root.value > 1.0
+            implicitWidth: root.handle.x - parent.handleOffset - parent.normalRangeEnd
+
+            color: Colours.palette.m3tertiary
+            radius: Appearance.rounding.full
+            topLeftRadius: 0
+            bottomLeftRadius: 0
+        }
+
+        // Unfilled track
+        StyledRect {
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            anchors.right: parent.right
+            anchors.topMargin: parent.trackMargin
+            anchors.bottomMargin: parent.trackMargin
+
+            implicitWidth: parent.width - root.handle.x - root.handle.implicitWidth - parent.handleOffset
+
+            color: Colours.palette.m3surfaceContainerHighest
+            radius: Appearance.rounding.full
+            topLeftRadius: root.implicitHeight / 15
+            bottomLeftRadius: root.implicitHeight / 15
+        }
+    }
+
+    handle: StyledRect {
+        x: root.visualPosition * root.availableWidth - implicitWidth / 2
+
+        implicitWidth: root.implicitHeight / 4.5
+        implicitHeight: root.implicitHeight
+
+        color: root.value > 1.0 ? Colours.palette.m3tertiary : Colours.palette.m3primary
+        radius: Appearance.rounding.full
+
+        MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.NoButton
+            cursorShape: Qt.PointingHandCursor
+        }
+    }
+
+    Behavior on value {
+        Anim {
+            duration: Appearance.anim.durations.large
+        }
+    }
+}

--- a/modules/osd/Content.qml
+++ b/modules/osd/Content.qml
@@ -48,6 +48,13 @@ Item {
                 value: root.volume
                 to: Config.services.maxVolume
                 onMoved: Audio.setVolume(value)
+
+                Connections {
+                    target: Config.services
+                    function onMaxVolumeChanged() {
+                        to = Config.services.maxVolume;
+                    }
+                }
             }
         }
 
@@ -73,6 +80,13 @@ Item {
                     value: root.sourceVolume
                     to: Config.services.maxVolume
                     onMoved: Audio.setSourceVolume(value)
+
+                    Connections {
+                        target: Config.services
+                        function onMaxVolumeChanged() {
+                            to = Config.services.maxVolume;
+                        }
+                    }
                 }
             }
         }

--- a/utils/Icons.qml
+++ b/utils/Icons.qml
@@ -172,7 +172,8 @@ Singleton {
     function getVolumeIcon(volume: real, isMuted: bool): string {
         if (isMuted)
             return "no_sound";
-        if (volume >= 0.5)
+        const halfMax = Config.services.maxVolume * 0.5;
+        if (volume >= halfMax)
             return "volume_up";
         if (volume > 0)
             return "volume_down";


### PR DESCRIPTION
While reviewing open issues and PRs, I came across a request for this feature:

- https://github.com/caelestia-dots/shell/issues/720  
- https://github.com/caelestia-dots/shell/pull/723  

This PR implements a **max volume toggle** in the control center.

<img width="1356" height="771" alt="swappy-20260121_143726" src="https://github.com/user-attachments/assets/6fbfe603-99f7-4dfe-b8d0-a76894ac1568" />