### PR TITLE
feat: improve game mode functionality

### DIFF
--- a/services/GameMode.qml
+++ b/services/GameMode.qml
@@ -52,7 +52,7 @@ Singleton {
         const jsonContent = JSON.stringify({
             enabled: root.enabled
         });
-        writeProcess.script = `mkdir -p ${Paths.state} && echo '${jsonContent}' > ${Paths.state}/gamemode.json`;
+        writeProcess.script = `mkdir -p ${Paths.state} && cat > ${Paths.state}/gamemode.json << 'EOF'\n${jsonContent}\nEOF`;
         writeProcess.running = true;
     }
 

--- a/services/GameMode.qml
+++ b/services/GameMode.qml
@@ -1,16 +1,18 @@
 pragma Singleton
 
 import QtQuick
+import QtQml
 import Quickshell
 import Quickshell.Io
 import Caelestia
 import Caelestia.Config
 import qs.services
+import qs.utils
 
 Singleton {
     id: root
 
-    property alias enabled: props.enabled
+    property bool enabled: false
 
     function setDynamicConfs(): void {
         Hypr.extras.applyOptions({
@@ -21,33 +23,63 @@ Singleton {
             "general:gaps_out": 0,
             "general:border_size": 1,
             "decoration:rounding": 0,
-            "general:allow_tearing": 1
+            "general:allow_tearing": 1,
+            "input:accel_profile": "flat"
         });
+        Hypr.extras.message("keyword windowrule opacity 1 override 1 override 1 override, match:title .*");
+    }
+
+    function saveState(): void {
+        const jsonContent = JSON.stringify({
+            enabled: root.enabled
+        });
+        writeProcess.script = `mkdir -p ${Paths.state} && echo '${jsonContent}' > ${Paths.state}/gamemode.json`;
+        writeProcess.running = true;
     }
 
     onEnabledChanged: {
         if (enabled) {
             setDynamicConfs();
             if (GlobalConfig.utilities.toasts.gameModeChanged)
-                Toaster.toast(qsTr("Game mode enabled"), qsTr("Disabled Hyprland animations, blur, gaps and shadows"), "gamepad");
+                Toaster.toast(qsTr("Game mode enabled"), qsTr("Disabled Hyprland animations, blur, gaps, shadows and mouse acceleration"), "gamepad");
         } else {
             Hypr.extras.message("reload");
             if (GlobalConfig.utilities.toasts.gameModeChanged)
                 Toaster.toast(qsTr("Game mode disabled"), qsTr("Hyprland settings restored"), "gamepad");
         }
+        saveState();
     }
 
-    PersistentProperties {
-        id: props
+    Process {
+        id: writeProcess
 
-        property bool enabled: Hypr.options["animations:enabled"] === 0 // qmllint disable missing-property
+        property string script: ""
 
-        reloadableId: "gameMode"
+        command: ["bash", "-c", script]
+        // qmllint disable signal-handler-parameters
+        onExited: function (exitCode) {
+            if (exitCode !== 0)
+                console.warn("GameMode: Failed to save gamemode state, exit code:" + exitCode);
+        }
+        // qmllint enable signal-handler-parameters
+    }
+
+    FileView {
+        path: `${Paths.state}/gamemode.json`
+        printErrors: false
+        onLoaded: {
+            try {
+                root.enabled = JSON.parse(text()).enabled;
+            } catch (e) {
+                console.warn("GameMode: Failed to load gamemode state:", e);
+            }
+        }
+        Component.onCompleted: reload()
     }
 
     Connections {
         function onConfigReloaded(): void {
-            if (props.enabled)
+            if (root.enabled)
                 root.setDynamicConfs();
         }
 
@@ -56,19 +88,19 @@ Singleton {
 
     IpcHandler {
         function isEnabled(): bool {
-            return props.enabled;
+            return root.enabled;
         }
 
         function toggle(): void {
-            props.enabled = !props.enabled;
+            root.enabled = !root.enabled;
         }
 
         function enable(): void {
-            props.enabled = true;
+            root.enabled = true;
         }
 
         function disable(): void {
-            props.enabled = false;
+            root.enabled = false;
         }
 
         target: "gameMode"

--- a/services/GameMode.qml
+++ b/services/GameMode.qml
@@ -14,6 +14,24 @@ Singleton {
 
     property bool enabled: false
 
+    // forces full opacity
+    // Windowrule for new windows + setprop for existing windows, batched to avoid races
+    function forceOpacity(): void {
+        const cmds = ["keyword windowrule opacity 1 override 1 override 1 override, match:title .*"];
+        for (const toplevel of Hypr.toplevels.values)
+            cmds.push(`dispatch setprop address:0x${toplevel.address} opaque 1`);
+        Hypr.extras.batchMessage(cmds);
+    }
+
+    // unset the opacity override for all windows
+    function revertOpacity(): void {
+        const cmds = [];
+        for (const toplevel of Hypr.toplevels.values)
+            cmds.push(`dispatch setprop address:0x${toplevel.address} opaque 0`);
+        cmds.push("reload");
+        Hypr.extras.batchMessage(cmds);
+    }
+
     function setDynamicConfs(): void {
         Hypr.extras.applyOptions({
             "animations:enabled": 0,
@@ -26,9 +44,10 @@ Singleton {
             "general:allow_tearing": 1,
             "input:accel_profile": "flat"
         });
-        Hypr.extras.message("keyword windowrule opacity 1 override 1 override 1 override, match:title .*");
+        forceOpacity();
     }
 
+    // save state to a file instead
     function saveState(): void {
         const jsonContent = JSON.stringify({
             enabled: root.enabled
@@ -43,7 +62,7 @@ Singleton {
             if (GlobalConfig.utilities.toasts.gameModeChanged)
                 Toaster.toast(qsTr("Game mode enabled"), qsTr("Disabled Hyprland animations, blur, gaps, shadows and mouse acceleration"), "gamepad");
         } else {
-            Hypr.extras.message("reload");
+            revertOpacity();
             if (GlobalConfig.utilities.toasts.gameModeChanged)
                 Toaster.toast(qsTr("Game mode disabled"), qsTr("Hyprland settings restored"), "gamepad");
         }


### PR DESCRIPTION
## Fixes some issues regarding gamemode:
closes - https://github.com/caelestia-dots/shell/issues/803
fixes - https://github.com/caelestia-dots/shell/issues/764

- Check gamemode state using dedicated gamemode.json state now in `~/.local/state/caelestia/gamemode.json`, instead of relying on checks for animation.
- Can now set animations to off as preference in hyprland settings without the shell thinking gamemode is on.
- Set opacity to full 1.0 during gamemode by overriding opacity in window rule aswell as using setprop so new and current window are properly updated.
- ~~Fix weird refresh rate, by temporarily disabling the allow tearing (I'm not sure why but currently it makes screen refresh rate verryy inconsistent on some monitors as well as mouse lag - https://github.com/caelestia-dots/shell/issues/764)~~

Open to suggestions and feedback :)