### PR TITLE
ControlCenter: add deform Scale setting

### DIFF
--- a/modules/controlcenter/appearance/AppearancePane.qml
+++ b/modules/controlcenter/appearance/AppearancePane.qml
@@ -31,6 +31,7 @@ Item {
     property real paddingScale: Config.appearance.padding.scale ?? 1
     property real roundingScale: Config.appearance.rounding.scale ?? 1
     property real spacingScale: Config.appearance.spacing.scale ?? 1
+    property real deformScale: Config.appearance.deformScale ?? 1
     property bool transparencyEnabled: GlobalConfig.appearance.transparency.enabled ?? false
     property real transparencyBase: GlobalConfig.appearance.transparency.base ?? 0.85
     property real transparencyLayers: GlobalConfig.appearance.transparency.layers ?? 0.4
@@ -65,6 +66,7 @@ Item {
         GlobalConfig.appearance.padding.scale = root.paddingScale;
         GlobalConfig.appearance.rounding.scale = root.roundingScale;
         GlobalConfig.appearance.spacing.scale = root.spacingScale;
+        GlobalConfig.appearance.deformScale = root.deformScale;
 
         GlobalConfig.appearance.transparency.enabled = root.transparencyEnabled;
         GlobalConfig.appearance.transparency.base = root.transparencyBase;

--- a/modules/controlcenter/appearance/sections/ScalesSection.qml
+++ b/modules/controlcenter/appearance/sections/ScalesSection.qml
@@ -89,4 +89,28 @@ CollapsibleSection {
             }
         }
     }
+
+    SectionContainer {
+        contentSpacing: Tokens.spacing.normal
+
+        SliderInput {
+            Layout.fillWidth: true
+
+            label: qsTr("deform scale")
+            value: rootPane.deformScale
+            from: 0
+            to: 10.0
+            decimals: 1
+            suffix: "×"
+            validator: DoubleValidator {
+                bottom: 0
+                top: 10.0
+            }
+
+            onValueModified: newValue => {
+                rootPane.deformScale = newValue;
+                rootPane.saveConfig();
+            }
+        }
+    }
 }


### PR DESCRIPTION
The deform scale configuration field has been added to the control center.

<img width="480" height="479" alt="image" src="https://github.com/user-attachments/assets/2f6a9831-22c2-469d-a077-6a0dc55df60a" />

The value can range from 0 to 10.