### PR TITLE
audio: default output sink cycle

### DIFF
--- a/services/Audio.qml
+++ b/services/Audio.qml
@@ -174,10 +174,10 @@ Singleton {
     }
 
     IpcHandler {
-        target: "audio"
-
         function cycleOutput(): void {
             root.cycleNextAudioOutput();
         }
+
+        target: "audio"
     }
 }


### PR DESCRIPTION
Tiny addition of a quick way to switch which sink is the default.
`caelestia shell audio cycleOutput` to just switch to the next in the list of outputs
