### PR TITLE
fix(services): debounce now playing toast to show correct track metadata

### DIFF
--- a/services/Players.qml
+++ b/services/Players.qml
@@ -1,7 +1,7 @@
 pragma Singleton
 
-import QtQml
 import QtQuick
+import QtQml
 import Quickshell
 import Quickshell.Io
 import Quickshell.Services.Mpris
@@ -38,6 +38,7 @@ Singleton {
     // D-Bus signal. Waiting a short time ensures the metadata has settled.
     Timer {
         id: nowPlayingTimer
+
         interval: 300
         onTriggered: {
             if (root.active && root.active.trackArtist != "" && root.active.trackTitle != "") {

--- a/services/Players.qml
+++ b/services/Players.qml
@@ -23,9 +23,7 @@ Singleton {
 
     Connections {
         function onPostTrackChanged() {
-            if (!Config.utilities.toasts.nowPlaying) {
-                return;
-            }
+            nowPlayingTimer.pendingPlayer = root.active;
             nowPlayingTimer.restart();
         }
 
@@ -36,17 +34,22 @@ Singleton {
     // Some players (e.g. Spotify) emit postTrackChanged as soon as the track
     // ID changes, before the title/artist properties are updated in a follow-up
     // D-Bus signal. Waiting a short time ensures the metadata has settled.
+    // The player is captured at signal time so that an active player switch
+    // during the debounce window does not show metadata from the wrong player.
     Timer {
         id: nowPlayingTimer
+
+        property MprisPlayer pendingPlayer: null
 
         interval: 300
         onTriggered: {
             if (!Config.utilities.toasts.nowPlaying) {
                 return;
             }
-            if (root.active && root.active.trackArtist != "" && root.active.trackTitle != "") {
-                Toaster.toast(qsTr("Now Playing"), qsTr("%1 - %2").arg(root.active.trackArtist).arg(root.active.trackTitle), "music_note");
+            if (pendingPlayer && pendingPlayer === root.active && pendingPlayer.trackArtist != "" && pendingPlayer.trackTitle != "") {
+                Toaster.toast(qsTr("Now Playing"), qsTr("%1 - %2").arg(pendingPlayer.trackArtist).arg(pendingPlayer.trackTitle), "music_note");
             }
+            pendingPlayer = null;
         }
     }
 

--- a/services/Players.qml
+++ b/services/Players.qml
@@ -1,6 +1,7 @@
 pragma Singleton
 
 import QtQml
+import QtQuick
 import Quickshell
 import Quickshell.Io
 import Quickshell.Services.Mpris
@@ -25,12 +26,24 @@ Singleton {
             if (!Config.utilities.toasts.nowPlaying) {
                 return;
             }
-            if (root.active.trackArtist != "" && root.active.trackTitle != "") {
-                Toaster.toast(qsTr("Now Playing"), qsTr("%1 - %2").arg(root.active.trackArtist).arg(root.active.trackTitle), "music_note");
-            }
+            nowPlayingTimer.restart();
         }
 
         target: root.active
+    }
+
+    // Debounce the now playing toast to avoid showing stale metadata.
+    // Some players (e.g. Spotify) emit postTrackChanged as soon as the track
+    // ID changes, before the title/artist properties are updated in a follow-up
+    // D-Bus signal. Waiting a short time ensures the metadata has settled.
+    Timer {
+        id: nowPlayingTimer
+        interval: 300
+        onTriggered: {
+            if (root.active && root.active.trackArtist != "" && root.active.trackTitle != "") {
+                Toaster.toast(qsTr("Now Playing"), qsTr("%1 - %2").arg(root.active.trackArtist).arg(root.active.trackTitle), "music_note");
+            }
+        }
     }
 
     PersistentProperties {

--- a/services/Players.qml
+++ b/services/Players.qml
@@ -41,6 +41,9 @@ Singleton {
 
         interval: 300
         onTriggered: {
+            if (!Config.utilities.toasts.nowPlaying) {
+                return;
+            }
             if (root.active && root.active.trackArtist != "" && root.active.trackTitle != "") {
                 Toaster.toast(qsTr("Now Playing"), qsTr("%1 - %2").arg(root.active.trackArtist).arg(root.active.trackTitle), "music_note");
             }


### PR DESCRIPTION
## Problem

When pressing next/previous, the now playing toast shows the **previous track** instead of the new one.

## Root cause

Some MPRIS players (notably Spotify and Google Chrome) emit `postTrackChanged` in two D-Bus phases:
1. First signal: `mpris:trackid` updates to the new track, but `xesam:title`/`xesam:artist` still carry the old track's values
2. Second signal: the actual title and artist arrive

`onPostTrackChanged` was firing immediately on phase 1, reading stale metadata and displaying the wrong song in the notification.

## Fix

Defer the toast via a `Timer { interval: 300 }`. The handler now calls `nowPlayingTimer.restart()` instead of showing the toast directly. If `postTrackChanged` fires again within 300ms (the second metadata update), the timer resets — so only one notification fires, after the metadata has settled.