### PR TITLE
appearance: Allow adjusting the speed of gifs

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ default, you must create it manually.
 ```json
 {
     "appearance": {
+        "mediaGifSpeedAdjustment": 300,
+        "sessionGifSpeed": 0.7,
         "anim": {
             "durations": {
                 "scale": 1

--- a/config/AppearanceConfig.qml
+++ b/config/AppearanceConfig.qml
@@ -80,6 +80,8 @@ JsonObject {
     }
 
     component Anim: JsonObject {
+        property real mediaGifSpeedAdjustment: 300
+        property real sessionGifSpeed: 0.7
         property AnimCurves curves: AnimCurves {}
         property AnimDurations durations: AnimDurations {}
     }

--- a/config/Config.qml
+++ b/config/Config.qml
@@ -122,6 +122,8 @@ Singleton {
                 }
             },
             anim: {
+                mediaGifSpeedAdjustment: 300,
+                sessionGifSpeed: 0.7,
                 durations: {
                     scale: appearance.anim.durations.scale
                 }

--- a/modules/dashboard/Media.qml
+++ b/modules/dashboard/Media.qml
@@ -380,7 +380,7 @@ Item {
             height: visualiser.height * 0.75
 
             playing: Players.active?.isPlaying ?? false
-            speed: Audio.beatTracker.bpm / 300
+            speed: Audio.beatTracker.bpm / Appearance.anim.mediaGifSpeedAdjustment
             source: Paths.absolutePath(Config.paths.mediaGif)
             asynchronous: true
             fillMode: AnimatedImage.PreserveAspectFit

--- a/modules/dashboard/dash/Media.qml
+++ b/modules/dashboard/dash/Media.qml
@@ -213,7 +213,7 @@ Item {
         anchors.margins: Appearance.padding.large * 2
 
         playing: Players.active?.isPlaying ?? false
-        speed: Audio.beatTracker.bpm / 300
+        speed: Audio.beatTracker.bpm / Appearance.anim.mediaGifSpeedAdjustment
         source: Paths.absolutePath(Config.paths.mediaGif)
         asynchronous: true
         fillMode: AnimatedImage.PreserveAspectFit

--- a/modules/session/Content.qml
+++ b/modules/session/Content.qml
@@ -53,7 +53,7 @@ Column {
 
         playing: visible
         asynchronous: true
-        speed: 0.7
+        speed: Appearance.anim.sessionGifSpeed
         source: Paths.absolutePath(Config.paths.sessionGif)
     }
 


### PR DESCRIPTION
This fixes #1140 by adding config options for both session and dash gif speed animation/adjustment.