### PR TITLE
Picker: Large screenshot should now work

### DIFF
--- a/modules/areapicker/Picker.qml
+++ b/modules/areapicker/Picker.qml
@@ -80,8 +80,8 @@ MouseArea {
             } else {
                 Quickshell.execDetached(["swappy", "-f", path]);
             }
+            closeAnim.start();
         });
-        closeAnim.start();
     }
 
     onClientsChanged: checkClientRects(mouseX, mouseY)


### PR DESCRIPTION
This has been an ongoing issue for a while (not sure which issues this solves I'll look for them after)
I'm not 100% sure it fully fixes the issue. Realistically speaking, the execDetached could be changed to exec or whatever function would do this by blocking the rest of stuff only to make sure the executables are "done", meaning a real wait before start the close animator and closing the LazyLoader. (I don't know enough about QML to be sure this would be the best way to do it.)

So far, it's worked just fine for my use, if someone has a much much higher resolution screen to test this, it would be great.