### PR TITLE
media: hide person icon if user pfp is ready

### DIFF
--- a/modules/dashboard/dash/User.qml
+++ b/modules/dashboard/dash/User.qml
@@ -32,6 +32,7 @@ Row {
             fill: 1
             grade: 200
             font.pointSize: Math.floor(info.implicitHeight / 2) || 1
+            visible: pfp.status !== Image.Ready
         }
 
         CachingImage {

--- a/modules/lock/Center.qml
+++ b/modules/lock/Center.qml
@@ -97,6 +97,7 @@ ColumnLayout {
             text: "person"
             color: Colours.palette.m3onSurfaceVariant
             font.pointSize: Math.floor(root.centerWidth / 4)
+            visible: pfp.status !== Image.Ready
         }
 
         CachingImage {


### PR DESCRIPTION
In the dashboard and the lock, this sets the visibility of the "person" icon to false if the user's pfp is ready.
This allows using a picture with a transparent background (without seeing the icon behind the pic).