### PR TITLE
fix: react weather location + nominatim fallback

### DIFF
--- a/services/Weather.qml
+++ b/services/Weather.qml
@@ -54,18 +54,35 @@ Singleton {
             return;
         }
 
-        const [lat, lon] = coords.split(",");
-        const url = `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lon}&format=geocodejson`;
-        Requests.get(url, text => {
+        const [lat, lon] = coords.split(",").map(s => s.trim());
+
+        const fallbackToBigDataCloud = () => {
+            const fallbackUrl = `https://api.bigdatacloud.net/data/reverse-geocode-client?latitude=${lat}&longitude=${lon}&localityLanguage=en`;
+            Requests.get(fallbackUrl, text => {
+                const geo = JSON.parse(text);
+                const geoCity = geo.city || geo.locality;
+                if (geoCity) {
+                    city = geoCity;
+                    cachedCities.set(coords, geoCity);
+                } else {
+                    city = "Unknown City";
+                }
+            });
+        };
+
+        const nominatimUrl = `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lon}&format=geocodejson`;
+        Requests.get(nominatimUrl, text => {
             const geo = JSON.parse(text).features?.[0]?.properties.geocoding;
             if (geo) {
                 const geoCity = geo.type === "city" ? geo.name : geo.city;
-                city = geoCity;
-                cachedCities.set(coords, geoCity);
-            } else {
-                city = "Unknown City";
+                if (geoCity) {
+                    city = geoCity;
+                    cachedCities.set(coords, geoCity);
+                    return;
+                }
             }
-        });
+            fallbackToBigDataCloud();
+        }, fallbackToBigDataCloud);
     }
 
     function fetchCoordsFromCity(cityName: string): void {
@@ -149,7 +166,7 @@ Singleton {
         if (!loc || loc.indexOf(",") === -1)
             return "";
 
-        const [lat, lon] = loc.split(",");
+        const [lat, lon] = loc.split(",").map(s => s.trim());
         const baseUrl = "https://api.open-meteo.com/v1/forecast";
         const params = ["latitude=" + lat, "longitude=" + lon, "hourly=weather_code,temperature_2m", "daily=weather_code,temperature_2m_max,temperature_2m_min,sunrise,sunset", "current=temperature_2m,relative_humidity_2m,apparent_temperature,is_day,weather_code,wind_speed_10m", "timezone=auto", "forecast_days=7"];
 
@@ -191,6 +208,13 @@ Singleton {
     }
 
     onLocChanged: fetchWeatherData()
+
+    Connections {
+        target: Config.services
+        function onWeatherLocationChanged(): void {
+            root.reload();
+        }
+    }
 
     // Refresh current location hourly
     Timer {


### PR DESCRIPTION
# Motivation

This PR aims to fix two problems:
- `Config.services.weatherLocation` inside `function reload()` is always empty, independent from the actual `weatherLocation` variable in the shell config file, causing the user defined weather location to be ignored;
- Nominatim 403 errors.

Closes #1283 

# Proposed Solution

- Add fallback to nominatim -> `https://api.bigdatacloud.net/data/reverse-geocode-client`
- Make Weather.qml react to location changes

# Proof of Testing

<details><summary>Connect Weather.qml to `onWeatherLocationChanged`</summary>

## Debugging

<img width="682" height="100" alt="image" src="https://github.com/user-attachments/assets/93d563aa-5e36-47f1-b3be-a839c3c623c2" />

## Before:

<img width="1532" height="1397" alt="image" src="https://github.com/user-attachments/assets/e9fff3a6-5d27-4763-84d3-ff8ef0876572" />

## After:

<img width="1455" height="1417" alt="image" src="https://github.com/user-attachments/assets/2780a912-4d87-4c24-ae75-34b22d8c25c6" />

</details>


<details><summary>Nominatim Fallback</summary>

## Debugging

<img width="1302" height="734" alt="image" src="https://github.com/user-attachments/assets/9e281050-8a62-4aa1-b7fa-eecde89f9b39" />


## Before:

<img width="1324" height="1406" alt="image" src="https://github.com/user-attachments/assets/d8cd4905-d5c3-4bac-a184-7d840ec527a6" />


## After:

<img width="1335" height="1399" alt="image" src="https://github.com/user-attachments/assets/6d3a6ea3-692f-4cab-a062-ab6a151e7eca" />


</details>

