### PR TITLE
bar: allow setting custom workspace app icons in shell.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,12 @@ default, you must create it manually.
                     "name": "steam",
                     "icon": "sports_esports"
                 }
+            ],
+            "windowIcons": [
+                {
+                    "regex": "steam(_app_(default|[0-9]+))?",
+                    "icon": "sports_esports"
+                }
             ]
         },
         "excludedScreens": [""],

--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -78,6 +78,7 @@ JsonObject {
         property string activeLabel: "󰮯"
         property string capitalisation: "preserve" // upper, lower, or preserve - relevant only if label is empty
         property list<var> specialWorkspaceIcons: []
+        property list<var> workspaceIcons: []
     }
 
     component ActiveWindow: JsonObject {

--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -78,7 +78,12 @@ JsonObject {
         property string activeLabel: "󰮯"
         property string capitalisation: "preserve" // upper, lower, or preserve - relevant only if label is empty
         property list<var> specialWorkspaceIcons: []
-        property list<var> windowIcons: []
+        property list<var> windowIcons: [
+            {
+                regex: "steam(_app_(default|[0-9]+))?",
+                icon: "sports_esports"
+            }
+        ]
     }
 
     component ActiveWindow: JsonObject {

--- a/config/BarConfig.qml
+++ b/config/BarConfig.qml
@@ -78,7 +78,7 @@ JsonObject {
         property string activeLabel: "󰮯"
         property string capitalisation: "preserve" // upper, lower, or preserve - relevant only if label is empty
         property list<var> specialWorkspaceIcons: []
-        property list<var> workspaceIcons: []
+        property list<var> windowIcons: []
     }
 
     component ActiveWindow: JsonObject {

--- a/config/Config.qml
+++ b/config/Config.qml
@@ -214,7 +214,8 @@ Singleton {
                 occupiedLabel: bar.workspaces.occupiedLabel,
                 activeLabel: bar.workspaces.activeLabel,
                 capitalisation: bar.workspaces.capitalisation,
-                specialWorkspaceIcons: bar.workspaces.specialWorkspaceIcons
+                specialWorkspaceIcons: bar.workspaces.specialWorkspaceIcons,
+                workspaceIcons: bar.workspaces.workspaceIcons
             },
             tray: {
                 background: bar.tray.background,

--- a/config/Config.qml
+++ b/config/Config.qml
@@ -215,7 +215,7 @@ Singleton {
                 activeLabel: bar.workspaces.activeLabel,
                 capitalisation: bar.workspaces.capitalisation,
                 specialWorkspaceIcons: bar.workspaces.specialWorkspaceIcons,
-                workspaceIcons: bar.workspaces.workspaceIcons
+                windowIcons: bar.workspaces.windowIcons
             },
             tray: {
                 background: bar.tray.background,

--- a/utils/Icons.qml
+++ b/utils/Icons.qml
@@ -87,6 +87,15 @@ Singleton {
     }
 
     function getAppCategoryIcon(name: string, fallback: string): string {
+
+        // Use regex matching to look for user defined icons.
+        for (const iconConfig of Config.bar.workspaces.workspaceIcons) {
+            const re = new RegExp(iconConfig.name, "i");
+            if (re.test(name)) {
+                return iconConfig.icon;
+            }
+        }
+
         const categories = DesktopEntries.heuristicLookup(name)?.categories;
 
         if (categories)

--- a/utils/Icons.qml
+++ b/utils/Icons.qml
@@ -79,6 +79,26 @@ Singleton {
             Office: "content_paste"
         })
 
+    // Checks if a name matches an icon config. Icon configs can have the following keys:
+    // - name: The exact name of the icon
+    // - regex: A regex to match against the name (takes priority over name)
+    // - flags: The regex flags (only used if regex is set)
+    // - icon: The icon to use
+    function matchIconConfig(name: string, iconConfig: var): bool {
+        if (!iconConfig.icon)
+            return false;
+
+        if (iconConfig.regex) {
+            const re = new RegExp(iconConfig.regex, iconConfig.flags ?? "");
+            if (re.test(name))
+                return true;
+        } else if (iconConfig.name === name) {
+            return true;
+        }
+
+        return false;
+    }
+
     function getAppIcon(name: string, fallback: string): string {
         const icon = DesktopEntries.heuristicLookup(name)?.icon;
         if (fallback !== "undefined")
@@ -87,14 +107,9 @@ Singleton {
     }
 
     function getAppCategoryIcon(name: string, fallback: string): string {
-
-        // Use regex matching to look for user defined icons.
-        for (const iconConfig of Config.bar.workspaces.workspaceIcons) {
-            const re = new RegExp(iconConfig.name, "i");
-            if (re.test(name)) {
+        for (const iconConfig of Config.bar.workspaces.windowIcons)
+            if (matchIconConfig(name, iconConfig))
                 return iconConfig.icon;
-            }
-        }
 
         const categories = DesktopEntries.heuristicLookup(name)?.categories;
 
@@ -197,11 +212,9 @@ Singleton {
     function getSpecialWsIcon(name: string): string {
         name = name.toLowerCase().slice("special:".length);
 
-        for (const iconConfig of Config.bar.workspaces.specialWorkspaceIcons) {
-            if (iconConfig.name === name) {
+        for (const iconConfig of Config.bar.workspaces.specialWorkspaceIcons)
+            if (matchIconConfig(name, iconConfig))
                 return iconConfig.icon;
-            }
-        }
 
         if (name === "special")
             return "star";


### PR DESCRIPTION
This PR allows users to define the material icon used for any app by editing `shell.json`.
The `shell.json` syntax should be the same as `bar.workspaces.specialWorkspaceIcons`'s; for example:
```json
{
  ...
  "bar": {
    ...
    "workspaces": {
      ...
      "workspaceIcons": [
        {
          "name": "firefox",
          "icon": "captive_portal"
        },
        {
          "name": "steam_app(.*)",
          "icon": "sports_esports"
        },
        {
          "name": "steam",
          "icon": "sports_esports"
        }
      ]
    },
    ...
  }
}
```

However, the name is matched via regular expression instead of string equality (this allows matching any steam game for instance).