### PR TITLE
feat: launcher smart caffeine

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,8 @@ default, you must create it manually.
             "kbLimit": true,
             "numLockChanged": true,
             "vpnChanged": true,
-            "nowPlaying": false
+            "nowPlaying": false,
+            "caffeineChanged": false
         },
         "vpn": {
             "enabled": true,

--- a/config/Config.qml
+++ b/config/Config.qml
@@ -253,6 +253,7 @@ Singleton {
             vimKeybinds: launcher.vimKeybinds,
             favouriteApps: launcher.favouriteApps,
             hiddenApps: launcher.hiddenApps,
+            caffeineApps: launcher.caffeineApps,
             useFuzzy: {
                 apps: launcher.useFuzzy.apps,
                 actions: launcher.useFuzzy.actions,
@@ -332,7 +333,8 @@ Singleton {
                 numLockChanged: utilities.toasts.numLockChanged,
                 kbLayoutChanged: utilities.toasts.kbLayoutChanged,
                 vpnChanged: utilities.toasts.vpnChanged,
-                nowPlaying: utilities.toasts.nowPlaying
+                nowPlaying: utilities.toasts.nowPlaying,
+                caffeineChanged: utilities.toasts.caffeineChanged
             },
             vpn: {
                 enabled: utilities.vpn.enabled,

--- a/config/LauncherConfig.qml
+++ b/config/LauncherConfig.qml
@@ -12,6 +12,7 @@ JsonObject {
     property bool vimKeybinds: false
     property list<string> favouriteApps: []
     property list<string> hiddenApps: []
+    property list<string> caffeineApps: []
     property UseFuzzy useFuzzy: UseFuzzy {}
     property Sizes sizes: Sizes {}
 

--- a/config/UtilitiesConfig.qml
+++ b/config/UtilitiesConfig.qml
@@ -57,6 +57,7 @@ JsonObject {
         property bool kbLimit: true
         property bool vpnChanged: true
         property bool nowPlaying: false
+        property bool caffeineChanged: false
     }
 
     component Vpn: JsonObject {

--- a/modules/controlcenter/launcher/LauncherPane.qml
+++ b/modules/controlcenter/launcher/LauncherPane.qml
@@ -25,6 +25,7 @@ Item {
     property var selectedApp: root.session.launcher.active
     property bool hideFromLauncherChecked: false
     property bool favouriteChecked: false
+    property bool caffeineChecked: false
     property string searchText: ""
     property list<var> filteredApps: []
 
@@ -32,6 +33,7 @@ Item {
         if (!root.selectedApp) {
             root.hideFromLauncherChecked = false;
             root.favouriteChecked = false;
+            root.caffeineChecked = false;
             return;
         }
 
@@ -39,6 +41,7 @@ Item {
 
         root.hideFromLauncherChecked = Config.launcher.hiddenApps && Config.launcher.hiddenApps.length > 0 && Strings.testRegexList(Config.launcher.hiddenApps, appId);
         root.favouriteChecked = Config.launcher.favouriteApps && Config.launcher.favouriteApps.length > 0 && Strings.testRegexList(Config.launcher.favouriteApps, appId);
+        root.caffeineChecked = Config.launcher.caffeineApps && Config.launcher.caffeineApps.length > 0 && Config.launcher.caffeineApps.includes(appId);
     }
 
     function saveHiddenApps(isHidden) {
@@ -359,14 +362,28 @@ Item {
                                 }
 
                                 Loader {
-                                    readonly property bool isHidden: modelData ? Strings.testRegexList(Config.launcher.hiddenApps, modelData.id) : false
-                                    readonly property bool isFav: modelData ? Strings.testRegexList(Config.launcher.favouriteApps, modelData.id) : false
-
                                     Layout.alignment: Qt.AlignVCenter
                                     asynchronous: true
-                                    active: isHidden || isFav
+                                    active: modelData ? Strings.testRegexList(Config.launcher.hiddenApps, modelData.id) : false
+                                    visible: active
 
-                                    sourceComponent: isHidden ? hiddenIcon : (isFav ? favouriteIcon : null)
+                                    sourceComponent: hiddenIcon
+                                }
+                                Loader {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    asynchronous: true
+                                    active: modelData ? Strings.testRegexList(Config.launcher.favouriteApps, modelData.id) : false
+                                    visible: active
+
+                                    sourceComponent: favouriteIcon
+                                }
+                                Loader {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    asynchronous: true
+                                    active: modelData ? (Config.launcher.caffeineApps && Config.launcher.caffeineApps.includes(modelData.id)) : false
+                                    visible: active
+
+                                    sourceComponent: caffeineIcon
                                 }
 
                                 Component {
@@ -384,6 +401,16 @@ Item {
 
                                     MaterialIcon {
                                         text: "favorite"
+                                        fill: 1
+                                        color: Colours.palette.m3primary
+                                    }
+                                }
+
+                                Component {
+                                    id: caffeineIcon
+
+                                    MaterialIcon {
+                                        text: "emoji_food_beverage"
                                         fill: 1
                                         color: Colours.palette.m3primary
                                     }
@@ -425,9 +452,11 @@ Item {
                         const appId = displayedApp.id || displayedApp.entry?.id;
                         root.hideFromLauncherChecked = Config.launcher.hiddenApps && Config.launcher.hiddenApps.length > 0 && Strings.testRegexList(Config.launcher.hiddenApps, appId);
                         root.favouriteChecked = Config.launcher.favouriteApps && Config.launcher.favouriteApps.length > 0 && Strings.testRegexList(Config.launcher.favouriteApps, appId);
+                        root.caffeineChecked = Config.launcher.caffeineApps && Config.launcher.caffeineApps.length > 0 && Config.launcher.caffeineApps.includes(appId);
                     } else {
                         root.hideFromLauncherChecked = false;
                         root.favouriteChecked = false;
+                        root.caffeineChecked = false;
                     }
                 }
 
@@ -640,7 +669,7 @@ Item {
                             // * app isn't in hiddenApps array but marked as hidden anyway
                             // ^^^ This means that this app is hidden because of a regex check
                             //     this button can not toggle regexed apps
-                            enabled: appDetailsLayout.displayedApp !== null && !root.favouriteChecked && (Config.launcher.hiddenApps.indexOf(appDetailsLayout.displayedApp.id || appDetailsLayout.displayedApp.entry?.id) !== -1 || !root.hideFromLauncherChecked)
+                            enabled: appDetailsLayout.displayedApp !== null && !root.favouriteChecked && !(Config.launcher.caffeineApps.includes(appDetailsLayout.displayedApp.id || appDetailsLayout.displayedApp.entry?.id)) && (Config.launcher.hiddenApps.indexOf(appDetailsLayout.displayedApp.id || appDetailsLayout.displayedApp.entry?.id) !== -1 || !root.hideFromLauncherChecked)
                             opacity: enabled ? 1 : 0.6
                             onToggled: checked => {
                                 root.hideFromLauncherChecked = checked;
@@ -659,6 +688,34 @@ Item {
                                         }
                                     }
                                     Config.launcher.hiddenApps = hiddenApps;
+                                    Config.save();
+                                }
+                            }
+                        }
+                        SwitchRow {
+                            Layout.topMargin: Appearance.spacing.normal
+                            visible: appDetailsLayout.displayedApp !== null
+                            label: qsTr("Smart awake")
+                            checked: root.caffeineChecked
+                            enabled: appDetailsLayout.displayedApp !== null && !root.hideFromLauncherChecked
+                            opacity: enabled ? 1 : 0.6
+                            onToggled: checked => {
+                                const app = appDetailsLayout.displayedApp;
+                                if (app) {
+                                    const appId = app.id || app.entry?.id || "";
+                                    const apps = Config.launcher.caffeineApps ? [...Config.launcher.caffeineApps] : [];
+                                    if (checked) {
+                                        if (!apps.includes(appId)) {
+                                            apps.push(appId);
+                                        }
+                                    } else {
+                                        const index = apps.indexOf(appId);
+                                        if (index !== -1) {
+                                            apps.splice(index, 1);
+                                        }
+                                    }
+                                    root.caffeineChecked = checked;
+                                    Config.launcher.caffeineApps = apps;
                                     Config.save();
                                 }
                             }

--- a/modules/launcher/items/AppItem.qml
+++ b/modules/launcher/items/AppItem.qml
@@ -86,5 +86,20 @@ Item {
                 color: Colours.palette.m3primary
             }
         }
+
+        Loader {
+            id: caffeineIcon
+
+            asynchronous: true
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.right: favouriteIcon.active ? favouriteIcon.left : parent.right
+            anchors.rightMargin: favouriteIcon.active ? Appearance.spacing.smaller : 0
+            active: root.modelData && Config.launcher.caffeineApps.includes(root.modelData.id)
+            sourceComponent: MaterialIcon {
+                text: "emoji_food_beverage"
+                fill: 1
+                color: Colours.palette.m3primary
+            }
+        }
     }
 }

--- a/modules/utilities/cards/IdleInhibit.qml
+++ b/modules/utilities/cards/IdleInhibit.qml
@@ -8,6 +8,8 @@ import qs.config
 StyledRect {
     id: root
 
+    readonly property bool smartCaffeineActive: CaffeineService.active
+
     Layout.fillWidth: true
     implicitHeight: layout.implicitHeight + (IdleInhibitor.enabled ? activeChip.implicitHeight + activeChip.anchors.topMargin : 0) + Appearance.padding.large * 2
 

--- a/services/CaffeineService.qml
+++ b/services/CaffeineService.qml
@@ -1,0 +1,86 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import qs.services
+import qs.config
+
+Singleton {
+    id: root
+
+    property bool active: matchCount > 0 && appPatterns.length > 0
+    property int matchCount: 0
+    property var appPatterns: []
+
+    function updateAppPatterns(): void {
+        if (!Config.launcher.caffeineApps || Config.launcher.caffeineApps.length === 0) {
+            appPatterns = [];
+            return;
+        }
+        const patterns = [];
+        for (const app of Config.launcher.caffeineApps) {
+            const lower = app.toLowerCase();
+            patterns.push({
+                full: lower,
+                dotSuffix: lower.includes('.') ? lower.split('.').pop() : null,
+                dashSuffix: lower.includes('-') ? lower.split('-').pop() : null
+            });
+        }
+        appPatterns = patterns;
+    }
+
+    function matchesAnyPattern(windowClass: string): bool {
+        for (const pattern of appPatterns) {
+            if (windowClass.includes(pattern.full)) {
+                return true;
+            }
+            if (pattern.dotSuffix && windowClass.includes(pattern.dotSuffix)) {
+                return true;
+            }
+            if (pattern.dashSuffix && windowClass.includes(pattern.dashSuffix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    onActiveChanged: IdleInhibitor.enabled = active
+
+    Component.onCompleted: updateAppPatterns()
+
+    Instantiator {
+        id: windowTracker
+
+        model: Hypr.toplevels
+
+        delegate: QtObject {
+            required property var modelData
+
+            readonly property string windowClass: (modelData?.lastIpcObject?.class ?? "").toLowerCase()
+            readonly property bool isValid: modelData !== null && !modelData.closed
+            readonly property bool matches: isValid && root.matchesAnyPattern(windowClass)
+
+            onMatchesChanged: root.matchCount += matches ? 1 : -1
+            Component.onCompleted: {
+                if (matches) {
+                    root.matchCount++;
+                }
+            }
+            Component.onDestruction: {
+                if (matches) {
+                    root.matchCount--;
+                }
+            }
+        }
+    }
+
+    Connections {
+        function onCaffeineAppsChanged(): void {
+            root.matchCount = 0;
+            root.updateAppPatterns();
+        }
+
+        target: Config.launcher
+    }
+}

--- a/services/Notifs.qml
+++ b/services/Notifs.qml
@@ -17,6 +17,8 @@ Singleton {
     property list<NotifData> list: []
     readonly property list<NotifData> notClosed: list.filter(n => !n.closed)
     readonly property list<NotifData> popups: list.filter(n => n.popup)
+    property bool caffeine: IdleInhibitor.enabled
+
     property alias dnd: props.dnd
 
     property bool loaded
@@ -29,6 +31,16 @@ Singleton {
             Toaster.toast(qsTr("Do not disturb enabled"), qsTr("Popup notifications are now disabled"), "do_not_disturb_on");
         else
             Toaster.toast(qsTr("Do not disturb disabled"), qsTr("Popup notifications are now enabled"), "do_not_disturb_off");
+    }
+
+    onCaffeineChanged: {
+        if (!Config.utilities.toasts.caffeineChanged)
+            return;
+
+        if (caffeine)
+            Toaster.toast(qsTr("Caffeine mode enabled"), qsTr("Preventing sleep mode"), "emoji_food_beverage");
+        else
+            Toaster.toast(qsTr("Caffeine mode disabled"), qsTr("Normal power management"), "local_cafe");
     }
 
     onListChanged: {


### PR DESCRIPTION
# Smart awake Feature - Pull Request

## Overview

Implements an automatic idle inhibitor (caffeine mode) that prevents the system from sleeping when specific applications are running. Users can mark applications as "caffeine apps" through the launcher interface, and the system will automatically enable idle inhibition when those apps are active.

## What's New

### ✨ Features

- **Automatic Idle Inhibition**: Mark apps (like video players, games) to automatically prevent sleep when running
- **Persistent Configuration**: Settings saved to `shell.json` and persist across sessions

### 🎯 Use Cases

- Keep system awake during games
- Maintain connection during video calls
- Any app that requires uninterrupted operation

### 📽️ Video

https://github.com/user-attachments/assets/a4e99046-e709-4c5e-beb8-a7ff996fb314

