### PR TITLE
shortcuts: Sidebar and Utilities shortcuts

### DIFF
--- a/modules/Shortcuts.qml
+++ b/modules/Shortcuts.qml
@@ -81,6 +81,17 @@ Scope {
         }
     }
 
+    CustomShortcut {
+        name: "utilities"
+        description: "Toggle utilities"
+        onPressed: {
+            if (root.hasFullscreen)
+                return;
+            const visibilities = Visibilities.getForActive();
+            visibilities.utilities = !visibilities.utilities;
+        }
+    }
+
     IpcHandler {
         target: "drawers"
 


### PR DESCRIPTION
## Added sidebar and utilities shortcuts
> Added sidebar and utilities CustomShortcut in `Shortcuts.qml`. 

I just think this belongs here as well — **Launcher, Dashboard, and Session** already have shortcuts, and leaving Sidebar and Utilities out was honestly giving me a bit of an OCD / completeness itch. It feels nicer if every drawer is listed in one place.

Example binding: 
 ```
 bind = Super, K, global, caelestia:sidebar
 bind = Super,  J, global, caelestia:utilities
 ```