### PR TITLE
Fix: desktop clock settings persistence in control center

### DIFF
--- a/config/Config.qml
+++ b/config/Config.qml
@@ -149,7 +149,20 @@ Singleton {
         return {
             enabled: background.enabled,
             desktopClock: {
-                enabled: background.desktopClock.enabled
+                enabled: background.desktopClock.enabled,
+                scale: background.desktopClock.scale,
+                position: background.desktopClock.position,
+                invertColors: background.desktopClock.invertColors,
+                background: {
+                    enabled: background.desktopClock.background.enabled,
+                    opacity: background.desktopClock.background.opacity,
+                    blur: background.desktopClock.background.blur
+                },
+                shadow: {
+                    enabled: background.desktopClock.shadow.enabled,
+                    opacity: background.desktopClock.shadow.opacity,
+                    blur: background.desktopClock.shadow.blur
+                }
             },
             visualiser: {
                 enabled: background.visualiser.enabled,


### PR DESCRIPTION
Desktop clock settings in the control center (e.g., background enabled toggle) did not persist after reload. Settings were saved in AppearancePane.qml but not serialized in Config.qml, so they reverted to defaults on reload.

Updated serializeBackground() in config/Config.qml to include all desktop clock properties when saving the config.