### PR TITLE
Fix bluetooth battery bar

### DIFF
--- a/modules/controlcenter/bluetooth/Details.qml
+++ b/modules/controlcenter/bluetooth/Details.qml
@@ -358,17 +358,11 @@ StyledFlickable {
                                 }
 
                                 RowLayout {
+                                    id: batteryPercent
                                     Layout.topMargin: Appearance.spacing.small / 2
                                     Layout.fillWidth: true
                                     Layout.preferredHeight: Appearance.padding.smaller
                                     spacing: Appearance.spacing.small / 2
-
-                                    StyledRect {
-                                        Layout.fillHeight: true
-                                        implicitWidth: root.device?.batteryAvailable ? parent.width * root.device.battery : 0
-                                        radius: Appearance.rounding.full
-                                        color: Colours.palette.m3primary
-                                    }
 
                                     StyledRect {
                                         Layout.fillWidth: true
@@ -377,12 +371,12 @@ StyledFlickable {
                                         color: Colours.palette.m3secondaryContainer
 
                                         StyledRect {
-                                            anchors.right: parent.right
+                                            anchors.left: parent.left
                                             anchors.top: parent.top
                                             anchors.bottom: parent.bottom
                                             anchors.margins: parent.height * 0.25
 
-                                            implicitWidth: height
+                                            implicitWidth: root.device?.batteryAvailable ? batteryPercent.width * root.device.battery : 0
                                             radius: Appearance.rounding.full
                                             color: Colours.palette.m3primary
                                         }


### PR DESCRIPTION
Fixes #864 as well as an issue reported on Discord recently.

This issue is due to the bar and its parent having widths which depend upon each other. As a result, the bar width continually updates resulting in the bar extending off-screen indefinitely.

<img width="744" height="393" alt="image" src="https://github.com/user-attachments/assets/200132fc-fa50-4c18-b30d-8c47f841be33" />
