### PR TITLE
AudioProcessor:  use signals for cross-thread AudioCollector ref/unref to prevent use-after-free

### DIFF
--- a/plugin/src/Caelestia/Services/audioprovider.cpp
+++ b/plugin/src/Caelestia/Services/audioprovider.cpp
@@ -21,7 +21,7 @@ void AudioProcessor::init() {
 }
 
 void AudioProcessor::start() {
-    QMetaObject::invokeMethod(&AudioCollector::instance(), &AudioCollector::ref, Qt::QueuedConnection, this);
+    emit activated();
     if (m_timer) {
         m_timer->start();
     }
@@ -31,7 +31,7 @@ void AudioProcessor::stop() {
     if (m_timer) {
         m_timer->stop();
     }
-    QMetaObject::invokeMethod(&AudioCollector::instance(), &AudioCollector::unref, Qt::QueuedConnection, this);
+    emit deactivated();
 }
 
 AudioProvider::AudioProvider(QObject* parent)
@@ -58,6 +58,13 @@ void AudioProvider::init() {
     connect(m_thread, &QThread::started, m_processor, &AudioProcessor::init);
     connect(m_thread, &QThread::finished, m_processor, &AudioProcessor::deleteLater);
     connect(m_thread, &QThread::finished, m_thread, &QThread::deleteLater);
+
+    connect(m_processor, &AudioProcessor::activated, this, [this]() {
+        AudioCollector::instance().ref(this);
+    });
+    connect(m_processor, &AudioProcessor::deactivated, this, [this]() {
+        AudioCollector::instance().unref(this);
+    });
 
     m_thread->start();
 }

--- a/plugin/src/Caelestia/Services/audioprovider.hpp
+++ b/plugin/src/Caelestia/Services/audioprovider.hpp
@@ -19,6 +19,10 @@ public slots:
     void start();
     void stop();
 
+signals:
+    void activated();
+    void deactivated();
+
 protected:
     virtual void process() = 0;
 


### PR DESCRIPTION
## Recurring SIGSEGV crashes with Caelestia Shell 

> **⚠️ AI-Assisted contribution, so **please** read first**
>
> This fix was identified and drafted with the help of AI tooling. I am not familiar with this codebase, Quickshell, or C++ in general. Please treat this PR as a starting point or a reference — **you are absolutely welcome to close it** if the proposed fix doesn't align with the project's patterns, introduces unintended side effects, or simply doesn't make sense to you. My only goal is to share what I found in case it's useful.


### Background

I was experiencing recurring crashes while using Caelestia, accumulating GBs of crash logs over time. Lacking the knowledge to diagnose the issue directly, I used AI to analyze the crash logs alongside the shell repository. The analysis pointed to a `use-after-free` bug causing consistent `SIGSEGV` crashes in `QCoreApplicationPrivate::sendPostedEvents`.

### Root Cause (According to the AI)

`AudioProcessor::start()` and `stop()` ran on a worker thread and passed `this` as a raw pointer to `AudioCollector::ref/unref` on the main thread via `QMetaObject::invokeMethod(..., Qt::QueuedConnection, this)`. The pointer was captured as a plain value in the queued event — Qt does not track its lifetime. If `AudioProcessor` was destroyed (via `deleteLater` from `QThread::finished`) before the main thread processed the event, `Service::ref()` would call `QObject::connect(danglingPointer, ...)`, dereferencing a freed object.

**Logs:**

```
#0  QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*)
#1  QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>)
#2  QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>)
#3  QCoreApplication::exec()
#4  qs::launch::launch(qs::launch::LaunchArgs const&, char**, QCoreApplication*)
```

### Proposed Fix

Replaced the raw `QMetaObject::invokeMethod(..., QueuedConnection, this)` calls with `activated`/`deactivated` signal emissions from `AudioProcessor`. `AudioProvider` (main thread) connects these signals to `AudioCollector::ref/unref` in `init()`, using itself as the connection context.

**Reasoning**:
- Qt dispatches the signal as a `QueuedConnection` (cross-thread) to the main thread where `AudioProvider` lives
- If `AudioProvider` is destroyed before the queued slot executes, `QObject::~QObject` calls `removePostedEvents(this)`, discarding the pending event
- The `destroyed → unref` connection established by `Service::ref` handles cleanup as a final safety net

<br />

### Notes

Again, I'm not familiar with this codebase or C++, so please take this with a grain of salt. Feel free to use this PR, the analysis, or neither. Whatever is most helpful to you.