### PR TITLE
fix: player selector menu and automatic recording

### DIFF
--- a/components/controls/Menu.qml
+++ b/components/controls/Menu.qml
@@ -55,7 +55,6 @@ Elevation {
                         function onClicked(): void {
                             root.itemSelected(item.modelData);
                             root.active = item.modelData;
-                            item.modelData.clicked();
                             root.expanded = false;
                         }
 

--- a/components/controls/SplitButton.qml
+++ b/components/controls/SplitButton.qml
@@ -145,20 +145,16 @@ Row {
         Menu {
             id: menu
 
-            states: State {
-                when: root.menuOnTop
-
-                AnchorChanges {
-                    target: menu
-                    anchors.top: undefined
-                    anchors.bottom: expandBtn.top
-                }
+            property point menuPos: {
+                void (implicitWidth);
+                void (implicitHeight);
+                const p = expandBtn.mapToItem(parent, 0, expandBtn.height);
+                return root.menuOnTop ? Qt.point(p.x, p.y - expandBtn.height - implicitHeight - Appearance.spacing.small) : Qt.point(p.x, p.y + Appearance.spacing.small);
             }
 
-            anchors.top: parent.bottom
-            anchors.right: parent.right
-            anchors.topMargin: Appearance.spacing.small
-            anchors.bottomMargin: Appearance.spacing.small
+            parent: root.Window.contentItem
+            x: menuPos.x + expandBtn.width - implicitWidth
+            y: menuPos.y
         }
     }
 }

--- a/components/controls/SplitButton.qml
+++ b/components/controls/SplitButton.qml
@@ -145,16 +145,20 @@ Row {
         Menu {
             id: menu
 
-            property point menuPos: {
-                void (implicitWidth);
-                void (implicitHeight);
+            property point menuPos: Qt.point(0, 0)
+
+            function updateMenuPos() {
                 const p = expandBtn.mapToItem(parent, 0, expandBtn.height);
-                return root.menuOnTop ? Qt.point(p.x, p.y - expandBtn.height - implicitHeight - Appearance.spacing.small) : Qt.point(p.x, p.y + Appearance.spacing.small);
+                menuPos = root.menuOnTop ? Qt.point(p.x, p.y - expandBtn.height - implicitHeight - Appearance.spacing.small) : Qt.point(p.x, p.y + Appearance.spacing.small);
             }
 
             parent: root.Window.contentItem
             x: menuPos.x + expandBtn.width - implicitWidth
             y: menuPos.y
+
+            onImplicitHeightChanged: updateMenuPos()
+            onImplicitWidthChanged: updateMenuPos()
+            Component.onCompleted: updateMenuPos()
         }
     }
 }

--- a/modules/dashboard/Content.qml
+++ b/modules/dashboard/Content.qml
@@ -21,6 +21,15 @@ Item {
         }
         return false;
     }
+    readonly property bool menuOpen: {
+        repeater.count;
+        for (let i = 0; i < repeater.count; i++) {
+            const loader = repeater.itemAt(i) as Loader;
+            if (loader?.sourceComponent === mediaComponent)
+                return (loader?.item as MediaWrapper)?.menuOpen ?? false;
+        }
+        return false;
+    }
     required property DashboardState dashState
     required property FileDialog facePicker
 

