### PR TITLE
Border Selection: prevent border thickness being < 2, 

### DIFF
--- a/modules/controlcenter/appearance/sections/BorderSection.qml
+++ b/modules/controlcenter/appearance/sections/BorderSection.qml
@@ -60,6 +60,7 @@ CollapsibleSection {
             }
 
             onValueModified: newValue => {
+                newValue = newValue < 2 ? 2 : newValue;
                 rootPane.borderThickness = newValue;
                 rootPane.saveConfig();
             }


### PR DESCRIPTION
...which would prevent you from accessing Dashboard as there was no place to detect an event.