### PR TITLE
fix: active window compact title binding loop

### DIFF
--- a/modules/bar/components/ActiveWindow.qml
+++ b/modules/bar/components/ActiveWindow.qml
@@ -19,7 +19,7 @@ Item {
             return qsTr("Desktop");
         if (Config.bar.activeWindow.compact) {
             // " - " (standard hyphen), " — " (em dash), " – " (en dash)
-            const parts = root.windowTitle.split(/\s+[\-\u2013\u2014]\s+/);
+            const parts = title.split(/\s+[\-\u2013\u2014]\s+/);
             if (parts.length > 1)
                 return parts[parts.length - 1].trim();
         }


### PR DESCRIPTION
## This PR fixes a binding loop error for ActiveWindow compact option for the Bar

It's a simple fix to avoid a binding loop. The previous implementation keeps throwing this error when compact is true:
```
 WARN scene: QML ActiveWindow at @modules/bar/Bar.qml[138:38]: Binding loop detected for property "windowTitle":
qs:@/qs/modules/bar/components/ActiveWindow.qml:16:5
```