### PR TITLE
icons: add touchpad notification icon fallback

### DIFF
--- a/utils/Icons.qml
+++ b/utils/Icons.qml
@@ -150,6 +150,10 @@ Singleton {
             return "power";
         if (summary.includes("screenshot"))
             return "screenshot_monitor";
+        if (summary.includes("touchpad") && summary.includes("disabled"))
+            return "touchpad_mouse_off";
+        if (summary.includes("touchpad"))
+            return "touchpad_mouse";
         if (summary.includes("welcome"))
             return "waving_hand";
         if (summary.includes("time") || summary.includes("a break"))


### PR DESCRIPTION
Adds touchpad icon fallback to `getNotifIcon` in `Icons.qml`.

Notifications with "touchpad" in the summary now show `touchpad_mouse` instead of the default `chat` icon. If the summary also contains "disabled", it shows `touchpad_mouse_off` instead.

This is useful for touchpad toggle scripts that use `notify-send` to indicate the current state (e.g. "Touchpad Enabled" / "Touchpad Disabled").