--- a/modules/dashboard/Media.qml
+++ b/modules/dashboard/Media.qml
@@ -24,6 +24,7 @@ Item {
     property bool lyricMenuOpen: false
     property bool lyricsShowing: LyricsService.lyricsVisible && LyricsService.model.count != 0
     property bool lyricsShowingDebounced: false
+    readonly property bool playerSelectorExpanded: playerSelector.expanded
 
     property real playerProgress: {
         const active = Players.active;

--- a/modules/dashboard/MediaWrapper.qml
+++ b/modules/dashboard/MediaWrapper.qml
@@ -3,6 +3,7 @@ import QtQuick
 Item {
     property alias visibilities: media.visibilities
     readonly property alias needsKeyboard: media.needsKeyboard
+    readonly property bool menuOpen: media.playerSelectorExpanded
 
     implicitWidth: media.implicitWidth
     implicitHeight: media.nonAnimHeight

--- a/modules/dashboard/Wrapper.qml
+++ b/modules/dashboard/Wrapper.qml
@@ -29,6 +29,7 @@ Item {
     }
 
     readonly property real nonAnimHeight: state === "visible" ? ((content.item as Content)?.nonAnimHeight ?? 0) : 0
+    readonly property bool menuOpen: (content.item as Content)?.menuOpen ?? false
 
     visible: height > 0
     implicitHeight: 0

--- a/modules/drawers/Interactions.qml
+++ b/modules/drawers/Interactions.qml
@@ -64,23 +64,18 @@ CustomMouseArea {
     onPressed: event => dragStart = Qt.point(event.x, event.y)
     onContainsMouseChanged: {
         if (!containsMouse) {
-            // Only hide if not activated by shortcut
             if (!osdShortcutActive) {
                 visibilities.osd = false;
                 root.panels.osd.hovered = false;
             }
-
-            if (!dashboardShortcutActive)
+            if (!dashboardShortcutActive && !panels.dashboard.menuOpen)
                 visibilities.dashboard = false;
-
-            if (!utilitiesShortcutActive)
+            if (!utilitiesShortcutActive && !panels.utilities.menuOpen)
                 visibilities.utilities = false;
-
             if (!popouts.currentName.startsWith("traymenu") || ((popouts.current as StackView)?.depth ?? 0) <= 1) {
                 popouts.hasCurrent = false;
                 bar.closeTray();
             }
-
             if (Config.bar.showOnHover)
                 bar.isHovered = false;
         }
@@ -196,7 +191,7 @@ CustomMouseArea {
         }
 
         // Show utilities on hover
-        const showUtilities = inBottomPanel(panels.utilities, x, y, true);
+        const showUtilities = inBottomPanel(panels.utilities, x, y) || panels.utilities.menuOpen;
 
         // Always update visibility based on hover if not in shortcut mode
         if (!utilitiesShortcutActive) {

--- a/modules/utilities/Content.qml
+++ b/modules/utilities/Content.qml
@@ -11,6 +11,7 @@ Item {
     required property var props
     required property DrawerVisibilities visibilities
     required property BarPopouts.Wrapper popouts
+    readonly property bool menuOpen: record.menuOpen
 
     implicitWidth: layout.implicitWidth
     implicitHeight: layout.implicitHeight
@@ -24,6 +25,8 @@ Item {
         IdleInhibit {}
 
         Record {
+            id: record
+
             props: root.props
             visibilities: root.visibilities
             z: 1

--- a/modules/utilities/Wrapper.qml
+++ b/modules/utilities/Wrapper.qml
@@ -21,6 +21,7 @@ Item {
         reloadableId: "utilities"
     }
     readonly property bool shouldBeActive: visibilities.sidebar || (visibilities.utilities && Config.utilities.enabled && !(visibilities.session && Config.session.enabled))
+    readonly property bool menuOpen: (content.item as Content)?.menuOpen ?? false
 
     visible: height > 0
     implicitHeight: 0

--- a/modules/utilities/cards/Record.qml
+++ b/modules/utilities/cards/Record.qml
@@ -12,6 +12,7 @@ StyledRect {
 
     required property var props
     required property DrawerVisibilities visibilities
+    readonly property bool menuOpen: splitButton.expanded
 
     Layout.fillWidth: true
     implicitHeight: layout.implicitHeight + layout.anchors.margins * 2
@@ -73,6 +74,8 @@ StyledRect {
             }
 
             SplitButton {
+                id: splitButton
+
                 disabled: Recorder.running
                 active: menuItems.find(m => root.props.recordingMode === m.icon + m.text) ?? menuItems[0]
                 menu.onItemSelected: item => root.props.recordingMode = item.icon + item.text


### PR DESCRIPTION
# fix: player selector unclickable and screen recorder menu automatic recording without click

## Problem

The player selector dropdown in the media dashboard opened but clicking items did nothing  the active player never changed.

While fixing this, the same underlying issue was found in the screen recorder mode selector in the utilities panel.


## Root Cause

Both menus were being clipped by a `ClippingRectangle` in their respective panel layouts, so mouse events never reached the menu items. Since there's no native overlay/popup system in Quickshell, the only fix was to reparent the `Menu` to `Window.contentItem`.

However, reparenting meant the menu renders outside the hover detection area in `Interactions.qml`, causing panels to close when hovering over the open menu.

## Fix

- Reparented `SplitButton`'s `Menu` to `Window.contentItem` and computed its position manually via `mapToItem` to escape parent clipping.
- Added `menuOpen` guards in `Interactions.qml` so panels don't close while a menu is open, propagating the state up through the component hierarchy for both dashboard and utilities.

## Video

https://github.com/user-attachments/assets/1819e26f-1360-4e58-9c28-200977e77d52


fixed #1351