### PR TITLE
gamemode: disable mouse acceleration

### DIFF
--- a/services/GameMode.qml
+++ b/services/GameMode.qml
@@ -21,7 +21,8 @@ Singleton {
             "general:gaps_out": 0,
             "general:border_size": 1,
             "decoration:rounding": 0,
-            "general:allow_tearing": 1
+            "general:allow_tearing": 1,
+            "input:accel_profile": "flat"
         });
     }
 
@@ -29,7 +30,7 @@ Singleton {
         if (enabled) {
             setDynamicConfs();
             if (Config.utilities.toasts.gameModeChanged)
-                Toaster.toast(qsTr("Game mode enabled"), qsTr("Disabled Hyprland animations, blur, gaps and shadows"), "gamepad");
+                Toaster.toast(qsTr("Game mode enabled"), qsTr("Disabled Hyprland animations, blur, gaps, shadows and mouse acceleration"), "gamepad");
         } else {
             Hypr.extras.message("reload");
             if (Config.utilities.toasts.gameModeChanged)


### PR DESCRIPTION
This PR adds a new configuration to the Game Mode service that disables mouse acceleration when enabled.

Changes:
Adds "input:accel_profile": "flat" to the Hyprland options applied during Game Mode.
Updates the toast notification to inform the user that mouse acceleration has been disabled alongside the other visual optimizations.
Reasoning: in most games mouse acceleration makes the mouse tracking inconsistent making it harder to aim in FPS games as well as track in other games that require it.