### PR TITLE
feat: gif support for profile picture

### DIFF
--- a/components/filedialog/FileDialog.qml
+++ b/components/filedialog/FileDialog.qml
@@ -37,7 +37,8 @@ LazyLoader {
 
         readonly property bool selectionValid: {
             const file = folderContents.currentItem?.modelData;
-            return (file && !file.isDir && (filters.includes("*") || filters.includes(file.suffix))) ?? false;
+            const suffix = file?.suffix.toLowerCase();
+            return (file && !file.isDir && (filters.includes("*") || filters.some(f => f.toLowerCase() === suffix))) ?? false;
         }
 
         function accepted(path: string): void {

--- a/components/images/ProfileImage.qml
+++ b/components/images/ProfileImage.qml
@@ -1,0 +1,53 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Caelestia
+
+Item {
+    id: root
+
+    property string path
+    property int _reloadToken
+    readonly property string _format: {
+        _reloadToken;
+        return CUtils.imageFormat(path);
+    }
+
+    readonly property int status: loader.item?.status ?? Image.Null // qmllint disable missing-property
+
+    function reload(): void {
+        _reloadToken++;
+        loader.active = false;
+        loader.active = true;
+    }
+
+    Loader {
+        id: loader
+
+        anchors.fill: parent
+        sourceComponent: root._format === "gif" ? animatedComponent : cachingComponent
+    }
+
+    Component {
+        id: animatedComponent
+
+        AnimatedImage {
+            anchors.fill: parent
+            fillMode: AnimatedImage.PreserveAspectCrop
+            asynchronous: true
+            cache: false
+            playing: true
+            source: Qt.resolvedUrl(root.path)
+        }
+    }
+
+    Component {
+        id: cachingComponent
+
+        CachingImage {
+            anchors.fill: parent
+            cache: false
+            path: root.path
+        }
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -30,13 +30,23 @@
       nixpkgs.lib.genAttrs nixpkgs.lib.platforms.linux (
         system: fn nixpkgs.legacyPackages.${system}
       );
+    sourceRev =
+      if self ? rev
+      then self.rev
+      else if self ? dirtyRev
+      then self.dirtyRev
+      else if self ? shortRev
+      then self.shortRev
+      else if self ? lastModifiedDate
+      then self.lastModifiedDate
+      else "unknown";
   in {
     formatter = forAllSystems (pkgs: pkgs.alejandra);
 
     packages = forAllSystems (pkgs: rec {
       caelestia-shell = pkgs.callPackage ./nix {
         inherit (inputs) m3shapes;
-        rev = self.rev or self.dirtyRev;
+        rev = sourceRev;
         stdenv = pkgs.clangStdenv;
         quickshell = inputs.quickshell.packages.${pkgs.stdenv.hostPlatform.system}.default.override {
           withX11 = false;

--- a/modules/dashboard/Wrapper.qml
+++ b/modules/dashboard/Wrapper.qml
@@ -18,7 +18,7 @@ Item {
     readonly property FileDialog facePicker: FileDialog {
         title: qsTr("Select a profile picture")
         filterLabel: qsTr("Image files")
-        filters: Images.validImageExtensions
+        filters: Images.validProfileImageExtensions
         onAccepted: path => {
             if (CUtils.copyFile(Qt.resolvedUrl(path), Qt.resolvedUrl(`${Paths.home}/.face`)))
                 Quickshell.execDetached(["notify-send", "-a", "caelestia-shell", "-u", "low", "-h", `STRING:image-path:${path}`, "Profile picture changed", `Profile picture changed to ${Paths.shortenHome(path)}`]);

--- a/modules/dashboard/dash/User.qml
+++ b/modules/dashboard/dash/User.qml
@@ -84,7 +84,7 @@ Item {
                 }
             }
 
-            CachingImage {
+            ProfileImage {
                 id: pfp
 
                 anchors.fill: parent
@@ -128,6 +128,14 @@ Item {
                     }
                 }
             }
+        }
+
+        Connections {
+            function onAccepted(): void {
+                Qt.callLater(pfp.reload);
+            }
+
+            target: root.facePicker
         }
     }
 

--- a/modules/lock/center/ProfilePic.qml
+++ b/modules/lock/center/ProfilePic.qml
@@ -42,7 +42,7 @@ Item {
         visible: pfp.status !== Image.Ready
     }
 
-    CachingImage {
+    ProfileImage {
         id: pfp
 
         anchors.fill: shape

--- a/plugin/src/Caelestia/cutils.cpp
+++ b/plugin/src/Caelestia/cutils.cpp
@@ -6,6 +6,7 @@
 #include <qdir.h>
 #include <qfileinfo.h>
 #include <qfuturewatcher.h>
+#include <qimagereader.h>
 #include <qloggingcategory.h>
 #include <qqmlengine.h>
 
@@ -136,6 +137,19 @@ QString CUtils::toLocalFile(const QUrl& url) {
     }
 
     return url.toLocalFile();
+}
+
+QString CUtils::imageFormat(const QUrl& url) {
+    if (!url.isLocalFile()) {
+        qCWarning(lcCUtils) << "imageFormat: url" << url << "is not a local file";
+        return QString();
+    }
+
+    return imageFormat(url.toLocalFile());
+}
+
+QString CUtils::imageFormat(const QString& path) {
+    return QString::fromLatin1(QImageReader::imageFormat(path));
 }
 
 qreal CUtils::clamp(qreal value, qreal min, qreal max) {

--- a/plugin/src/Caelestia/cutils.hpp
+++ b/plugin/src/Caelestia/cutils.hpp
@@ -27,6 +27,8 @@ public:
     Q_INVOKABLE static bool copyFile(const QUrl& source, const QUrl& target, bool overwrite = true);
     Q_INVOKABLE static bool deleteFile(const QUrl& path);
     Q_INVOKABLE static QString toLocalFile(const QUrl& url);
+    Q_INVOKABLE static QString imageFormat(const QUrl& url);
+    Q_INVOKABLE static QString imageFormat(const QString& path);
 
     Q_INVOKABLE static qreal clamp(qreal value, qreal min, qreal max);
 

--- a/utils/Images.qml
+++ b/utils/Images.qml
@@ -5,8 +5,16 @@ import Quickshell
 Singleton {
     readonly property list<string> validImageTypes: ["jpeg", "png", "webp", "tiff", "svg"]
     readonly property list<string> validImageExtensions: ["jpg", "jpeg", "png", "webp", "tif", "tiff", "svg"]
+    readonly property list<string> validProfileImageTypes: validImageTypes.concat(["gif"])
+    readonly property list<string> validProfileImageExtensions: validImageExtensions.concat(["gif"])
 
     function isValidImageByName(name: string): bool {
-        return validImageExtensions.some(t => name.endsWith(`.${t}`));
+        const lowerName = name.toLowerCase();
+        return validImageExtensions.some(t => lowerName.endsWith(`.${t}`));
+    }
+
+    function isValidProfileImageByName(name: string): bool {
+        const lowerName = name.toLowerCase();
+        return validProfileImageExtensions.some(t => lowerName.endsWith(`.${t}`));
     }
 }


### PR DESCRIPTION
## Summary
- Add animated GIF support for profile pictures (`~/.face`)
- New `ProfileImage` component that detects image format via magic bytes (`QImageReader`) and switches between `AnimatedImage` (GIF) and `CachingImage` (static)
- GIF added to file picker filter so users can select `.gif` files directly

## Changes
- `CUtils::imageFormat()` — new C++ method for format detection without file extension
- `components/images/ProfileImage.qml` — Loader-based component switching between animated/static rendering
- Updated `User.qml` (dashboard) and `Center.qml` (lock screen) to use `ProfileImage`
- Added `gif` to valid image types in `Images.qml`

https://github.com/user-attachments/assets/f60de980-21b1-4ce2-9a3b-6e74719d5563

> Purple squares are an unrelated icon loading issue, not caused by this PR.