### PR TITLE
fix: YouTube thumbnail fallback for missing mpris:artUrl

### DIFF
--- a/modules/dashboard/Media.qml
+++ b/modules/dashboard/Media.qml
@@ -181,19 +181,7 @@ Item {
 
             anchors.fill: parent
 
-            source: {
-                const p = Players.active;
-                if (!p) {
-                    return ""; // qmllint disable incompatible-type
-                }
-                if (p.trackArtUrl) {
-                    return p.trackArtUrl;
-                }
-
-                const id = (p.metadata["xesam:url"] || "").match(/[?&]v=([\w-]{11})/)?.[1];
-                return id ? `https://img.youtube.com/vi/${id}/hqdefault.jpg` : "";
-            }
-
+            source: Players.getArtUrl(Players.active)
             asynchronous: true
             fillMode: Image.PreserveAspectCrop
             sourceSize.width: width

--- a/modules/dashboard/dash/Media.qml
+++ b/modules/dashboard/dash/Media.qml
@@ -106,19 +106,7 @@ Item {
 
             anchors.fill: parent
 
-            source: {
-                const p = Players.active;
-                if (!p) {
-                    return ""; // qmllint disable incompatible-type
-                }
-                if (p.trackArtUrl) {
-                    return p.trackArtUrl;
-                }
-
-                const id = (p.metadata["xesam:url"] || "").match(/[?&]v=([\w-]{11})/)?.[1];
-                return id ? `https://img.youtube.com/vi/${id}/hqdefault.jpg` : "";
-            }
-
+            source: Players.getArtUrl(Players.active)
             asynchronous: true
             fillMode: Image.PreserveAspectCrop
             sourceSize.width: width

--- a/modules/lock/Media.qml
+++ b/modules/lock/Media.qml
@@ -18,7 +18,7 @@ Item {
 
     Image {
         anchors.fill: parent
-        source: Players.active?.trackArtUrl ?? "" // qmllint disable incompatible-type
+        source: Players.getArtUrl(Players.active)
 
         asynchronous: true
         fillMode: Image.PreserveAspectCrop

--- a/services/Players.qml
+++ b/services/Players.qml
@@ -20,6 +20,21 @@ Singleton {
         return alias?.to ?? player.identity;
     }
 
+    function getArtUrl(player: MprisPlayer): string {
+        if (!player)
+            return "";
+        if (player.trackArtUrl)
+            return player.trackArtUrl;
+
+        const url = player.metadata["xesam:url"] ?? "";
+        if (url.startsWith("https://www.youtube.com/watch")) {
+            // Fallback for youtube
+            const id = url.match(/[?&]v=([\w-]{11})/)?.[1];
+            return id ? `https://img.youtube.com/vi/${id}/hqdefault.jpg` : "";
+        }
+        return "";
+    }
+
     Connections {
         function onPostTrackChanged() {
             if (!Config.utilities.toasts.nowPlaying) {


### PR DESCRIPTION
# fix: YouTube thumbnail fallback for missing mpris:artUrl

## Problem

Firefox 149.0 no longer provides `mpris:artUrl` in MPRIS metadata when playing Youtube videos, causing the media cover art to show nothing (only the fallback icon).

```
# Firefox 148.0.2 (working)
firefox mpris:artUrl   file:///home/.../.mozilla/firefox/firefox-mpris/9550_0.png

# Firefox 149.0 (broken)
# mpris:artUrl field missing entirely (Youtube)
```
## Screenshots

<img width="275" height="524" alt="Image" src="https://github.com/user-attachments/assets/37cb53f6-dd3c-40c7-ae17-b6c29cf92e9b" />

<img width="333" height="446" alt="Image" src="https://github.com/user-attachments/assets/fd02f3db-d1ea-41f4-9a36-3a8bfa89faae" />

## Solution

Fall back to the YouTube thumbnail API when `trackArtUrl` is empty, using the video ID extracted from `xesam:url`. Other platforms (e.g. Dailymotion) that still provide `mpris:artUrl` are unaffected.