### PR TITLE
notifications: reduce sidebar cost for large groups

### DIFF
--- a/modules/sidebar/Notif.qml
+++ b/modules/sidebar/Notif.qml
@@ -13,6 +13,7 @@ StyledRect {
     required property NotifData modelData
     required property Props props
     required property bool expanded
+    required property bool animationsEnabled
     required property DrawerVisibilities visibilities
 
     readonly property StyledText body: (expandedContent.item as ExpandedBody)?.body ?? null
@@ -42,6 +43,8 @@ StyledRect {
     }
 
     transitions: Transition {
+        enabled: root.animationsEnabled
+
         Anim {
             properties: "margins,width,maximumLineCount"
         }
@@ -82,6 +85,7 @@ StyledRect {
         id: compactBody
 
         shouldBeActive: !root.expanded
+        loadAsynchronously: true
         anchors.top: parent.top
         anchors.left: dummySummary.right
         anchors.right: parent.right
@@ -98,6 +102,7 @@ StyledRect {
         id: timeStr
 
         shouldBeActive: root.expanded
+        loadAsynchronously: true
         anchors.top: parent.top
         anchors.right: parent.right
 
@@ -113,6 +118,9 @@ StyledRect {
         id: expandedContent
 
         shouldBeActive: root.expanded
+        // Load expanded content synchronously so group expansion can start immediately.
+        // Leaving this async makes the parent wait for the loader before its new height is measurable.
+        loadAsynchronously: false
         anchors.top: summary.bottom
         anchors.left: parent.left
         anchors.right: parent.right
@@ -122,6 +130,8 @@ StyledRect {
     }
 
     Behavior on implicitHeight {
+        enabled: root.animationsEnabled
+
         Anim {
             duration: Appearance.anim.durations.expressiveDefaultSpatial
             easing.bezierCurve: Appearance.anim.curves.expressiveDefaultSpatial
@@ -155,12 +165,15 @@ StyledRect {
 
     component WrappedLoader: Loader {
         required property bool shouldBeActive
+        required property bool loadAsynchronously
 
-        asynchronous: true
-        opacity: shouldBeActive ? 1 : 0
+        asynchronous: loadAsynchronously
         active: opacity > 0
+        opacity: shouldBeActive ? 1 : 0
 
         Behavior on opacity {
+            enabled: root.animationsEnabled
+
             Anim {}
         }
     }

--- a/modules/sidebar/NotifDock.qml
+++ b/modules/sidebar/NotifDock.qml
@@ -16,7 +16,7 @@ Item {
 
     required property Props props
     required property DrawerVisibilities visibilities
-    readonly property int notifCount: Notifs.list.reduce((acc, n) => n.closed ? acc : acc + 1, 0)
+    readonly property int notifCount: Notifs.notClosed.length
 
     anchors.fill: parent
     anchors.margins: Appearance.padding.normal
@@ -155,9 +155,11 @@ Item {
         onTriggered: {
             let next = null;
             for (let i = 0; i < notifList.repeater.count; i++) {
-                next = notifList.repeater.itemAt(i);
-                if (!next?.closed) // qmllint disable missing-property
+                const item = notifList.repeater.itemAt(i);
+                if (!item?.closed) { // qmllint disable missing-property
+                    next = item;
                     break;
+                }
             }
             if (next) {
                 next.closeAll(); // qmllint disable missing-property

--- a/modules/sidebar/NotifDockList.qml
+++ b/modules/sidebar/NotifDockList.qml
@@ -15,31 +15,27 @@ Item {
 
     readonly property alias repeater: repeater
     readonly property int spacing: Appearance.spacing.small
-    property bool flag
 
     anchors.left: parent.left
     anchors.right: parent.right
-    implicitHeight: {
-        const item = repeater.itemAt(repeater.count - 1);
-        return item ? item.y + item.implicitHeight : 0;
-    }
+    implicitHeight: groups.implicitHeight
 
-    Repeater {
-        id: repeater
+    Column {
+        id: groups
 
-        model: ScriptModel {
-            values: {
-                const map = new Map();
-                for (const n of Notifs.notClosed)
-                    map.set(n.appName, null);
-                for (const n of Notifs.list)
-                    map.set(n.appName, null);
-                return [...map.keys()];
+        anchors.left: parent.left
+        anchors.right: parent.right
+        spacing: 0
+
+        Repeater {
+            id: repeater
+
+            model: ScriptModel {
+                values: [...Notifs.sidebarGroupKeys]
             }
-            onValuesChanged: root.flagChanged()
-        }
 
-        delegate: NotifGroupDelegate {}
+            delegate: NotifGroupDelegate {}
+        }
     }
 
     component NotifGroupDelegate: MouseArea {
@@ -49,23 +45,11 @@ Item {
         required property string modelData
 
         readonly property bool closed: notifInner.notifCount === 0
-        readonly property alias nonAnimHeight: notifInner.nonAnimHeight
+        readonly property int topSpacing: index > 0 ? root.spacing : 0
         property int startY
 
         function closeAll(): void {
-            for (const n of Notifs.notClosed.filter(n => n.appName === modelData))
-                n.close();
-        }
-
-        y: {
-            root.flag; // Force update
-            let y = 0;
-            for (let i = 0; i < index; i++) {
-                const item = repeater.itemAt(i) as NotifGroupDelegate;
-                if (item && !item.closed)
-                    y += item.nonAnimHeight + root.spacing;
-            }
-            return y;
+            Notifs.closeGroup(modelData);
         }
 
         containmentMask: QtObject {
@@ -76,8 +60,12 @@ Item {
             }
         }
 
-        implicitWidth: root.width
-        implicitHeight: notifInner.implicitHeight
+        width: root.width
+        height: closed ? 0 : notifInner.implicitHeight + topSpacing
+        implicitWidth: width
+        implicitHeight: height
+        opacity: closed ? 0 : 1
+        visible: !closed || opacity > 0
 
         hoverEnabled: true
         cursorShape: pressed ? Qt.ClosedHandCursor : undefined
@@ -109,57 +97,35 @@ Item {
                 closeAll();
         }
 
-        ParallelAnimation {
-            running: true
+        Item {
+            id: gap
 
-            Anim {
-                target: notif
-                property: "opacity"
-                from: 0
-                to: 1
-            }
-            Anim {
-                target: notif
-                property: "scale"
-                from: 0
-                to: 1
-                duration: Appearance.anim.durations.expressiveDefaultSpatial
-                easing.bezierCurve: Appearance.anim.curves.expressiveDefaultSpatial
-            }
-        }
-
-        ParallelAnimation {
-            running: notif.closed
-
-            Anim {
-                target: notif
-                property: "opacity"
-                to: 0
-            }
-            Anim {
-                target: notif
-                property: "scale"
-                to: 0.6
-            }
+            // Keep spacing inside the delegate so Column spacing does not leave holes while groups close.
+            anchors.left: notif.left
+            anchors.right: notif.right
+            anchors.top: notif.top
+            height: notif.topSpacing
         }
 
         NotifGroup {
             id: notifInner
 
+            anchors.left: notif.left
+            anchors.right: notif.right
+            anchors.top: gap.bottom
             modelData: notif.modelData
             props: root.props
             container: root.container
             visibilities: root.visibilities
         }
 
-        Behavior on x {
+        Behavior on opacity {
             Anim {
-                duration: Appearance.anim.durations.expressiveDefaultSpatial
-                easing.bezierCurve: Appearance.anim.curves.expressiveDefaultSpatial
+                duration: Appearance.anim.durations.large
             }
         }
 
-        Behavior on y {
+        Behavior on x {
             Anim {
                 duration: Appearance.anim.durations.expressiveDefaultSpatial
                 easing.bezierCurve: Appearance.anim.curves.expressiveDefaultSpatial

--- a/modules/sidebar/NotifGroup.qml
+++ b/modules/sidebar/NotifGroup.qml
@@ -18,37 +18,13 @@ StyledRect {
     required property Flickable container
     required property DrawerVisibilities visibilities
 
-    readonly property list<var> notifs: Notifs.list.filter(n => n.appName === modelData)
-    readonly property var groupProps: {
-        let count = 0;
-        let img = "";
-        let icon = "";
-        let hasCritical = false;
-        let hasNormal = false;
-        for (const n of notifs) {
-            if (!n.closed) {
-                count++;
-                if (!img && n.image.length > 0)
-                    img = n.image;
-                if (!icon && n.appIcon.length > 0)
-                    icon = n.appIcon;
-                if (n.urgency === NotificationUrgency.Critical)
-                    hasCritical = true;
-                else if (n.urgency === NotificationUrgency.Normal)
-                    hasNormal = true;
-            }
-        }
-        return {
-            count,
-            img,
-            icon,
-            urgency: hasCritical ? NotificationUrgency.Critical : hasNormal ? NotificationUrgency.Normal : NotificationUrgency.Low
-        };
-    }
-    readonly property int notifCount: groupProps.count
-    readonly property string image: groupProps.img
-    readonly property string appIcon: groupProps.icon
-    readonly property int urgency: groupProps.urgency
+    readonly property var groupData: Notifs.sidebarGroups[modelData] ?? null
+    readonly property list<var> notifs: groupData?.notifs ?? []
+    readonly property var latestNotif: groupData?.latestOpen ?? groupData?.latestAny ?? null
+    readonly property int notifCount: groupData?.count ?? 0
+    readonly property string image: groupData?.image ?? ""
+    readonly property string appIcon: groupData?.appIcon ?? ""
+    readonly property int urgency: groupData?.urgency ?? NotificationUrgency.Low
 
     readonly property int nonAnimHeight: {
         const headerHeight = header.implicitHeight + (root.expanded ? Math.round(Appearance.spacing.small / 2) : 0);
@@ -124,7 +100,7 @@ StyledRect {
                 id: materialIconComp
 
                 MaterialIcon {
-                    text: Icons.getNotifIcon(root.notifs[0]?.summary, root.urgency)
+                    text: Icons.getNotifIcon(root.latestNotif?.summary, root.urgency)
                     color: root.urgency === NotificationUrgency.Critical ? Colours.palette.m3onError : root.urgency === NotificationUrgency.Low ? Colours.palette.m3onSurface : Colours.palette.m3onSecondaryContainer
                     font.pointSize: Appearance.font.size.large
                 }
@@ -191,7 +167,7 @@ StyledRect {
 
                 StyledText {
                     animate: true
-                    text: root.notifs.find(n => !n.closed)?.timeStr ?? ""
+                    text: root.latestNotif?.timeStr ?? ""
                     color: Colours.palette.m3outline
                     font.pointSize: Appearance.font.size.small
                 }

--- a/modules/sidebar/NotifGroupList.qml
+++ b/modules/sidebar/NotifGroupList.qml
@@ -16,57 +16,149 @@ Item {
     required property Flickable container
     required property DrawerVisibilities visibilities
 
-    readonly property real nonAnimHeight: {
-        let h = -root.spacing;
-        for (let i = 0; i < repeater.count; i++) {
-            const item = repeater.itemAt(i) as NotifDelegate;
-            if (item && !item.modelData.closed && !item.previewHidden)
-                h += item.nonAnimHeight + root.spacing;
+    readonly property real nonAnimHeight: notifColumn.implicitHeight
+    readonly property int previewCount: Config.notifs.groupPreviewNum + 1
+    readonly property int openNotifCount: root.notifs.filter(notif => !notif.closed).length
+    readonly property int batchSize: 50
+    readonly property real estimatedNotifHeight: Math.max(1, Config.notifs.sizes.image + Appearance.padding.normal * 2)
+    readonly property real animationOverscan: root.container.height * 0.5
+    readonly property int renderWindowSize: Math.max(root.previewCount, Math.ceil((root.container.height + root.animationOverscan) / root.estimatedNotifHeight))
+    readonly property list<var> visibleNotifs: {
+        if (root.previewCount <= 0 && !root.showAllNotifs)
+            return [];
+
+        if (root.showAllNotifs) {
+            const visible = [];
+            let openCount = 0;
+            for (const notif of root.notifs) {
+                if (!notif.closed) {
+                    visible.push(notif);
+                    openCount++;
+                } else if (notif.locks.size > 0) {
+                    // Keep locked closed items around just long enough to finish their close animation.
+                    visible.push(notif);
+                }
+
+                if (openCount >= root.renderCount)
+                    break;
+            }
+            return visible;
         }
-        return h;
+
+        const preview = [];
+        let openCount = 0;
+        for (const notif of root.notifs) {
+            if (!notif.closed) {
+                preview.push(notif);
+                openCount++;
+            } else if (notif.locks.size > 0) {
+                preview.push(notif);
+            }
+
+            if (openCount >= root.previewCount)
+                break;
+        }
+        return preview;
     }
 
     readonly property int spacing: Math.round(Appearance.spacing.small / 2)
     property bool showAllNotifs
-    property bool flag
+    property int renderCount: previewCount
 
     signal requestToggleExpand(expand: bool)
 
+    function shouldLoadMore(): bool {
+        if (!root.expanded || root.renderCount >= root.openNotifCount)
+            return false;
+        const top = root.mapToItem(root.container.contentItem, 0, 0).y;
+        const bottom = root.mapToItem(root.container.contentItem, 0, root.height).y;
+        const minY = root.container.contentY - root.animationOverscan;
+        const maxY = root.container.contentY + root.container.height + root.animationOverscan;
+        return bottom >= minY && top <= maxY && bottom <= maxY;
+    }
+
+    function maybeLoadMore(): void {
+        if (root.shouldLoadMore() && !batchTimer.running)
+            batchTimer.start();
+    }
+
     onExpandedChanged: {
         if (expanded) {
-            clearTimer.stop();
             showAllNotifs = true;
+            renderCount = Math.min(root.openNotifCount, root.renderWindowSize);
+            Qt.callLater(root.maybeLoadMore);
         } else {
-            clearTimer.start();
+            batchTimer.stop();
+            // Collapse back to the preview model immediately so the group shrinks
+            // to its final collapsed height in one step.
+            showAllNotifs = false;
+            renderCount = previewCount;
         }
     }
+
+    onNotifsChanged: {
+        if (!expanded) {
+            showAllNotifs = false;
+            renderCount = previewCount;
+        } else if (renderCount > root.openNotifCount) {
+            renderCount = root.openNotifCount;
+        } else if (expanded) {
+            renderCount = Math.max(renderCount, Math.min(root.openNotifCount, root.renderWindowSize));
+            Qt.callLater(root.maybeLoadMore);
+        }
+    }
+
+    onYChanged: Qt.callLater(root.maybeLoadMore)
 
     Layout.fillWidth: true
     implicitHeight: nonAnimHeight
 
     Timer {
-        id: clearTimer
+        id: batchTimer
 
-        interval: Appearance.anim.durations.normal
-        onTriggered: root.showAllNotifs = false
+        interval: 16
+        repeat: true
+        onTriggered: {
+            // Grow very large groups in batches instead of instantiating the whole list at once.
+            if (!root.shouldLoadMore()) {
+                stop();
+                return;
+            }
+
+            root.renderCount = Math.min(root.openNotifCount, root.renderCount + root.batchSize);
+            if (root.renderCount >= root.openNotifCount)
+                stop();
+        }
     }
 
-    Repeater {
-        id: repeater
+    Column {
+        id: notifColumn
 
-        model: ScriptModel {
-            values: root.showAllNotifs ? root.notifs : root.notifs.slice(0, Config.notifs.groupPreviewNum + 1)
-            onValuesChanged: root.flagChanged()
+        anchors.left: parent.left
+        anchors.right: parent.right
+        spacing: 0
+
+        Repeater {
+            id: repeater
+
+            model: ScriptModel {
+                values: root.visibleNotifs
+            }
+
+            delegate: NotifDelegate {}
         }
-
-        delegate: NotifDelegate {}
     }
 
-    Behavior on implicitHeight {
-        Anim {
-            duration: Appearance.anim.durations.expressiveDefaultSpatial
-            easing.bezierCurve: Appearance.anim.curves.expressiveDefaultSpatial
+    Connections {
+        function onContentYChanged(): void {
+            root.maybeLoadMore();
         }
+
+        function onHeightChanged(): void {
+            root.maybeLoadMore();
+        }
+
+        target: root.container
     }
 
     component NotifDelegate: MouseArea {
@@ -76,29 +168,17 @@ Item {
         required property NotifData modelData
 
         readonly property alias nonAnimHeight: notifInner.nonAnimHeight
-        readonly property bool previewHidden: {
-            if (root.expanded)
-                return false;
-
-            let extraHidden = 0;
-            for (let i = 0; i < index; i++)
-                if (root.notifs[i].closed)
-                    extraHidden++;
-
-            return index >= Config.notifs.groupPreviewNum + extraHidden;
+        readonly property int topSpacing: index > 0 ? root.spacing : 0
+        readonly property bool animationsEnabled: {
+            const pos = notif.mapToItem(root.container.contentItem, 0, 0);
+            const top = pos.y;
+            const itemHeight = Math.max(notif.height, notif.nonAnimHeight);
+            const bottom = top + itemHeight;
+            const minY = root.container.contentY - root.animationOverscan;
+            const maxY = root.container.contentY + root.container.height + root.animationOverscan;
+            return bottom >= minY && top <= maxY;
         }
         property int startY
-
-        y: {
-            root.flag; // Force update
-            let y = 0;
-            for (let i = 0; i < index; i++) {
-                const item = repeater.itemAt(i) as NotifDelegate;
-                if (item && !item.modelData.closed && !item.previewHidden)
-                    y += item.nonAnimHeight + root.spacing;
-            }
-            return y;
-        }
 
         containmentMask: QtObject {
             function contains(p: point): bool {
@@ -108,11 +188,14 @@ Item {
             }
         }
 
-        opacity: previewHidden ? 0 : 1
-        scale: previewHidden ? 0.7 : 1
-
-        implicitWidth: root.width
-        implicitHeight: notifInner.implicitHeight
+        width: root.width
+        // Size the list from the notification's target height so the group can expand
+        // immediately instead of waiting for every child height animation to settle.
+        height: modelData.closed ? 0 : notifInner.nonAnimHeight + topSpacing
+        implicitWidth: width
+        implicitHeight: height
+        opacity: modelData.closed ? 0 : 1
+        visible: !modelData.closed || opacity > 0
 
         hoverEnabled: true
         cursorShape: notifInner.body?.hoveredLink ? Qt.PointingHandCursor : pressed ? Qt.ClosedHandCursor : undefined
@@ -144,68 +227,73 @@ Item {
                 modelData.close();
         }
 
+        onModelDataChanged: {
+            if (modelData?.closed)
+                closeCleanupTimer.start();
+        }
+
         Component.onCompleted: modelData.lock(this)
         Component.onDestruction: modelData.unlock(this)
 
-        ParallelAnimation {
-            Component.onCompleted: running = !notif.previewHidden
+        Connections {
+            function onClosedChanged(): void {
+                if (notif.modelData.closed) {
+                    notif.x = notif.x >= 0 ? notif.width : -notif.width;
+                    if (notif.animationsEnabled)
+                        closeCleanupTimer.restart();
+                    else
+                        notif.modelData.unlock(notif);
+                }
+            }
 
-            Anim {
-                target: notif
-                property: "opacity"
-                from: 0
-                to: 1
-            }
-            Anim {
-                target: notif
-                property: "scale"
-                from: 0.7
-                to: 1
-            }
+            target: notif.modelData
         }
 
-        ParallelAnimation {
-            running: notif.modelData.closed
-            onFinished: notif.modelData.unlock(notif)
+        Timer {
+            id: closeCleanupTimer
 
-            Anim {
-                target: notif
-                property: "opacity"
-                to: 0
-            }
-            Anim {
-                target: notif
-                property: "x"
-                to: notif.x >= 0 ? notif.width : -notif.width
-            }
+            interval: Math.max(Appearance.anim.durations.large, Appearance.anim.durations.expressiveDefaultSpatial)
+            onTriggered: notif.modelData.unlock(notif)
+        }
+
+        Item {
+            id: gap
+
+            // Keep spacing inside the delegate so Column spacing does not leave holes while items close.
+            anchors.left: notif.left
+            anchors.right: notif.right
+            anchors.top: notif.top
+            height: notif.topSpacing
         }
 
         Notif {
             id: notifInner
 
-            anchors.fill: parent
+            anchors.left: notif.left
+            anchors.right: notif.right
+            anchors.top: gap.bottom
             modelData: notif.modelData
             props: root.props
             expanded: root.expanded
+            animationsEnabled: notif.animationsEnabled
             visibilities: root.visibilities
         }
 
-        Behavior on opacity {
-            Anim {}
+        Behavior on height {
+            enabled: notif.animationsEnabled
+
+            Anim {
+                duration: Appearance.anim.durations.large
+            }
         }
 
-        Behavior on scale {
+        Behavior on opacity {
+            enabled: notif.animationsEnabled
+
             Anim {}
         }
 
         Behavior on x {
-            Anim {
-                duration: Appearance.anim.durations.expressiveDefaultSpatial
-                easing.bezierCurve: Appearance.anim.curves.expressiveDefaultSpatial
-            }
-        }
-
-        Behavior on y {
             Anim {
                 duration: Appearance.anim.durations.expressiveDefaultSpatial
                 easing.bezierCurve: Appearance.anim.curves.expressiveDefaultSpatial

--- a/services/NotifData.qml
+++ b/services/NotifData.qml
@@ -188,16 +188,24 @@ QtObject {
 
     function unlock(item: Item): void {
         locks.delete(item);
-        if (closed)
-            close();
+        if (closed) {
+            // qmllint disable missing-property
+            Notifs.scheduleCompactClosed();
+            // qmllint enable missing-property
+        }
     }
 
     function close(): void {
+        popup = false;
         closed = true;
-        if (locks.size === 0 && Notifs.list.includes(this)) {
-            Notifs.list = Notifs.list.filter(n => n !== this);
-            notification?.dismiss();
-            destroy();
+        // qmllint disable missing-property
+        Notifs.scheduleSave();
+        // qmllint enable missing-property
+
+        if (locks.size === 0) {
+            // qmllint disable missing-property
+            Notifs.scheduleCompactClosed();
+            // qmllint enable missing-property
         }
     }
 

--- a/services/Notifs.qml
+++ b/services/Notifs.qml
@@ -17,9 +17,173 @@ Singleton {
     property list<NotifData> list: []
     readonly property list<NotifData> notClosed: list.filter(n => !n.closed)
     readonly property list<NotifData> popups: list.filter(n => n.popup)
+    property list<NotifData> closingSidebarNotifs: []
+    readonly property list<string> sidebarGroupKeys: {
+        const seen = new Set();
+        const keys = [];
+
+        for (const notif of root.notClosed) {
+            if (!seen.has(notif.appName)) {
+                seen.add(notif.appName);
+                keys.push(notif.appName);
+            }
+        }
+
+        for (const notif of root.list) {
+            if (!seen.has(notif.appName)) {
+                seen.add(notif.appName);
+                keys.push(notif.appName);
+            }
+        }
+
+        return keys;
+    }
+    readonly property var sidebarGroups: {
+        const groups = Object.create(null);
+        const closingNotifs = new Set(root.closingSidebarNotifs);
+
+        for (const notif of root.list) {
+            const key = notif.appName;
+            let group = groups[key];
+
+            if (!group) {
+                group = groups[key] = {
+                    appName: key,
+                    count: 0,
+                    notifs: [],
+                    latestOpen: null,
+                    latestAny: notif,
+                    image: "",
+                    appIcon: "",
+                    urgency: NotificationUrgency.Low
+                };
+            }
+
+            // Keep a closing group collapsed in the sidebar until its notifications are cleaned up.
+            if (closingNotifs.has(notif))
+                continue;
+
+            group.notifs.push(notif);
+
+            if (notif.closed)
+                continue;
+
+            if (!group.latestOpen)
+                group.latestOpen = notif;
+
+            group.count++;
+
+            if (!group.image && notif.image.length > 0)
+                group.image = notif.image;
+            if (!group.appIcon && notif.appIcon.length > 0)
+                group.appIcon = notif.appIcon;
+
+            if (notif.urgency === NotificationUrgency.Critical) {
+                group.urgency = NotificationUrgency.Critical;
+            } else if (notif.urgency === NotificationUrgency.Normal && group.urgency !== NotificationUrgency.Critical) {
+                group.urgency = NotificationUrgency.Normal;
+            }
+        }
+
+        return groups;
+    }
     property alias dnd: props.dnd
 
     property bool loaded
+
+    function scheduleSave(): void {
+        if (loaded)
+            saveTimer.restart();
+    }
+
+    function scheduleCompactClosed(): void {
+        compactTimer.restart();
+    }
+
+    function scheduleSidebarCleanup(): void {
+        sidebarCleanupTimer.restart();
+    }
+
+    function beginSidebarClose(targetNotifs: var): void {
+        const closingNotifs = new Set(root.closingSidebarNotifs);
+        const pending = targetNotifs.filter(notif => !closingNotifs.has(notif));
+        if (pending.length === 0)
+            return;
+
+        // Hide the target snapshot first so large group dismissals collapse as one sidebar update.
+        root.closingSidebarNotifs = root.closingSidebarNotifs.concat(pending);
+        scheduleSidebarCleanup();
+    }
+
+    function compactClosed(): void {
+        const remaining = [];
+        const removed = [];
+
+        for (const notif of root.list) {
+            if (notif.closed && notif.locks.size === 0)
+                removed.push(notif);
+            else
+                remaining.push(notif);
+        }
+
+        if (removed.length === 0)
+            return;
+
+        root.list = remaining;
+        const remainingNotifs = new Set(remaining);
+        root.closingSidebarNotifs = root.closingSidebarNotifs.filter(notif => remainingNotifs.has(notif));
+
+        for (const notif of removed) {
+            notif.notification?.dismiss();
+            notif.destroy();
+        }
+    }
+
+    function closeGroup(appName: string): void {
+        const targetNotifs = root.list.filter(notif => !notif.closed && notif.appName === appName);
+        if (targetNotifs.length === 0)
+            return;
+
+        beginSidebarClose(targetNotifs);
+    }
+
+    function processSidebarCleanup(): void {
+        if (root.closingSidebarNotifs.length === 0)
+            return;
+
+        const closingNotifs = new Set(root.closingSidebarNotifs);
+        const remaining = [];
+        const removed = [];
+        const stillClosing = [];
+
+        for (const notif of root.list) {
+            if (!closingNotifs.has(notif)) {
+                remaining.push(notif);
+                continue;
+            }
+
+            notif.popup = false;
+            if (notif.locks.size === 0) {
+                removed.push(notif);
+            } else {
+                notif.closed = true;
+                stillClosing.push(notif);
+                remaining.push(notif);
+            }
+        }
+
+        if (removed.length > 0)
+            root.list = remaining;
+        else if (stillClosing.length > 0)
+            scheduleSave();
+
+        root.closingSidebarNotifs = stillClosing;
+
+        for (const notif of removed) {
+            notif.notification?.dismiss();
+            notif.destroy();
+        }
+    }
 
     onDndChanged: {
         if (!Config.utilities.toasts.dndChanged)
@@ -31,10 +195,7 @@ Singleton {
             Toaster.toast(qsTr("Do not disturb disabled"), qsTr("Popup notifications are now enabled"), "do_not_disturb_off");
     }
 
-    onListChanged: {
-        if (loaded)
-            saveTimer.restart();
-    }
+    onListChanged: scheduleSave()
 
     Timer {
         id: saveTimer
@@ -54,6 +215,20 @@ Singleton {
                     hasActionIcons: n.hasActionIcons,
                     actions: n.actions
                 }))))
+    }
+
+    Timer {
+        id: compactTimer
+
+        interval: 0
+        onTriggered: root.compactClosed()
+    }
+
+    Timer {
+        id: sidebarCleanupTimer
+
+        interval: 0
+        onTriggered: root.processSidebarCleanup()
     }
 
     PersistentProperties {
@@ -111,15 +286,13 @@ Singleton {
         name: "clearNotifs"
         description: "Clear all notifications"
         onPressed: {
-            for (const notif of root.list.slice())
-                notif.close();
+            root.beginSidebarClose(root.list.filter(notif => !notif.closed));
         }
     }
 
     IpcHandler {
         function clear(): void {
-            for (const notif of root.list.slice())
-                notif.close();
+            root.beginSidebarClose(root.list.filter(notif => !notif.closed));
         }
 
         function isDndEnabled(): bool {


### PR DESCRIPTION
Closes #1265.

Improves performance of notification sidebar when expanding/collapsing or dismissing large groups.

## Changes:
- Move group aggregation into `services/Notifs.qml` so that group delegates don't recompute filtered state and derived metadata
- Closing a group now snapshots target notifications, hides the group instantly, and cleans them up after the sidebar is updated, instead of animating every child.
- `Clear all` is routed through the same bulk-close path.
- Group items are rendered incrementally in batches of 50 instead of all at once. 
- Use `Column`-based layout instead of manual per-item positioning
- A few bindings that were repeatedly scanning notification data were replaced with cheaper service-side or precomputed values

## Tested with:

```bash
for i in $(seq 1 1000); do notify-send -a 'Caelestia Perf Test' 'Perf Test' "Notification $i"; done
```

## Before:

https://github.com/user-attachments/assets/871e9603-046c-448f-8b9a-7346ed1290da

## After:

https://github.com/user-attachments/assets/80c91902-010b-4b6a-b212-8180fadebd11
