### PR TITLE
fix: unify wifi toggle state with Nmcli service to prevent desync

### DIFF
--- a/modules/utilities/cards/Toggles.qml
+++ b/modules/utilities/cards/Toggles.qml
@@ -38,8 +38,8 @@ StyledRect {
 
             Toggle {
                 icon: "wifi"
-                checked: Network.wifiEnabled
-                onClicked: Network.toggleWifi()
+                checked: Nmcli.wifiEnabled
+                onClicked: Nmcli.toggleWifi()
             }
 
             Toggle {


### PR DESCRIPTION
## Problem

The WiFi quick toggle in Control Center uses `Network.wifiEnabled`, while the bar popout uses `Nmcli.wifiEnabled`.

This causes state desynchronization.

### Video

https://github.com/user-attachments/assets/151004d2-e372-4219-81a0-e1bb89fc990a

## Solution

Updated the Control Center WiFi toggle to rely on `Nmcli` instead of `Network`, aligning it with the bar popout implementation.

By using `Nmcli` as the single source of truth, both UI components now reflect the same reactive state.