### PR TITLE
drawers: restore focus to previous window on dismiss

### DIFF
--- a/modules/drawers/Drawers.qml
+++ b/modules/drawers/Drawers.qml
@@ -91,8 +91,20 @@ Variants {
             HyprlandFocusGrab {
                 id: focusGrab
 
+                property string previousWindowAddress: ""
+
                 active: (visibilities.launcher && Config.launcher.enabled) || (visibilities.session && Config.session.enabled) || (visibilities.sidebar && Config.sidebar.enabled) || (!Config.dashboard.showOnHover && visibilities.dashboard && Config.dashboard.enabled) || (panels.popouts.currentName.startsWith("traymenu") && (panels.popouts.current as StackView)?.depth > 1)
                 windows: [win]
+
+                onActiveChanged: {
+                    if (active) {
+                        previousWindowAddress = Hypr.activeToplevel?.lastIpcObject.address ?? "";
+                    } else if (previousWindowAddress) {
+                        Hypr.dispatch(`focuswindow address:0x${previousWindowAddress}`);
+                        previousWindowAddress = "";
+                    }
+                }
+
                 onCleared: {
                     visibilities.launcher = false;
                     visibilities.session = false;


### PR DESCRIPTION
Fixes #1322

## What this does

When a drawer (launcher, session, sidebar, dashboard) is opened via `HyprlandFocusGrab`, it takes keyboard focus from the active window. Previously, when the drawer was dismissed (via Escape, keybind toggle, or clicking outside), focus was not restored to the previously active window. Hyprland would then fall back to focusing whatever window happened to be under the mouse cursor.

This patch stores the active toplevel's address when the focus grab activates, and dispatches `focuswindow` to restore it when the grab deactivates.

## How it works

- `onActiveChanged` handler on the existing `HyprlandFocusGrab`
- When `active` becomes `true`: saves `Hypr.activeToplevel.lastIpcObject.address`
- When `active` becomes `false`: dispatches `focuswindow address:0x{saved}` to restore focus
- If the saved window was closed while the drawer was open, the dispatch is silently ignored by Hyprland and focus falls back to the default behavior (no regression)
- When an app is launched from the launcher, focus is briefly restored to the previous window, then the newly spawned window takes focus naturally

## Breaking changes

None.

## Side effects

This also restores focus after dismissing the session menu, sidebar, and dashboard, not just the launcher. This should be the expected behavior for all of these.