### PR TITLE
fix(lock): set live: false on ScreencopyView to prevent DPMS crash

### DIFF
--- a/modules/lock/LockSurface.qml
+++ b/modules/lock/LockSurface.qml
@@ -163,7 +163,10 @@ WlSessionLockSurface {
         id: background
 
         anchors.fill: parent
-        captureSource: root.screen
+	captureSource: root.screen
+	
+	live:false
+
         opacity: 0
 
         layer.enabled: true


### PR DESCRIPTION
ScreencopyView was holding a live reference to the Wayland output. When DPMS turned the monitor off, the output got suspended while the capture was still active, causing Quickshell to crash and showing the 'Oopsie Daisy' screen with the session still locked.

Setting live: false makes ScreencopyView capture a single snapshot at lock time instead of a continuous feed, which is also the correct behavior for a lock screen background.

## Testing
Reproduced and tested locally by:
1. Locking the screen with Super+L
2. Forcing DPMS off with `hyprctl dispatch dpms off`
3. Waking the monitor back up

Before fix: "Oopsie Daisy" crash screen appeared.
After fix: Lock screen remains intact with blur working correctly.

Fixes #1231