### PR TITLE
feat: Improve Desktop Clock Inverted Colours

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,8 @@ For example, to disable the bar on DP-1:
                 "opacity": 0.7,
                 "blur": true
             },
-            "invertColors": false
+            "invertColors": false,
+            "invertLightOnly": false
         },
         "enabled": true,
         "visualiser": {

--- a/modules/background/DesktopClock.qml
+++ b/modules/background/DesktopClock.qml
@@ -18,7 +18,9 @@ Item {
     readonly property bool bgEnabled: Config.background.desktopClock.background.enabled
     readonly property bool blurEnabled: bgEnabled && Config.background.desktopClock.background.blur && !GameMode.enabled
     readonly property bool invertColors: Config.background.desktopClock.invertColors
-    readonly property bool useLightSet: Colours.light ? !invertColors : invertColors
+    readonly property bool invertLightOnly: Config.background.desktopClock.invertLightOnly
+    readonly property bool effectiveInvert: invertColors && (invertLightOnly ? Colours.light : true)
+    readonly property bool useLightSet: Colours.light ? !effectiveInvert : effectiveInvert
     readonly property color safePrimary: useLightSet ? Colours.palette.m3primaryContainer : Colours.palette.m3primary
     readonly property color safeSecondary: useLightSet ? Colours.palette.m3secondaryContainer : Colours.palette.m3secondary
     readonly property color safeTertiary: useLightSet ? Colours.palette.m3tertiaryContainer : Colours.palette.m3tertiary

--- a/modules/controlcenter/appearance/AppearancePane.qml
+++ b/modules/controlcenter/appearance/AppearancePane.qml
@@ -47,6 +47,7 @@ Item {
     property real desktopClockBackgroundOpacity: Config.background.desktopClock.background.opacity ?? 0.7
     property bool desktopClockBackgroundBlur: Config.background.desktopClock.background.blur ?? false
     property bool desktopClockInvertColors: Config.background.desktopClock.invertColors ?? false
+    property bool desktopClockInvertLightOnly: Config.background.desktopClock.invertLightOnly ?? false
     property bool backgroundEnabled: Config.background.enabled ?? true
     property bool wallpaperEnabled: Config.background.wallpaperEnabled ?? true
     property bool visualiserEnabled: Config.background.visualiser.enabled ?? false
@@ -81,6 +82,7 @@ Item {
         GlobalConfig.background.desktopClock.background.opacity = root.desktopClockBackgroundOpacity;
         GlobalConfig.background.desktopClock.background.blur = root.desktopClockBackgroundBlur;
         GlobalConfig.background.desktopClock.invertColors = root.desktopClockInvertColors;
+        GlobalConfig.background.desktopClock.invertLightOnly = root.desktopClockInvertLightOnly;
 
         GlobalConfig.background.wallpaperEnabled = root.wallpaperEnabled;
 

--- a/modules/controlcenter/appearance/sections/BackgroundSection.qml
+++ b/modules/controlcenter/appearance/sections/BackgroundSection.qml
@@ -151,6 +151,18 @@ CollapsibleSection {
         checked: rootPane.desktopClockInvertColors
         onToggled: checked => {
             rootPane.desktopClockInvertColors = checked;
+            if (!checked)
+                rootPane.desktopClockInvertLightOnly = false;
+            rootPane.saveConfig();
+        }
+    }
+
+    SwitchRow {
+        label: qsTr("Invert light only")
+        enabled: rootPane.desktopClockInvertColors
+        checked: rootPane.desktopClockInvertLightOnly
+        onToggled: checked => {
+            rootPane.desktopClockInvertLightOnly = checked;
             rootPane.saveConfig();
         }
     }

--- a/plugin/src/Caelestia/Config/backgroundconfig.hpp
+++ b/plugin/src/Caelestia/Config/backgroundconfig.hpp
@@ -40,6 +40,7 @@ class DesktopClock : public ConfigObject {
     CONFIG_PROPERTY(qreal, scale, 1.0)
     CONFIG_PROPERTY(QString, position, QStringLiteral("bottom-right"))
     CONFIG_PROPERTY(bool, invertColors, false)
+    CONFIG_PROPERTY(bool, invertLightOnly, false)
     CONFIG_SUBOBJECT(DesktopClockBackground, background)
     CONFIG_SUBOBJECT(DesktopClockShadow, shadow)
 


### PR DESCRIPTION
Allow to invert Desktop Clock color when only using light theme.
Helps improve clarity, because default colors from light scheme are washed up, and can still use the normal colors with dark scheme. 

**Before:**
<img width="1918" height="1078" alt="image" src="https://github.com/user-attachments/assets/4a173705-d8d4-430f-b28d-062b85224324" />

**After:**
<img width="1917" height="1078" alt="image" src="https://github.com/user-attachments/assets/f7535384-afa4-43db-9a2f-0e8612b371fe" />

Showcase:
<video src="https://github.com/user-attachments/assets/7ef81c02-adb7-430c-b6c9-6f78ba38e16b" controls="controls" style="max-width: 100%;">
</video>


Todos:
- [x] update README
- [x] update Config