### PR TITLE
fix: preserve VPN interface and command fields

### DIFF
--- a/config/Config.qml
+++ b/config/Config.qml
@@ -326,7 +326,7 @@ Singleton {
             const provider = {
                 displayName: p.displayName,
                 enabled: p.enabled,
-                interface: p.iface,
+                interface: p.interface,
                 name: p.name
             };
             if (p.connectCmd && p.connectCmd.length > 0) {

--- a/modules/controlcenter/network/VpnDetails.qml
+++ b/modules/controlcenter/network/VpnDetails.qml
@@ -72,6 +72,13 @@ DeviceDetails {
                                         newProvider.enabled = (i === index) ? false : (p.enabled !== false);
                                     }
 
+                                    if (p.connectCmd && p.connectCmd.length > 0) {
+                                        newProvider.connectCmd = p.connectCmd;
+                                    }
+                                    if (p.disconnectCmd && p.disconnectCmd.length > 0) {
+                                        newProvider.disconnectCmd = p.disconnectCmd;
+                                    }
+
                                     providers.push(newProvider);
                                 } else {
                                     providers.push(p);
@@ -504,21 +511,31 @@ DeviceDetails {
                                 const newProvider = {
                                     displayName: editVpnDialog.displayName || editVpnDialog.interfaceName,
                                     enabled: wasEnabled,
-                                    iface: editVpnDialog.interfaceName,
-                                    name: editVpnDialog.providerName,
-                                    connectCmd: hasCommands ? editVpnDialog.connectCmd.split(" ").filter(s => s.length > 0) : undefined,
-                                    disconnectCmd: hasCommands ? editVpnDialog.disconnectCmd.split(" ").filter(s => s.length > 0) : undefined
+                                    interface: editVpnDialog.interfaceName,
+                                    name: editVpnDialog.providerName
                                 };
 
-                                // Remove undefined properties
-                                if (!hasCommands) {
-                                    delete newProvider.connectCmd;
-                                    delete newProvider.disconnectCmd;
+                                if (hasCommands) {
+                                    newProvider.connectCmd = editVpnDialog.connectCmd.split(" ").filter(s => s.length > 0);
+                                    newProvider.disconnectCmd = editVpnDialog.disconnectCmd.split(" ").filter(s => s.length > 0);
                                 }
 
                                 providers.push(newProvider);
                             } else {
-                                providers.push(Config.utilities.vpn.provider[i]);
+                                const p = Config.utilities.vpn.provider[i];
+                                const reconstructed = {
+                                    displayName: p.displayName,
+                                    enabled: p.enabled,
+                                    interface: p.interface,
+                                    name: p.name
+                                };
+                                if (p.connectCmd && p.connectCmd.length > 0) {
+                                    reconstructed.connectCmd = p.connectCmd;
+                                }
+                                if (p.disconnectCmd && p.disconnectCmd.length > 0) {
+                                    reconstructed.disconnectCmd = p.disconnectCmd;
+                                }
+                                providers.push(reconstructed);
                             }
                         }
 

--- a/modules/controlcenter/network/VpnList.qml
+++ b/modules/controlcenter/network/VpnList.qml
@@ -36,6 +36,12 @@ ColumnLayout {
                             interface: p.interface,
                             enabled: (i === targetIndex)
                         };
+                        if (p.connectCmd && p.connectCmd.length > 0) {
+                            newProvider.connectCmd = p.connectCmd;
+                        }
+                        if (p.disconnectCmd && p.disconnectCmd.length > 0) {
+                            newProvider.disconnectCmd = p.disconnectCmd;
+                        }
                         providers.push(newProvider);
                     } else {
                         providers.push(p);
@@ -226,6 +232,12 @@ ColumnLayout {
                                                     interface: p.interface,
                                                     enabled: (i === clickedIndex)
                                                 };
+                                                if (p.connectCmd && p.connectCmd.length > 0) {
+                                                    newProvider.connectCmd = p.connectCmd;
+                                                }
+                                                if (p.disconnectCmd && p.disconnectCmd.length > 0) {
+                                                    newProvider.disconnectCmd = p.disconnectCmd;
+                                                }
                                                 providers.push(newProvider);
                                             } else {
                                                 providers.push(p);
@@ -265,7 +277,20 @@ ColumnLayout {
                                 const providers = [];
                                 for (let i = 0; i < Config.utilities.vpn.provider.length; i++) {
                                     if (i !== modelData.index) {
-                                        providers.push(Config.utilities.vpn.provider[i]);
+                                        const p = Config.utilities.vpn.provider[i];
+                                        const reconstructed = {
+                                            name: p.name,
+                                            displayName: p.displayName,
+                                            interface: p.interface,
+                                            enabled: p.enabled
+                                        };
+                                        if (p.connectCmd && p.connectCmd.length > 0) {
+                                            reconstructed.connectCmd = p.connectCmd;
+                                        }
+                                        if (p.disconnectCmd && p.disconnectCmd.length > 0) {
+                                            reconstructed.disconnectCmd = p.disconnectCmd;
+                                        }
+                                        providers.push(reconstructed);
                                     }
                                 }
                                 Config.utilities.vpn.provider = providers;

--- a/modules/controlcenter/network/VpnSettings.qml
+++ b/modules/controlcenter/network/VpnSettings.qml
@@ -119,30 +119,62 @@ ColumnLayout {
                             icon: modelData.isActive ? "arrow_downward" : "arrow_upward"
                             visible: !modelData.isActive || Config.utilities.vpn.provider.length > 1
                             onClicked: {
-                                if (modelData.isActive && index < Config.utilities.vpn.provider.length - 1) {
+                                const providers = [];
+                                for (let i = 0; i < Config.utilities.vpn.provider.length; i++) {
+                                    const p = Config.utilities.vpn.provider[i];
+                                    const reconstructed = {
+                                        name: p.name,
+                                        displayName: p.displayName,
+                                        interface: p.interface,
+                                        enabled: p.enabled
+                                    };
+                                    if (p.connectCmd && p.connectCmd.length > 0) {
+                                        reconstructed.connectCmd = p.connectCmd;
+                                    }
+                                    if (p.disconnectCmd && p.disconnectCmd.length > 0) {
+                                        reconstructed.disconnectCmd = p.disconnectCmd;
+                                    }
+                                    providers.push(reconstructed);
+                                }
+
+                                if (modelData.isActive && index < providers.length - 1) {
                                     // Move down
-                                    const providers = [...Config.utilities.vpn.provider];
                                     const temp = providers[index];
                                     providers[index] = providers[index + 1];
                                     providers[index + 1] = temp;
-                                    Config.utilities.vpn.provider = providers;
-                                    Config.save();
                                 } else if (!modelData.isActive) {
                                     // Make active (move to top)
-                                    const providers = [...Config.utilities.vpn.provider];
                                     const provider = providers.splice(index, 1)[0];
                                     providers.unshift(provider);
-                                    Config.utilities.vpn.provider = providers;
-                                    Config.save();
                                 }
+
+                                Config.utilities.vpn.provider = providers;
+                                Config.save();
                             }
                         }
 
                         IconButton {
                             icon: "delete"
                             onClicked: {
-                                const providers = [...Config.utilities.vpn.provider];
-                                providers.splice(index, 1);
+                                const providers = [];
+                                for (let i = 0; i < Config.utilities.vpn.provider.length; i++) {
+                                    if (i !== index) {
+                                        const p = Config.utilities.vpn.provider[i];
+                                        const reconstructed = {
+                                            name: p.name,
+                                            displayName: p.displayName,
+                                            interface: p.interface,
+                                            enabled: p.enabled
+                                        };
+                                        if (p.connectCmd && p.connectCmd.length > 0) {
+                                            reconstructed.connectCmd = p.connectCmd;
+                                        }
+                                        if (p.disconnectCmd && p.disconnectCmd.length > 0) {
+                                            reconstructed.disconnectCmd = p.disconnectCmd;
+                                        }
+                                        providers.push(reconstructed);
+                                    }
+                                }
                                 Config.utilities.vpn.provider = providers;
                                 Config.save();
                             }


### PR DESCRIPTION
Changing a VPN would reset the fields like interface or cmd's for other entries, and miss in prior PR caused a mismatch due to the VPNDetails.