### PR TITLE
desktopClock: background blur GameMode support

### DIFF
--- a/modules/background/DesktopClock.qml
+++ b/modules/background/DesktopClock.qml
@@ -16,7 +16,7 @@ Item {
 
     property real scale: Config.background.desktopClock.scale
     readonly property bool bgEnabled: Config.background.desktopClock.background.enabled
-    readonly property bool blurEnabled: bgEnabled && Config.background.desktopClock.background.blur
+    readonly property bool blurEnabled: bgEnabled && Config.background.desktopClock.background.blur && !GameMode.enabled
     readonly property bool invertColors: Config.background.desktopClock.invertColors
     readonly property bool useLightSet: Colours.light ? !invertColors : invertColors
     readonly property color safePrimary: useLightSet ? Colours.palette.m3primaryContainer : Colours.palette.m3primary


### PR DESCRIPTION
Changed the property `blurEnabled` to check when `GameMode.enabled`

fixes #1143 