### PR TITLE
fix: Escape button and the Tab button getting recognized as input network password dialog

### DIFF
--- a/modules/bar/popouts/WirelessPassword.qml
+++ b/modules/bar/popouts/WirelessPassword.qml
@@ -280,6 +280,11 @@ ColumnLayout {
                         forceActiveFocus();
                     }
 
+                    if (event.key === Qt.Key_Escape) {
+                        event.accepted = false;
+                        closeDialog();
+                    }
+
                     // Clear error when user starts typing
                     if (connectButton.hasError && event.text && event.text.length > 0) {
                         connectButton.hasError = false;
@@ -298,6 +303,10 @@ ColumnLayout {
                         }
                         event.accepted = true;
                     } else if (event.text && event.text.length > 0) {
+                        if (event.key === Qt.Key_Tab) {
+                            event.accepted = false;
+                            return;
+                        }
                         passwordBuffer += event.text;
                         event.accepted = true;
                     }

--- a/modules/controlcenter/network/WirelessPasswordDialog.qml
+++ b/modules/controlcenter/network/WirelessPasswordDialog.qml
@@ -202,6 +202,11 @@ Item {
                         forceActiveFocus();
                     }
 
+                    if (event.key === Qt.Key_Escape) {
+                        event.accepted = false;
+                        closeDialog();
+                    }
+
                     if (connectButton.hasError && event.text && event.text.length > 0) {
                         connectButton.hasError = false;
                     }
@@ -219,6 +224,10 @@ Item {
                         }
                         event.accepted = true;
                     } else if (event.text && event.text.length > 0) {
+                        if (event.key === Qt.Key_Tab) {
+                            event.accepted = false;
+                            return;
+                        }
                         passwordBuffer += event.text;
                         event.accepted = true;
                     }


### PR DESCRIPTION
The escape and Tab button were getting recognized as input (Network password dialog) in the control center and the pop out. The fix was to Intercept the signal and do nothing on tab but close the dialog on escape.