### PR TITLE
launcher: add folder selection cycle and debounce

### DIFF
--- a/config/Config.qml
+++ b/config/Config.qml
@@ -293,6 +293,8 @@ Singleton {
             actionPrefix: launcher.actionPrefix,
             enableDangerousActions: launcher.enableDangerousActions,
             dragThreshold: launcher.dragThreshold,
+            folderWrapAround: launcher.folderWrapAround,
+            folderSelection: launcher.folderSelection,
             vimKeybinds: launcher.vimKeybinds,
             hiddenApps: launcher.hiddenApps,
             useFuzzy: {

--- a/config/LauncherConfig.qml
+++ b/config/LauncherConfig.qml
@@ -9,6 +9,8 @@ JsonObject {
     property string actionPrefix: ">"
     property bool enableDangerousActions: false // Allow actions that can cause losing data, like shutdown, reboot and logout
     property int dragThreshold: 50
+    property bool folderWrapAround: true
+    property bool folderSelection: true
     property bool vimKeybinds: false
     property list<string> hiddenApps: []
     property UseFuzzy useFuzzy: UseFuzzy {}

--- a/modules/launcher/Content.qml
+++ b/modules/launcher/Content.qml
@@ -101,8 +101,34 @@ Item {
                 }
             }
 
-            Keys.onUpPressed: list.currentList?.decrementCurrentIndex()
-            Keys.onDownPressed: list.currentList?.incrementCurrentIndex()
+            Keys.onUpPressed: event => {
+                if (event.modifiers & Qt.ShiftModifier && list.showWallpapers) {
+                    if (!Config.launcher.folderSelection) return;
+                    
+                    if (Config.launcher.folderWrapAround) {
+                        const len = Wallpapers.folders.length;
+                        Wallpapers.currentFolderIndex = (Wallpapers.currentFolderIndex - 1 + len) % len;
+                    } else {
+                        Wallpapers.currentFolderIndex = Math.max(0, Wallpapers.currentFolderIndex - 1);
+                    }
+                } else {
+                    list.currentList?.decrementCurrentIndex();
+                }
+            }
+            Keys.onDownPressed: event => {
+                if (event.modifiers & Qt.ShiftModifier && list.showWallpapers) {
+                    if (!Config.launcher.folderSelection) return;
+
+                    if (Config.launcher.folderWrapAround) {
+                        const len = Wallpapers.folders.length;
+                        Wallpapers.currentFolderIndex = (Wallpapers.currentFolderIndex + 1) % len;
+                    } else {
+                        Wallpapers.currentFolderIndex = Math.min(Wallpapers.folders.length - 1, Wallpapers.currentFolderIndex + 1);
+                    }
+                } else {
+                    list.currentList?.incrementCurrentIndex();
+                }
+            }
 
             Keys.onEscapePressed: root.visibilities.launcher = false
 

--- a/modules/launcher/ContentList.qml
+++ b/modules/launcher/ContentList.qml
@@ -47,9 +47,10 @@ Item {
             name: "wallpapers"
 
             PropertyChanges {
-                root.implicitWidth: Math.max(Config.launcher.sizes.itemWidth * 1.2, wallpaperList.implicitWidth)
-                root.implicitHeight: Config.launcher.sizes.wallpaperHeight
+                root.implicitWidth: Math.max(Config.launcher.sizes.itemWidth * 1.2, wallpaperList.implicitWidth, folderBar.implicitWidth)
+                root.implicitHeight: Config.launcher.sizes.wallpaperHeight + (folderBar.active ? folderBar.implicitHeight + Appearance.spacing.normal : 0)
                 wallpaperList.active: true
+                folderBar.active: Config.launcher.folderSelection
             }
         }
     ]
@@ -88,11 +89,24 @@ Item {
     }
 
     Loader {
-        id: wallpaperList
+        id: folderBar
 
         active: false
 
         anchors.top: parent.top
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        sourceComponent: FolderBar {
+        }
+    }
+
+    Loader {
+        id: wallpaperList
+
+        active: false
+
+        anchors.top: folderBar.bottom
+        anchors.topMargin: Appearance.spacing.normal
         anchors.bottom: parent.bottom
         anchors.horizontalCenter: parent.horizontalCenter
 

--- a/modules/launcher/FolderBar.qml
+++ b/modules/launcher/FolderBar.qml
@@ -1,0 +1,140 @@
+import "items"
+import qs.components
+import qs.services
+import qs.config
+import Quickshell
+import QtQuick
+
+Item {
+    id: root
+
+    readonly property int itemWidth: 100
+    readonly property int visibleItems: Math.min(7, Math.max(1, Wallpapers.folders.length))
+
+    implicitWidth: visibleItems * itemWidth
+    implicitHeight: 36
+
+    // Extract valid folders to ensure consistent indices
+    readonly property var folders: Wallpapers.folders
+    readonly property int currentIndex: Wallpapers.currentFolderIndex
+
+    Component {
+        id: delegateComponent
+        
+        Item {
+            id: delegateRoot
+            
+            required property int index
+            required property string modelData
+            
+            width: root.itemWidth
+            height: root.height
+            
+            readonly property bool isCurrent: index === root.currentIndex
+            
+            // PathView specific properties
+            readonly property bool onPath: PathView.onPath ?? true
+            readonly property bool isPathCurrent: PathView.isCurrentItem ?? isCurrent
+            
+            scale: isPathCurrent ? 1.0 : 0.85
+            opacity: onPath ? (isPathCurrent ? 1.0 : 0.6) : 0
+
+            StyledRect {
+                anchors.fill: parent
+                anchors.margins: 4
+
+                color: delegateRoot.isPathCurrent 
+                    ? Colours.palette.m3primaryContainer 
+                    : Colours.palette.m3surfaceContainerHigh
+                radius: Appearance.rounding.full
+
+                Behavior on color {
+                    ColorAnimation {
+                        duration: Appearance.anim.durations.normal
+                    }
+                }
+            }
+
+            StyledText {
+                anchors.centerIn: parent
+
+                text: delegateRoot.modelData
+                color: delegateRoot.isPathCurrent 
+                    ? Colours.palette.m3onPrimaryContainer 
+                    : Colours.palette.m3onSurfaceVariant
+                font.pointSize: Appearance.font.size.small
+                font.weight: delegateRoot.isPathCurrent ? 600 : 400
+            }
+
+            Behavior on scale {
+                Anim {
+                    duration: Appearance.anim.durations.normal
+                }
+            }
+
+            Behavior on opacity {
+                Anim {
+                    duration: Appearance.anim.durations.normal
+                }
+            }
+            
+            MouseArea {
+                anchors.fill: parent
+                onClicked: Wallpapers.currentFolderIndex = index
+            }
+        }
+    }
+
+    Loader {
+        anchors.fill: parent
+        sourceComponent: Config.launcher.folderWrapAround ? pathViewComp : listViewComp
+    }
+
+    Component {
+        id: listViewComp
+
+        ListView {
+            model: root.folders
+            currentIndex: root.currentIndex
+            
+            orientation: ListView.Horizontal
+            
+            highlightMoveDuration: Appearance.anim.durations.normal
+            highlightMoveVelocity: -1
+            
+            preferredHighlightBegin: (width - itemWidth) / 2
+            preferredHighlightEnd: (width + itemWidth) / 2
+            highlightRangeMode: ListView.StrictlyEnforceRange
+
+            delegate: delegateComponent
+        }
+    }
+
+    Component {
+        id: pathViewComp
+        
+        PathView {
+            model: root.folders
+            currentIndex: root.currentIndex
+            
+            pathItemCount: root.visibleItems + 2 // Extra items for smooth entry/exit
+            
+            preferredHighlightBegin: 0.5
+            preferredHighlightEnd: 0.5
+            highlightRangeMode: PathView.StrictlyEnforceRange
+            snapMode: PathView.SnapToItem
+            
+            delegate: delegateComponent
+            
+            path: Path {
+                startX: -root.itemWidth / 2
+                startY: root.height / 2
+                
+                PathLine {
+                    x: root.width + root.itemWidth / 2
+                    y: root.height / 2
+                }
+            }
+        }
+    }
+}

--- a/modules/launcher/WallpaperList.qml
+++ b/modules/launcher/WallpaperList.qml
@@ -48,8 +48,9 @@ PathView {
         id: scriptModel
 
         readonly property string search: root.search.text.split(" ").slice(1).join(" ")
+        readonly property string folder: Wallpapers.debouncedCurrentFolder
 
-        values: Wallpapers.query(search)
+        values: Wallpapers.queryWithFolder(search, folder)
         onValuesChanged: root.currentIndex = search ? 0 : values.findIndex(w => w.path === Wallpapers.actualCurrent)
     }
 


### PR DESCRIPTION
I added a filter to the wallpaper picker to separate images by folder. By selecting folders, we can choose wallpapers from the images within them more easily. 

**Usage:** Open the wallpaper picker; you could already navigate between images with the up and down keys. Now, if you press **Shift + Up/Down** arrow keys, the folder changes (there is also an "All" option where all images are visible) and the images in that folder are shown. It features infinite scrolling, just like the wallpapers.

**Configuration:**
- `folderWrapAround` and `folderSelection` settings have been added to `shell.json`. 
- `folderWrapAround` enables cycling through folders in an infinite loop.
- `folderSelection` toggles the folder selection feature on or off. If disabled, it returns to the classic wallpaper selection format.

Also added a debounce mechanism to prevent UI lag and stuttering when rapidly scrolling/cycling through folders.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/78a1b198-975d-4fec-bc72-8ef0b8f044af" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e73e97ba-0d30-4f22-8a25-710cffa14e87" />
