### PR TITLE
feat: blob deformation config

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,8 @@ For example, to disable the bar on DP-1:
     "border": {
         "rounding": 25,
         "smoothing": 32,
-        "thickness": 10
+        "thickness": 10,
+        "blobDeformation": true
     },
     "dashboard": {
         "enabled": true,

--- a/modules/drawers/ContentWindow.qml
+++ b/modules/drawers/ContentWindow.qml
@@ -303,6 +303,6 @@ StyledWindow {
         implicitWidth: panel.width
         implicitHeight: panel.height
         radius: Tokens.rounding.large
-        deformScale: deformAmount / 10000
+        deformScale: Config.border.blobDeformation ? deformAmount / 10000 : 0
     }
 }

--- a/plugin/src/Caelestia/Config/borderconfig.hpp
+++ b/plugin/src/Caelestia/Config/borderconfig.hpp
@@ -13,6 +13,7 @@ class BorderConfig : public ConfigObject {
     CONFIG_PROPERTY(int, thickness, 10)
     CONFIG_PROPERTY(int, rounding, 25)
     CONFIG_PROPERTY(int, smoothing, 32)
+    CONFIG_PROPERTY(bool, blobDeformation, true)
 
     Q_PROPERTY(int minThickness READ minThickness CONSTANT)
     Q_PROPERTY(int clampedThickness READ clampedThickness NOTIFY thicknessChanged)


### PR DESCRIPTION
After updating, I found that the Dashboard and Launcher has new spring deformation effect, but I personally think this is annoying, so I made this PR.

## Summary
Add `border.blobDeformation` (default: true) to toggle the underdamped spring deformation effect on panel backgrounds. When disabled, panels slide in/out without the jelly-like bounce animation.

## Showcase
`border.blobDeformation: true`(before)

https://github.com/user-attachments/assets/47208bec-6796-4af5-bd69-de69ef7832aa

`border.blobDeformation: false`(after)

https://github.com/user-attachments/assets/7921755e-5bb5-441b-87a8-b819840103c5


