### PR TITLE
Config: add option to hide Notifications on lockscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,7 +566,8 @@ default, you must create it manually.
         "hiddenApps": []
     },
     "lock": {
-        "recolourLogo": false
+        "recolourLogo": false,
+        "hideNotifs": false
     },
     "notifs": {
         "actionOnClick": false,

--- a/config/Config.qml
+++ b/config/Config.qml
@@ -391,6 +391,7 @@ Singleton {
             recolourLogo: lock.recolourLogo,
             enableFprint: lock.enableFprint,
             maxFprintTries: lock.maxFprintTries,
+            hideNotifs: lock.hideNotifs,
             sizes: {
                 heightMult: lock.sizes.heightMult,
                 ratio: lock.sizes.ratio,

--- a/config/LockConfig.qml
+++ b/config/LockConfig.qml
@@ -4,6 +4,7 @@ JsonObject {
     property bool recolourLogo: false
     property bool enableFprint: true
     property int maxFprintTries: 3
+    property bool hideNotifs: false
     property Sizes sizes: Sizes {}
 
     component Sizes: JsonObject {

--- a/modules/lock/NotifDock.qml
+++ b/modules/lock/NotifDock.qml
@@ -41,7 +41,7 @@ ColumnLayout {
         Loader {
             anchors.centerIn: parent
             active: opacity > 0
-            opacity: Notifs.list.length > 0 ? 0 : 1
+            opacity: Notifs.list.length > 0 && !Config.lock.hideNotifs ? 0 : 1
 
             sourceComponent: ColumnLayout {
                 spacing: Appearance.spacing.large
@@ -61,7 +61,7 @@ ColumnLayout {
 
                 StyledText {
                     Layout.alignment: Qt.AlignHCenter
-                    text: qsTr("No Notifications")
+                    text: Config.lock.hideNotifs ? qsTr("Unlock for Notifications") : qsTr("No Notifications")
                     color: Colours.palette.m3outlineVariant
                     font.pointSize: Appearance.font.size.large
                     font.family: Appearance.font.family.mono
@@ -78,7 +78,7 @@ ColumnLayout {
 
         StyledListView {
             anchors.fill: parent
-
+            visible: !Config.lock.hideNotifs
             spacing: Appearance.spacing.small
             clip: true
 


### PR DESCRIPTION
# Configuration Example
> It can be toggled in `shell.json` under `"lock"`
```
"lock": {
    "hideNotifs": true
  }
```

# Preview
<img width="1920" height="1080" alt="20260223185927" src="https://github.com/user-attachments/assets/64075541-9a23-4c13-8953-ff3f82a51690" />
