### PR TITLE
Media Player: position display fix

### DIFF
--- a/modules/dashboard/Media.qml
+++ b/modules/dashboard/Media.qml
@@ -354,7 +354,7 @@ Item {
 
                 anchors.left: parent.left
 
-                text: root.lengthStr(Players.active?.position % Players.active?.length ?? -1)
+                text: root.lengthStr(Players.active ? Players.active.position % Players.active.length : -1)
                 color: Colours.palette.m3onSurfaceVariant
                 font.pointSize: Tokens.font.size.small
             }

--- a/modules/dashboard/Media.qml
+++ b/modules/dashboard/Media.qml
@@ -27,7 +27,7 @@ Item {
 
     property real playerProgress: {
         const active = Players.active;
-        return active?.length ? active.position / active.length : 0;
+        return active?.length ? (active.position % active.length) / active.length : 0;
     }
 
     function lengthStr(length: int): string {
@@ -354,7 +354,7 @@ Item {
 
                 anchors.left: parent.left
 
-                text: root.lengthStr(Players.active?.position ?? -1)
+                text: root.lengthStr(Players.active?.position % Players.active?.length ?? -1)
                 color: Colours.palette.m3onSurfaceVariant
                 font.pointSize: Tokens.font.size.small
             }

--- a/modules/dashboard/dash/Media.qml
+++ b/modules/dashboard/dash/Media.qml
@@ -11,7 +11,7 @@ Item {
 
     property real playerProgress: {
         const active = Players.active;
-        return active?.length ? active.position / active.length : 0;
+        return active?.length ? (active.position % active.length) / active.length : 0;
     }
 
     anchors.top: parent.top


### PR DESCRIPTION
By default the position keeps on being updated by the timer. If the value goes beyond the maximum length of the track it just displays weirdly in the dashboard
<img width="452" height="250" alt="image" src="https://github.com/user-attachments/assets/8baa3c11-696f-4a41-b1d6-5df47f500c38" />
<img width="286" height="441" alt="image" src="https://github.com/user-attachments/assets/2a235663-9c61-44cd-8a86-7534edc00792" />
This happens when looping a single song, as looping a playlist doesn't have this effect, you effectively change tracks and the position resets to 0.

This PR should fix the display part only. I didn't want to play around with changing how the timer gets updated so this is a safe way to visually update the bars.