### PR TITLE
config: added option to set session icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,12 @@ default, you must create it manually.
         "dragThreshold": 30,
         "enabled": true,
         "vimKeybinds": false,
+        "icons": {
+            "logout": "logout",
+            "shutdown": "power_settings_new",
+            "hibernate": "downloading",
+            "reboot": "cached"
+        },
         "commands": {
             "logout": ["loginctl", "terminate-user", ""],
             "shutdown": ["systemctl", "poweroff"],

--- a/config/Config.qml
+++ b/config/Config.qml
@@ -349,6 +349,12 @@ Singleton {
             enabled: session.enabled,
             dragThreshold: session.dragThreshold,
             vimKeybinds: session.vimKeybinds,
+            icons: {
+                logout: session.icons.logout,
+                shutdown: session.icons.shutdown,
+                hibernate: session.icons.hibernate,
+                reboot: session.icons.reboot
+            },
             commands: {
                 logout: session.commands.logout,
                 shutdown: session.commands.shutdown,

--- a/config/SessionConfig.qml
+++ b/config/SessionConfig.qml
@@ -4,9 +4,17 @@ JsonObject {
     property bool enabled: true
     property int dragThreshold: 30
     property bool vimKeybinds: false
+    property Icons icons: Icons {}
     property Commands commands: Commands {}
 
     property Sizes sizes: Sizes {}
+
+    component Icons: JsonObject {
+        property string logout: "logout"
+        property string shutdown: "power_settings_new"
+        property string hibernate: "downloading"
+        property string reboot: "cached"
+    }
 
     component Commands: JsonObject {
         property list<string> logout: ["loginctl", "terminate-user", ""]

--- a/modules/session/Content.qml
+++ b/modules/session/Content.qml
@@ -18,7 +18,7 @@ Column {
     SessionButton {
         id: logout
 
-        icon: "logout"
+        icon: Config.session.icons.logout
         command: Config.session.commands.logout
 
         KeyNavigation.down: shutdown
@@ -38,7 +38,7 @@ Column {
     SessionButton {
         id: shutdown
 
-        icon: "power_settings_new"
+        icon: Config.session.icons.shutdown
         command: Config.session.commands.shutdown
 
         KeyNavigation.up: logout
@@ -60,7 +60,7 @@ Column {
     SessionButton {
         id: hibernate
 
-        icon: "downloading"
+        icon: Config.session.icons.hibernate
         command: Config.session.commands.hibernate
 
         KeyNavigation.up: shutdown
@@ -70,7 +70,7 @@ Column {
     SessionButton {
         id: reboot
 
-        icon: "cached"
+        icon: Config.session.icons.reboot
         command: Config.session.commands.reboot
 
         KeyNavigation.up: hibernate


### PR DESCRIPTION
# Overview
Added the ability to set icons for the session panel on the right side
# Configuration Example
> it can be set in `shell.json` under `"session"`:
```
"session": {
  "icons": {
    "logout": "logout",
    "shutdown": "power_settings_new",
    "hibernate": "downloading",
    "reboot": "cached"
  },
}
```
The value is just the name of a specific glyph from [Google's Material Icons](https://fonts.google.com/icons?icon.style=Rounded). Glyph names are what's displayed there, all lower cased, with underscores replacing spaces.