### PR TITLE
systemusage: Optimized storage aggregation and improved device filtering

### DIFF
--- a/services/SystemUsage.qml
+++ b/services/SystemUsage.qml
@@ -141,68 +141,77 @@ Singleton {
         // Get physical disks with aggregated usage from their partitions
         // -J triggers JSON output. -b triggers bytes.
         command: ["lsblk", "-J", "-b", "-o", "NAME,SIZE,TYPE,FSUSED,FSSIZE,MOUNTPOINT"]
-        
+
         stdout: StdioCollector {
             onStreamFinished: {
-              const data = JSON.parse(text);
-              const diskList = [];
-              const seenDevices = new Set();
+                const data = JSON.parse(text);
+                const diskList = [];
+                const seenDevices = new Set();
 
-              // Helper to recursively sum usage from children (partitions, crypt, lvm)
-              const aggregateUsage = (dev) => {
-                  let used = 0;
-                  let size = 0;
-                  let isRoot = dev.mountpoint === "/" || (dev.mountpoints && dev.mountpoints.includes("/"));
+                // Helper to recursively sum usage from children (partitions, crypt, lvm)
+                const aggregateUsage = dev => {
+                    let used = 0;
+                    let size = 0;
+                    let isRoot = dev.mountpoint === "/" || (dev.mountpoints && dev.mountpoints.includes("/"));
 
-                  if (!seenDevices.has(dev.name)) {
-                      // lsblk returns null for empty/unformatted partitions, which parses to 0 here
-                      used = parseInt(dev.fsused) || 0;
-                      size = parseInt(dev.fssize) || 0;
-                      seenDevices.add(dev.name);
-                  }
+                    if (!seenDevices.has(dev.name)) {
+                        // lsblk returns null for empty/unformatted partitions, which parses to 0 here
+                        used = parseInt(dev.fsused) || 0;
+                        size = parseInt(dev.fssize) || 0;
+                        seenDevices.add(dev.name);
+                    }
 
-                  if (dev.children) {
-                      for (const child of dev.children) {
-                          const stats = aggregateUsage(child);
-                          used += stats.used;
-                          size += stats.size;
-                          if (stats.isRoot) isRoot = true;
-                      }
-                  }
-                  return { used, size, isRoot };
-              };
+                    if (dev.children) {
+                        for (const child of dev.children) {
+                            const stats = aggregateUsage(child);
+                            used += stats.used;
+                            size += stats.size;
+                            if (stats.isRoot)
+                                isRoot = true;
+                        }
+                    }
+                    return {
+                        used,
+                        size,
+                        isRoot
+                    };
+                };
 
-              for (const dev of data.blockdevices) {
-                  // Only process physical disks at the top level
-                  if (dev.type === "disk" && !dev.name.startsWith("zram")) {
-                      const stats = aggregateUsage(dev);
+                for (const dev of data.blockdevices) {
+                    // Only process physical disks at the top level
+                    if (dev.type === "disk" && !dev.name.startsWith("zram")) {
+                        const stats = aggregateUsage(dev);
 
-                      if (stats.size === 0) {
-                          continue;
-                      }
-                      
-                      const total = stats.size;
-                      const used = stats.used;
-                      
-                      diskList.push({
-                          mount: dev.name,
-                          used: used / 1024,      // KiB
-                          total: total / 1024,    // KiB
-                          free: (total - used) / 1024,
-                          perc: total > 0 ? used / total : 0,
-                          hasRoot: stats.isRoot
-                      });
-                  }
-              }
+                        if (stats.size === 0) {
+                            continue;
+                        }
 
-              // Sort by putting the disk with root first, then sort the rest alphabetically
-              root.disks = diskList.sort((a, b) => {
-                  if (a.hasRoot && !b.hasRoot) return -1;
-                  if (!a.hasRoot && b.hasRoot) return 1;
-                  return a.mount.localeCompare(b.mount);
-              });
-          }
-      }
+                        const total = stats.size;
+                        const used = stats.used;
+
+                        diskList.push({
+                            mount: dev.name,
+                            used: used / 1024      // KiB
+                            ,
+                            total: total / 1024    // KiB
+                            ,
+                            free: (total - used) / 1024,
+                            perc: total > 0 ? used / total : 0,
+                            hasRoot: stats.isRoot
+                        });
+                    }
+                }
+
+                // Sort by putting the disk with root first, then sort the rest alphabetically
+                root.disks = diskList.sort((a, b) => {
+                    if (a.hasRoot && !b.hasRoot)
+                        return -1;
+                    if (!a.hasRoot && b.hasRoot)
+                        return 1;
+                    return a.mount.localeCompare(b.mount);
+                });
+            }
+        }
     }
 
     // GPU name detection (one-time)


### PR DESCRIPTION
+ The storage aggregation logic in SystemUsage.qml doesn't account for more complex storage setups and relied too much on risky string parsing to guess where partitions were. For example, in my case, I had a LUKS-encrypted drive which lives inside a "crypt," because the code couldn't match the accepted types (it only matched "disk" and "part"), it did not show the actual total storage of my encrypted drive at all. Also, Linux devices names aren't always predictable, like mapper devices or complex NVMe paths, if the Regex doesn't specifically match the name of those devices, they just get totally ignored.

+ I decided to go for a JSON approach to make the code shorter, safer and actually work.

+ Should solve: #1233 

+ Update: Added more "intuitive" sorting and filtering of storage device as described by: #1257 

+ There should be no side-effects as far as I know.