### PR TITLE
fix: serialize excludedScreens config

### DIFF
--- a/config/Config.qml
+++ b/config/Config.qml
@@ -241,7 +241,8 @@ Singleton {
                 batteryWidth: bar.sizes.batteryWidth,
                 networkWidth: bar.sizes.networkWidth
             },
-            entries: bar.entries
+            entries: bar.entries,
+            excludedScreens: bar.excludedScreens
         };
     }
 


### PR DESCRIPTION
## excludedScreens Serialize
This fixes an issue where the entry of `excludedScreens` config under `bar` gets removed after a save using the Control Center.
 