### PR TITLE
fix: Wallpaper.qml "Wallpaper missing?" race condition on boot

### DIFF
--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -13,6 +13,11 @@ Item {
 
     property string source: Wallpapers.current
     property Image current: one
+    property bool ready: false
+
+    Component.onCompleted: {
+        if (source) Qt.callLater(() => one.update());
+    }
 
     onSourceChanged: {
         if (!source)
@@ -23,15 +28,16 @@ Item {
             one.update();
     }
 
-    Component.onCompleted: {
-        if (source)
-            Qt.callLater(() => one.update());
+    Timer {
+        running: true
+        interval: 0
+        onTriggered: root.ready = true
     }
 
     Loader {
         anchors.fill: parent
 
-        active: !root.source
+        active: root.ready && !root.source
 
         sourceComponent: StyledRect {
             color: Colours.palette.m3surfaceContainer


### PR DESCRIPTION
Since commit `69adb92`, a subtle race condition has been introduced during the initial shell startup. 

The `Loader` responsible for the "Wallpaper missing?" error UI is now bound directly to the absence of a wallpaper path. Since quickshell initializes faster than the CLI can resolve and broadcast the current wallpaper path via IPC, the error UI "Wallpaper missing?" shows on screen for a brief window on certain systems even when a wallpaper is already set correctly. 

On fast drives, this is a non issue, but on potato systems with higher I/O latency (mechanical HDDs/ slow SATA SSDs/ flash drives, etc.), the "sentiment_stressed" icon and error text shows and can remain visible for seconds before the wallpaper appears.

This fix implements a "single-frame grace period" using a non-repeating `Timer` with an `interval: 0`, the logic executes only after the initial event loop has cleared and property bindings have had a chance to settle, in essence a `ready` latch to gate the error `Loader` and flipping to `true` only after the first event cycle, allowing the asynchronous wallpaper service to populate the `source` property before the shell assumes it is missing.

Fast systems see no change in behavior, while slower systems are spared from seeing a "broken" system state during every boot.