### PR TITLE
nix: Remove outadeted app2unit version pin.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,6 @@
           withX11 = false;
           withI3 = false;
         };
-        app2unit = pkgs.callPackage ./nix/app2unit.nix {inherit pkgs;};
         caelestia-cli = inputs.caelestia-cli.packages.${pkgs.stdenv.hostPlatform.system}.default;
       };
       with-cli = caelestia-shell.override {withCli = true;};

--- a/nix/app2unit.nix
+++ b/nix/app2unit.nix
@@ -1,6 +1,0 @@
-{
-  pkgs, # To ensure the nixpkgs version of app2unit
-  fetchFromGitHub,
-  ...
-}:
-pkgs.app2unit


### PR DESCRIPTION
The override Attrs in the nix/app2unit.nix file pinned app2unit to v1.0.3, but the pkgs derivation is at a later version (v1.3.0). This breaks the build, because the postFixup from nixpkgs tries to substitute A"U__TERMINAL_HANDLER=xdg-terminal-exec, does not exist on v1.03, and breaks the build.

Since nixpks already ships v1.3.0, the override is needed no longer.
TESTED: nix build + shell launch/kill + app2unit -T all work.

I believe this is related to issue #1260 , so, some feedback would be appreciated!