### PR TITLE
weather: wrong time format causing yesterday to show as today in dashboard

### DIFF
--- a/services/Weather.qml
+++ b/services/Weather.qml
@@ -128,7 +128,7 @@ Singleton {
             const forecastList = [];
             for (let i = 0; i < json.daily.time.length; i++)
                 forecastList.push({
-                    date: json.daily.time[i],
+                    date: json.daily.time[i].replace(/-/g, "/"),
                     maxTempC: Math.round(json.daily.temperature_2m_max[i]),
                     maxTempF: Math.round(toFahrenheit(json.daily.temperature_2m_max[i])),
                     minTempC: Math.round(json.daily.temperature_2m_min[i]),
@@ -141,7 +141,8 @@ Singleton {
             const hourlyList = [];
             const now = new Date();
             for (let i = 0; i < json.hourly.time.length; i++) {
-                const time = new Date(json.hourly.time[i]);
+                const time = new Date(json.hourly.time[i].replace("T", " "));
+
                 if (time < now)
                     continue;
 


### PR DESCRIPTION
<img width="355" height="186" alt="image" src="https://github.com/user-attachments/assets/cc2ee0b6-a419-403c-ab97-4ad537be9484" />

As seen in above, the current version of the Weather tab shows yesterday's date as today. The weather date is not from yesterday rather today, so this is mostly a visual bug coming from how Javascript formats dates.

By default dates in YYYY-MM-DD are considered in UTC. This becomes a problem in the WeatherTab.qml file where the visuals are created, as it applies the locale/current timezone of the computer again. 
Ex: today is March 26, so 2026-03-26. This gets converted back to 2026-03-25 20:00:00 (for UTC-4), but this is valid for any sort of timezone.

<img width="270" height="210" alt="image" src="https://github.com/user-attachments/assets/a93d1a9b-8dcd-4e30-a4c5-10043a46dbf8" />
New version should fix it.
Thanks to @B4fl4t on Discord for the fix on line 144 for the hourly forecast.