### PR TITLE
nix: fix material symbols font

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -34,7 +34,13 @@
   extraRuntimeDeps ? [],
 }: let
   version = "1.0.0";
-
+  material-symbols-fix = material-symbols.overrideAttrs (attrs: {
+    postInstall = ''
+      ln -sf "$out/share/fonts/TTF/MaterialSymbolsRounded.ttf" "$out/share/fonts/TTF/MaterialSymbolsRounded[FILL,GRAD,opsz,wght].ttf"
+      ln -sf "$out/share/fonts/TTF/MaterialSymbolsOutlined.ttf" "$out/share/fonts/TTF/MaterialSymbolsOutlined[FILL,GRAD,opsz,wght].ttf"
+      ln -sf "$out/share/fonts/TTF/MaterialSymbolsSharp.ttf" "$out/share/fonts/TTF/MaterialSymbolsSharp[FILL,GRAD,opsz,wght].ttf"
+    '';
+  });
   runtimeDeps =
     [
       fish
@@ -48,12 +54,13 @@
       libqalculate
       bash
       hyprland
+      material-symbols-fix
     ]
     ++ extraRuntimeDeps
     ++ lib.optional withCli caelestia-cli;
 
   fontconfig = makeFontsConf {
-    fontDirectories = [material-symbols rubik nerd-fonts.caskaydia-cove];
+    fontDirectories = [material-symbols-fix rubik nerd-fonts.caskaydia-cove];
   };
 
   cmakeBuildType =


### PR DESCRIPTION
# Fix the material symbols font on nixOS
Fixes #1315 

## Problem

On NixOS, the dashboard can freeze for 1–3 seconds when opening or switching tabs
This happens because of a issue with the Material Symbols font file names

## Fix
At post-install, create symlinks with font names that include `[FILL,GRAD,opsz,wght]`, and include the font in the runtimeDeps

---
This also speedup the config loading on my laptop from ~3150ms to ~800ms