### PR TITLE
fix: broken dashboard panel

### DIFF
--- a/modules/dashboard/Content.qml
+++ b/modules/dashboard/Content.qml
@@ -138,6 +138,13 @@ Item {
                             const arr = view.paneLoaders.slice();
                             arr[index] = paneLoader;
                             view.paneLoaders = arr;
+                            active = Qt.binding(() => {
+                                if (index === view.currentIndex)
+                                    return true;
+                                const vx = Math.floor(view.visibleArea.xPosition * view.contentWidth);
+                                const vex = Math.floor(vx + view.visibleArea.widthRatio * view.contentWidth);
+                                return (vx >= x && vx <= x + implicitWidth) || (vex >= x && vex <= x + implicitWidth);
+                            })
                         }
                     }
                 }


### PR DESCRIPTION
# Motivation

After 12b07b7cdfa9de0e7f78b7168fc2cee358002167 a strange behavior started to occur when I close the dashboard panel specifically from the Weather Tab. I am not really able to tell why but the panel will not open again after unhovering it.

**edit**: I've mispointed the source, although changing the binding fixes the issue, seems like it actually came from the Repeater, after a reeval interaction the repeater was showing up as the `currentItem`, because the Repeater appends new delegates AFTER itself (stackAfter) instead of before:

- before row.children = [L0, L1, L2, L3, Repeater] → [3] = Weather Loader (before reeval)
- After broken recreation: row.children = [L0, L1, L2, Repeater, L3'] → [3] = Repeater (after reeval)


# Proposed Solution

Use a separate registry for the loaders instead of `children`

# Proof of Testing

## Before

<img width="904" height="529" alt="image" src="https://github.com/user-attachments/assets/e51d47a0-92d8-4079-809a-59138ef43f44" />


## After

<img width="1010" height="643" alt="image" src="https://github.com/user-attachments/assets/14c8a2e2-ea63-476e-aef2-66e137071ba9" />


