### PR TITLE
ci: add a stable banch that tracks the latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,8 @@ jobs:
             caelestia-shell-${{ github.ref_name }}.tar.gz
             caelestia-shell-latest.tar.gz
           generate_release_notes: true
+      
+      - name: Move stable branch to this release
+        run: |
+          git branch -f stable "$GITHUB_SHA"
+          git push origin stable --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
             caelestia-shell-latest.tar.gz
           generate_release_notes: true
       
-      - name: Move stable branch to this release
+      - name: Update stable branch
         run: |
           git branch -f stable "$GITHUB_SHA"
           git push origin stable --force


### PR DESCRIPTION
## Summary

Add automatic updates for a `stable` branch during releases.

When a new version tag matching `v*` is pushed, the release workflow will now move the `stable` branch to the same commit as that tag. This makes `stable` always point to the latest released version.

## Why

Nix flake refs do not support a special `latest` keyword for “latest release” or “latest tag”. A ref like `?ref=latest` only works if a branch or tag named `latest` actually exists.

By maintaining a moving `stable` branch, consumers can use a predictable flake input such as:

```nix
github:caelestia-dots/shell/stable
```

This provides a simple, stable reference that tracks the newest published release.

## Changes

- Keep the existing release workflow triggered on `v*` tags
- After creating the GitHub release, force-update the `stable` branch to the tagged commit
- Preserve the existing release tarball generation and upload behavior

## Result

After this change:

- pushing `v1.2.3` creates the release as before
- `stable` is moved to the commit for `v1.2.3`
- downstream users can follow the latest release via the `stable` branch

## Notes

- `stable` is intentionally a moving branch
- this branch should not be protected from force-pushes by GitHub Actions
- no new commits are created; the workflow only updates the branch ref