### PR TITLE
feat: Google Calendar integration via gws CLI

### DIFF
--- a/config/Config.qml
+++ b/config/Config.qml
@@ -225,6 +225,7 @@ Singleton {
             mediaUpdateInterval: dashboard.mediaUpdateInterval,
             resourceUpdateInterval: dashboard.resourceUpdateInterval,
             dragThreshold: dashboard.dragThreshold,
+            showUpcoming: dashboard.showUpcoming,
             performance: {
                 showBattery: dashboard.performance.showBattery,
                 showGpu: dashboard.performance.showGpu,
@@ -366,6 +367,7 @@ Singleton {
     function serializeSidebar(): var {
         return {
             enabled: sidebar.enabled,
+            showUpcoming: sidebar.showUpcoming,
             dragThreshold: sidebar.dragThreshold
         };
     }
@@ -390,7 +392,8 @@ Singleton {
                 enabled: services.calendar.enabled,
                 command: services.calendar.command,
                 agendaDays: services.calendar.agendaDays,
-                upcomingHours: services.calendar.upcomingHours,
+                dashUpcomingHours: services.calendar.dashUpcomingHours,
+                sidebarUpcomingHours: services.calendar.sidebarUpcomingHours,
                 reminderMinutes: services.calendar.reminderMinutes,
                 refreshInterval: services.calendar.refreshInterval
             }

--- a/config/Config.qml
+++ b/config/Config.qml
@@ -385,7 +385,15 @@ Singleton {
             defaultPlayer: services.defaultPlayer,
             playerAliases: services.playerAliases,
             showLyrics: services.showLyrics,
-            lyricsBackend: services.lyricsBackend
+            lyricsBackend: services.lyricsBackend,
+            calendar: {
+                enabled: services.calendar.enabled,
+                command: services.calendar.command,
+                agendaDays: services.calendar.agendaDays,
+                upcomingHours: services.calendar.upcomingHours,
+                reminderMinutes: services.calendar.reminderMinutes,
+                refreshInterval: services.calendar.refreshInterval
+            }
         };
     }
 

--- a/config/DashboardConfig.qml
+++ b/config/DashboardConfig.qml
@@ -10,6 +10,7 @@ JsonObject {
     property bool showMedia: true
     property bool showPerformance: true
     property bool showWeather: true
+    property bool showUpcoming: false
     property Sizes sizes: Sizes {}
     property Performance performance: Performance {}
 

--- a/config/ServiceConfig.qml
+++ b/config/ServiceConfig.qml
@@ -27,7 +27,8 @@ JsonObject {
         property bool enabled: false // Requires gws CLI in PATH
         property string command: "gws" // Path or name of the gws CLI binary
         property int agendaDays: 30 // How many days ahead to fetch events
-        property int upcomingHours: 24 // Hours ahead to show in upcoming list
+        property int dashUpcomingHours: 24 // Hours ahead to show in dashboard upcoming list
+        property int sidebarUpcomingHours: 120 // Hours ahead to show in sidebar upcoming list
         property int reminderMinutes: 10 // Minutes before event to send notification, 0 to disable
         property int refreshInterval: 900 // Refresh interval in seconds
     }

--- a/config/ServiceConfig.qml
+++ b/config/ServiceConfig.qml
@@ -21,4 +21,14 @@ JsonObject {
     ]
     property bool showLyrics: false
     property string lyricsBackend: "Auto"
+    property GCalendarConfig calendar: GCalendarConfig {}
+
+    component GCalendarConfig: JsonObject {
+        property bool enabled: false // Requires gws CLI in PATH
+        property string command: "gws" // Path or name of the gws CLI binary
+        property int agendaDays: 30 // How many days ahead to fetch events
+        property int upcomingHours: 24 // Hours ahead to show in upcoming list
+        property int reminderMinutes: 10 // Minutes before event to send notification, 0 to disable
+        property int refreshInterval: 900 // Refresh interval in seconds
+    }
 }

--- a/config/SidebarConfig.qml
+++ b/config/SidebarConfig.qml
@@ -2,6 +2,7 @@ import Quickshell.Io
 
 JsonObject {
     property bool enabled: true
+    property bool showUpcoming: true
     property int dragThreshold: 80
     property Sizes sizes: Sizes {}
 

--- a/modules/dashboard/Dash.qml
+++ b/modules/dashboard/Dash.qml
@@ -126,10 +126,10 @@ GridLayout {
                 font.weight: 600
             }
 
-            Repeater {
+            Repeater { // qmllint disable missing-property
                 model: GCalendar.upcomingDash
 
-                RowLayout {
+                RowLayout { // qmllint disable missing-property
                     id: eventRow
 
                     required property var modelData
@@ -138,7 +138,7 @@ GridLayout {
                     spacing: Appearance.spacing.small
 
                     Rectangle {
-                        width: 3
+                        Layout.preferredWidth: 3
                         Layout.fillHeight: true
                         radius: 1.5
                         color: Colours.palette.m3tertiary
@@ -154,7 +154,7 @@ GridLayout {
                             color: Colours.palette.m3onSurface
                             font.pointSize: Appearance.font.size.small
                             font.weight: 500
-                            elide: Text.ElideRight
+                            elide: Text.ElideRight // qmllint disable unqualified
                         }
 
                         StyledText {
@@ -167,7 +167,7 @@ GridLayout {
                             }
                             color: Colours.palette.m3onSurfaceVariant
                             font.pointSize: Appearance.font.size.small * 0.9
-                            elide: Text.ElideRight
+                            elide: Text.ElideRight // qmllint disable unqualified
                         }
                     }
                 }

--- a/modules/dashboard/Dash.qml
+++ b/modules/dashboard/Dash.qml
@@ -126,8 +126,8 @@ GridLayout {
                 font.weight: 600
             }
 
-            Repeater { // qmllint disable missing-property
-                model: GCalendar.upcomingDash
+            Repeater {
+                model: GCalendar.upcomingDash // qmllint disable missing-property
 
                 RowLayout { // qmllint disable missing-property
                     id: eventRow
@@ -140,8 +140,8 @@ GridLayout {
                     Rectangle {
                         Layout.preferredWidth: 3
                         Layout.fillHeight: true
-                        radius: 1.5
-                        color: Colours.palette.m3tertiary
+                        radius: 1.5 // qmllint disable missing-property
+                        color: Colours.palette.m3tertiary // qmllint disable missing-property
                     }
 
                     ColumnLayout {

--- a/modules/dashboard/Dash.qml
+++ b/modules/dashboard/Dash.qml
@@ -88,7 +88,7 @@ GridLayout {
     Rect {
         Layout.row: 0
         Layout.column: 5
-        Layout.rowSpan: GCalendar.upcoming.length > 0 ? 3 : 2
+        Layout.rowSpan: Config.dashboard.showUpcoming && GCalendar.upcomingDash.length > 0 ? 3 : 2
         Layout.preferredWidth: media.implicitWidth
         Layout.fillHeight: true
 
@@ -107,7 +107,7 @@ GridLayout {
         Layout.fillWidth: true
         Layout.preferredHeight: eventsCol.implicitHeight
 
-        visible: GCalendar.upcoming.length > 0
+        visible: Config.dashboard.showUpcoming && GCalendar.upcomingDash.length > 0
         radius: Appearance.rounding.large
 
         ColumnLayout {
@@ -127,7 +127,7 @@ GridLayout {
             }
 
             Repeater {
-                model: GCalendar.upcoming
+                model: GCalendar.upcomingDash
 
                 RowLayout {
                     id: eventRow
@@ -160,7 +160,7 @@ GridLayout {
                         StyledText {
                             Layout.fillWidth: true
                             text: {
-                                let line = GCalendar.formatEventTime(eventRow.modelData);
+                                let line = GCalendar.formatEventTime(eventRow.modelData, Config.services.calendar.dashUpcomingHours);
                                 if (eventRow.modelData.location)
                                     line += ` · ${eventRow.modelData.location}`;
                                 return line;

--- a/modules/dashboard/Dash.qml
+++ b/modules/dashboard/Dash.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import "dash"
 import QtQuick.Layouts
 import qs.components
@@ -86,7 +88,7 @@ GridLayout {
     Rect {
         Layout.row: 0
         Layout.column: 5
-        Layout.rowSpan: 2
+        Layout.rowSpan: GCalendar.upcoming.length > 0 ? 3 : 2
         Layout.preferredWidth: media.implicitWidth
         Layout.fillHeight: true
 
@@ -94,6 +96,86 @@ GridLayout {
 
         Media {
             id: media
+        }
+    }
+
+    // Upcoming events
+    Rect {
+        Layout.row: 2
+        Layout.column: 0
+        Layout.columnSpan: 5
+        Layout.fillWidth: true
+        Layout.preferredHeight: eventsCol.implicitHeight
+
+        visible: GCalendar.upcoming.length > 0
+        radius: Appearance.rounding.large
+
+        ColumnLayout {
+            id: eventsCol
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.margins: Appearance.padding.large
+            spacing: Appearance.spacing.small
+
+            StyledText {
+                Layout.topMargin: Appearance.padding.small
+                text: qsTr("Upcoming")
+                color: Colours.palette.m3primary
+                font.pointSize: Appearance.font.size.small
+                font.weight: 600
+            }
+
+            Repeater {
+                model: GCalendar.upcoming
+
+                RowLayout {
+                    id: eventRow
+
+                    required property var modelData
+
+                    Layout.fillWidth: true
+                    spacing: Appearance.spacing.small
+
+                    Rectangle {
+                        width: 3
+                        Layout.fillHeight: true
+                        radius: 1.5
+                        color: Colours.palette.m3tertiary
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 0
+
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: eventRow.modelData.summary
+                            color: Colours.palette.m3onSurface
+                            font.pointSize: Appearance.font.size.small
+                            font.weight: 500
+                            elide: Text.ElideRight
+                        }
+
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: {
+                                let line = GCalendar.formatEventTime(eventRow.modelData);
+                                if (eventRow.modelData.location)
+                                    line += ` · ${eventRow.modelData.location}`;
+                                return line;
+                            }
+                            color: Colours.palette.m3onSurfaceVariant
+                            font.pointSize: Appearance.font.size.small * 0.9
+                            elide: Text.ElideRight
+                        }
+                    }
+                }
+            }
+
+            Item {
+                Layout.preferredHeight: Appearance.padding.small
+            }
         }
     }
 

--- a/modules/dashboard/dash/Calendar.qml
+++ b/modules/dashboard/dash/Calendar.qml
@@ -166,6 +166,8 @@ CustomMouseArea {
 
                     required property var model
 
+                    readonly property bool hasEvent: GCalendar.hasEvent(model.date)
+
                     implicitWidth: implicitHeight
                     implicitHeight: text.implicitHeight + Appearance.padding.small * 2
 
@@ -186,6 +188,18 @@ CustomMouseArea {
                         opacity: dayItem.model.today || dayItem.model.month === grid.month ? 1 : 0.4
                         font.pointSize: Appearance.font.size.normal
                         font.weight: 500
+                    }
+
+                    Rectangle {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.bottom: parent.bottom
+                        anchors.bottomMargin: 1
+                        width: 4
+                        height: 4
+                        radius: 2
+                        color: Colours.palette.m3tertiary
+                        visible: dayItem.hasEvent
+                        opacity: dayItem.model.today || dayItem.model.month === grid.month ? 1 : 0.4
                     }
                 }
             }

--- a/modules/sidebar/Content.qml
+++ b/modules/sidebar/Content.qml
@@ -1,6 +1,10 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Layouts
 import qs.components
+import qs.components.containers
+import qs.components.controls
 import qs.services
 import qs.config
 
@@ -26,6 +30,111 @@ Item {
             NotifDock {
                 props: root.props
                 visibilities: root.visibilities
+            }
+        }
+
+        // Upcoming events
+        StyledRect {
+            Layout.fillWidth: true
+            Layout.preferredHeight: Math.min(upcomingCol.implicitHeight, 300)
+
+            visible: Config.sidebar.showUpcoming && GCalendar.enabled && GCalendar.upcomingSidebar.length > 0
+            radius: Appearance.rounding.normal
+            color: Colours.tPalette.m3surfaceContainerLow
+
+            ColumnLayout {
+                id: upcomingHeader
+
+                anchors.top: parent.top
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.margins: Appearance.padding.normal
+
+                StyledText {
+                    Layout.topMargin: Appearance.padding.small
+                    text: qsTr("Upcoming Events")
+                    color: Colours.palette.m3primary
+                    font.pointSize: Appearance.font.size.small
+                    font.weight: 600
+                }
+            }
+
+            StyledFlickable {
+                id: upcomingView
+
+                clip: true
+                anchors.top: upcomingHeader.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                anchors.margins: Appearance.padding.normal
+                anchors.topMargin: Appearance.spacing.small
+
+                flickableDirection: Flickable.VerticalFlick
+                contentWidth: width
+                contentHeight: upcomingCol.implicitHeight
+
+                StyledScrollBar.vertical: StyledScrollBar {
+                    flickable: upcomingView
+                }
+
+                ColumnLayout {
+                    id: upcomingCol
+
+                    width: parent.width
+                    spacing: Appearance.spacing.small
+
+                    Repeater {
+                        model: GCalendar.upcomingSidebar
+
+                        RowLayout {
+                            id: sidebarEventRow
+
+                            required property var modelData
+
+                            Layout.fillWidth: true
+                            spacing: Appearance.spacing.small
+
+                            Rectangle {
+                                width: 3
+                                Layout.fillHeight: true
+                                radius: 1.5
+                                color: Colours.palette.m3tertiary
+                            }
+
+                            ColumnLayout {
+                                Layout.fillWidth: true
+                                spacing: 0
+
+                                StyledText {
+                                    Layout.fillWidth: true
+                                    text: sidebarEventRow.modelData.summary
+                                    color: Colours.palette.m3onSurface
+                                    font.pointSize: Appearance.font.size.small
+                                    font.weight: 500
+                                    elide: Text.ElideRight
+                                }
+
+                                StyledText {
+                                    Layout.fillWidth: true
+                                    text: {
+                                        let line = GCalendar.formatEventTime(sidebarEventRow.modelData, Config.services.calendar.sidebarUpcomingHours);
+                                        if (sidebarEventRow.modelData.location)
+                                            line += ` · ${sidebarEventRow.modelData.location}`;
+                                        return line;
+                                    }
+                                    color: Colours.palette.m3onSurfaceVariant
+                                    font.pointSize: Appearance.font.size.small * 0.9
+                                    elide: Text.ElideRight
+                                }
+                            }
+                        }
+                    }
+
+                    Item {
+                        Layout.preferredHeight: Appearance.padding.small
+                    }
+                }
             }
         }
 

--- a/modules/sidebar/Content.qml
+++ b/modules/sidebar/Content.qml
@@ -96,7 +96,7 @@ Item {
                             spacing: Appearance.spacing.small
 
                             Rectangle {
-                                width: 3
+                                Layout.preferredWidth: 3
                                 Layout.fillHeight: true
                                 radius: 1.5
                                 color: Colours.palette.m3tertiary

--- a/services/GCalendar.qml
+++ b/services/GCalendar.qml
@@ -1,0 +1,196 @@
+pragma Singleton
+
+import qs.config
+import qs.utils
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+Singleton {
+    id: root
+
+    readonly property bool enabled: Config.services.calendar.enabled
+
+    property list<var> events: []
+    readonly property var eventDateSet: {
+        const s = new Set();
+        for (const ev of events)
+            s.add(ev.dateKey);
+        return s;
+    }
+    readonly property list<var> upcoming: {
+        const now = Date.now();
+        const cutoff = now + Config.services.calendar.upcomingHours * 3600000;
+        return events.filter(ev => {
+            const t = ev.startTime;
+            return t >= now && t < cutoff;
+        });
+    }
+
+    property var notifiedSet: new Set()
+
+    function hasEvent(date: date): bool {
+        if (!enabled)
+            return false;
+        const y = date.getUTCFullYear();
+        const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+        const d = String(date.getUTCDate()).padStart(2, "0");
+        return eventDateSet.has(`${y}-${m}-${d}`);
+    }
+
+    function formatTime(isoStr: string): string {
+        if (!isoStr || isoStr.length === 10)
+            return qsTr("All day");
+        const d = new Date(isoStr);
+        return Config.services.useTwelveHourClock
+            ? Qt.formatDateTime(d, "h:mm AP")
+            : Qt.formatDateTime(d, "hh:mm");
+    }
+
+    function formatEventTime(ev: var): string {
+        let parts = [];
+        if (Config.services.calendar.upcomingHours > 24) {
+            const d = new Date(ev.start);
+            const target = ev.isAllDay ? new Date(ev.start + "T00:00:00") : d;
+            const now = new Date();
+            const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+            const dayAfter = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 2);
+            if (target >= now && target < tomorrow)
+                parts.push(qsTr("Today"));
+            else if (target >= tomorrow && target < dayAfter)
+                parts.push(qsTr("Tomorrow"));
+            else
+                parts.push(Qt.formatDateTime(target, "ddd, MMM d"));
+        }
+        parts.push(formatTime(ev.start));
+        return parts.join(" · ");
+    }
+
+    function parseEvents(data: var): list<var> {
+        const parsed = [];
+        for (const ev of data) {
+            const startStr = ev.start ?? "";
+            const startDate = new Date(startStr);
+            const isAllDay = startStr.length === 10;
+            let dateKey;
+            if (isAllDay) {
+                dateKey = startStr;
+            } else {
+                const y = startDate.getFullYear();
+                const m = String(startDate.getMonth() + 1).padStart(2, "0");
+                const d = String(startDate.getDate()).padStart(2, "0");
+                dateKey = `${y}-${m}-${d}`;
+            }
+            parsed.push({
+                summary: ev.summary ?? "",
+                start: startStr,
+                end: ev.end ?? "",
+                location: ev.location ?? "",
+                calendar: ev.calendar ?? "",
+                startTime: startDate.getTime(),
+                dateKey: dateKey,
+                isAllDay: isAllDay
+            });
+        }
+        parsed.sort((a, b) => a.startTime - b.startTime);
+        return parsed;
+    }
+
+    function saveCache(): void {
+        cache.setText(JSON.stringify(root.events.map(ev => ({
+            summary: ev.summary,
+            start: ev.start,
+            end: ev.end,
+            location: ev.location,
+            calendar: ev.calendar
+        }))));
+    }
+
+    function fetch(): void {
+        if (!enabled)
+            return;
+        fetchProc.running = true;
+    }
+
+    // Load cached events on startup
+    FileView {
+        id: cache
+
+        path: `${Paths.state}/gcalendar.json`
+        onLoaded: {
+            try {
+                const data = JSON.parse(text());
+                if (root.events.length === 0)
+                    root.events = root.parseEvents(data);
+            } catch (e) {
+                // Ignore corrupt cache
+            }
+        }
+        onLoadFailed: err => {
+            if (err === FileViewError.FileNotFound)
+                setText("[]");
+        }
+    }
+
+    Process {
+        id: fetchProc
+
+        command: [
+            Config.services.calendar.command, "calendar", "+agenda",
+            "--days", String(Config.services.calendar.agendaDays),
+            "--format", "json"
+        ]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    const json = JSON.parse(text);
+                    root.events = root.parseEvents(json.events ?? []);
+                    root.saveCache();
+                } catch (e) {
+                    console.warn("GCalendar: failed to parse gws output:", e);
+                }
+            }
+        }
+    }
+
+    // Check for reminders
+    Timer {
+        interval: 30000
+        running: root.enabled && Config.services.calendar.reminderMinutes > 0
+        repeat: true
+        onTriggered: {
+            const now = Date.now();
+            const reminderMs = Config.services.calendar.reminderMinutes * 60000;
+            for (const ev of root.events) {
+                if (ev.isAllDay)
+                    continue;
+                const diff = ev.startTime - now;
+                if (diff > 0 && diff <= reminderMs + 60000 && diff > reminderMs - 60000) {
+                    const key = ev.summary + ev.start;
+                    if (!root.notifiedSet.has(key)) {
+                        root.notifiedSet.add(key);
+                        const timeStr = root.formatTime(ev.start);
+                        Quickshell.execDetached([
+                            "notify-send", "-a", "caelestia-shell",
+                            "-u", "normal",
+                            "-i", "calendar",
+                            ev.summary,
+                            `Starts at ${timeStr}${ev.location ? " - " + ev.location : ""}`
+                        ]);
+                    }
+                }
+            }
+        }
+    }
+
+    // Periodic refresh
+    Timer {
+        interval: Config.services.calendar.refreshInterval * 1000
+        running: root.enabled
+        repeat: true
+        onTriggered: root.fetch()
+    }
+
+    // Initial fetch (refreshes cache in background)
+    Component.onCompleted: fetch()
+}

--- a/services/GCalendar.qml
+++ b/services/GCalendar.qml
@@ -1,10 +1,10 @@
 pragma Singleton
 
-import qs.config
-import qs.utils
+import QtQuick
 import Quickshell
 import Quickshell.Io
-import QtQuick
+import qs.config
+import qs.utils
 
 Singleton {
     id: root
@@ -36,6 +36,9 @@ Singleton {
     }
 
     property var notifiedSet: new Set()
+
+    // Initial fetch (refreshes cache in background)
+    Component.onCompleted: fetch()
 
     function hasEvent(date: date): bool {
         if (!enabled)
@@ -186,7 +189,4 @@ Singleton {
         repeat: true
         onTriggered: root.fetch()
     }
-
-    // Initial fetch (refreshes cache in background)
-    Component.onCompleted: fetch()
 }

--- a/services/GCalendar.qml
+++ b/services/GCalendar.qml
@@ -37,9 +37,6 @@ Singleton {
 
     property var notifiedSet: new Set()
 
-    // Initial fetch (refreshes cache in background)
-    Component.onCompleted: fetch()
-
     function hasEvent(date: date): bool {
         if (!enabled)
             return false;
@@ -120,6 +117,9 @@ Singleton {
             return;
         fetchProc.running = true;
     }
+
+    // Initial fetch (refreshes cache in background)
+    Component.onCompleted: fetch()
 
     // Load cached events on startup
     FileView {

--- a/services/GCalendar.qml
+++ b/services/GCalendar.qml
@@ -50,9 +50,7 @@ Singleton {
         if (!isoStr || isoStr.length === 10)
             return qsTr("All day");
         const d = new Date(isoStr);
-        return Config.services.useTwelveHourClock
-            ? Qt.formatDateTime(d, "h:mm AP")
-            : Qt.formatDateTime(d, "hh:mm");
+        return Config.services.useTwelveHourClock ? Qt.formatDateTime(d, "h:mm AP") : Qt.formatDateTime(d, "hh:mm");
     }
 
     function formatEventTime(ev: var, upcomingHours: int): string {
@@ -106,12 +104,12 @@ Singleton {
 
     function saveCache(): void {
         cache.setText(JSON.stringify(root.events.map(ev => ({
-            summary: ev.summary,
-            start: ev.start,
-            end: ev.end,
-            location: ev.location,
-            calendar: ev.calendar
-        }))));
+                    summary: ev.summary,
+                    start: ev.start,
+                    end: ev.end,
+                    location: ev.location,
+                    calendar: ev.calendar
+                }))));
     }
 
     function fetch(): void {
@@ -143,11 +141,7 @@ Singleton {
     Process {
         id: fetchProc
 
-        command: [
-            Config.services.calendar.command, "calendar", "+agenda",
-            "--days", String(Config.services.calendar.agendaDays),
-            "--format", "json"
-        ]
+        command: [Config.services.calendar.command, "calendar", "+agenda", "--days", String(Config.services.calendar.agendaDays), "--format", "json"]
         stdout: StdioCollector {
             onStreamFinished: {
                 try {
@@ -178,13 +172,7 @@ Singleton {
                     if (!root.notifiedSet.has(key)) {
                         root.notifiedSet.add(key);
                         const timeStr = root.formatTime(ev.start);
-                        Quickshell.execDetached([
-                            "notify-send", "-a", "caelestia-shell",
-                            "-u", "normal",
-                            "-i", "calendar",
-                            ev.summary,
-                            `Starts at ${timeStr}${ev.location ? " - " + ev.location : ""}`
-                        ]);
+                        Quickshell.execDetached(["notify-send", "-a", "caelestia-shell", "-u", "normal", "-i", "calendar", ev.summary, `Starts at ${timeStr}${ev.location ? " - " + ev.location : ""}`]);
                     }
                 }
             }

--- a/services/GCalendar.qml
+++ b/services/GCalendar.qml
@@ -18,9 +18,17 @@ Singleton {
             s.add(ev.dateKey);
         return s;
     }
-    readonly property list<var> upcoming: {
+    readonly property list<var> upcomingDash: {
         const now = Date.now();
-        const cutoff = now + Config.services.calendar.upcomingHours * 3600000;
+        const cutoff = now + Config.services.calendar.dashUpcomingHours * 3600000;
+        return events.filter(ev => {
+            const t = ev.startTime;
+            return t >= now && t < cutoff;
+        });
+    }
+    readonly property list<var> upcomingSidebar: {
+        const now = Date.now();
+        const cutoff = now + Config.services.calendar.sidebarUpcomingHours * 3600000;
         return events.filter(ev => {
             const t = ev.startTime;
             return t >= now && t < cutoff;
@@ -47,9 +55,9 @@ Singleton {
             : Qt.formatDateTime(d, "hh:mm");
     }
 
-    function formatEventTime(ev: var): string {
+    function formatEventTime(ev: var, upcomingHours: int): string {
         let parts = [];
-        if (Config.services.calendar.upcomingHours > 24) {
+        if (upcomingHours > 24) {
             const d = new Date(ev.start);
             const target = ev.isAllDay ? new Date(ev.start + "T00:00:00") : d;
             const now = new Date();


### PR DESCRIPTION
## Summary

- Adds a `GCalendar` service that fetches events from Google Calendar using the [`gws`](https://github.com/googleworkspace/cli) CLI (`gws calendar +agenda`)
- Displays subtle dot indicators on calendar days that have events
- Shows upcoming events in a dedicated row below the calendar in the dashboard (default **off**)
- Shows upcoming events in a scrollable sidebar widget below notifications (default **on**)
- Sends desktop notifications before events start (configurable minutes)
- Caches events to disk (`gcalendar.json`) for instant display on shell restart
- Fully configurable via `services.calendar`, `dashboard.showUpcoming`, and `sidebar.showUpcoming` in `shell.json`, calendar disabled by default

## Configuration

```json
{
  "services": {
    "calendar": {
      "enabled": true,
      "command": "gws",
      "agendaDays": 30,
      "dashUpcomingHours": 24,
      "sidebarUpcomingHours": 120,
      "reminderMinutes": 10,
      "refreshInterval": 900
    }
  },
  "dashboard": {
    "showUpcoming": false
  },
  "sidebar": {
    "showUpcoming": true
  }
}
```

| Option | Default | Description |
|---|---|---|
| `services.calendar.enabled` | `false` | Master toggle — requires `gws` CLI in PATH |
| `services.calendar.command` | `"gws"` | Path or name of the gws binary |
| `services.calendar.agendaDays` | `30` | How many days ahead to fetch events |
| `services.calendar.dashUpcomingHours` | `24` | Hours ahead to show in dashboard upcoming list |
| `services.calendar.sidebarUpcomingHours` | `120` | Hours ahead (5 days) to show in sidebar upcoming list |
| `services.calendar.reminderMinutes` | `10` | Minutes before event to send notification (0 to disable) |
| `services.calendar.refreshInterval` | `900` | Refresh interval in seconds |
| `dashboard.showUpcoming` | `false` | Show upcoming events row in dashboard |
| `sidebar.showUpcoming` | `true` | Show upcoming events widget in sidebar |

When `dashUpcomingHours` or `sidebarUpcomingHours` exceeds 24, dates are shown as "Today", "Tomorrow", or "Wed, Mar 18" alongside the time.

## Screenshots

### Calendar dots + upcoming events row
Events are shown in their own row below the calendar, so they don't stretch the DateTime/Resources columns.

<img width="850" height="696" alt="image" src="https://github.com/user-attachments/assets/349aebe8-ab90-444d-a5e6-428980139f73" />