### PR TITLE
Add Pomodoro timer to dashboard

### DIFF
--- a/modules/dashboard/Content.qml
+++ b/modules/dashboard/Content.qml
@@ -13,6 +13,17 @@ Item {
     id: root
 
     required property ScreenState screenState
+    readonly property bool needsKeyboard: {
+        const count = repeater.count;
+        for (let i = 0; i < count; i++) {
+            const item = repeater.itemAt(i) as Loader;
+            if (item?.sourceComponent === mediaComponent && (item?.item as MediaWrapper)?.needsKeyboard)
+                return true;
+            if (item?.sourceComponent === pomodoroComponent && (item?.item as Pomodoro)?.needsKeyboard)
+                return true;
+        }
+        return false;
+    }
     required property FileDialog facePicker
 
     readonly property var dashboardTabs: {
@@ -28,6 +39,12 @@ Item {
                 iconName: "queue_music",
                 text: qsTr("Media"),
                 enabled: Config.dashboard.showMedia
+            },
+            {
+                component: pomodoroComponent,
+                iconName: "timer",
+                text: qsTr("Pomodoro"),
+                enabled: true
             },
             {
                 component: performanceComponent,
@@ -167,6 +184,12 @@ Item {
                 Media {
                     screenState: root.screenState
                 }
+            }
+
+            Component {
+                id: pomodoroComponent
+
+                Pomodoro {}
             }
 
             Component {

--- a/modules/dashboard/Pomodoro.qml
+++ b/modules/dashboard/Pomodoro.qml
@@ -1,0 +1,526 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+
+Item {
+    id: root
+
+    property var svc: PomodoroService
+
+    // ── Colors ────────────────────────────────────────────────────────────
+    readonly property color phaseColor: {
+        if (root.svc.idleMode)
+            return Colours.palette.m3onSurfaceVariant;
+        if (root.svc.currentPhase.type === "work")
+            return Colours.palette.m3primary;
+        if (root.svc.phaseIndex === 5 && root.svc.useLongBreak)
+            return Colours.palette.m3secondary;
+        return Colours.palette.m3tertiary;
+    }
+
+    readonly property color onPhaseColor: {
+        if (root.svc.idleMode)
+            return Colours.palette.m3onSurface;
+        if (root.svc.currentPhase.type === "work")
+            return Colours.palette.m3onPrimary;
+        if (root.svc.phaseIndex === 5 && root.svc.useLongBreak)
+            return Colours.palette.m3onSecondary;
+        return Colours.palette.m3onTertiary;
+    }
+
+    readonly property bool needsKeyboard: settingsSection.expanded
+
+    implicitWidth: 480
+    implicitHeight: outerCol.implicitHeight + Tokens.padding.large * 2
+
+    StyledRect {
+        anchors.fill: parent
+        color: Colours.tPalette.m3surfaceContainer
+        radius: Tokens.rounding.large
+
+        ColumnLayout {
+            id: outerCol
+
+            anchors {
+                top: parent.top
+                left: parent.left
+                right: parent.right
+                margins: Tokens.padding.large
+            }
+            spacing: Tokens.spacing.normal
+
+            // ── Header ────────────────────────────────────────────────────
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Tokens.spacing.small
+
+                MaterialIcon {
+                    text: "timer"
+                    font.pointSize: Tokens.font.size.large
+                    color: root.phaseColor
+
+                    Behavior on color {
+                        CAnim {
+                            duration: Tokens.anim.durations.normal
+                        }
+                    }
+                }
+
+                StyledText {
+                    text: qsTr("Pomodoro")
+                    font.pointSize: Tokens.font.size.large
+                    font.weight: Font.Medium
+                    color: Colours.palette.m3onSurface
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                // Stats + reset cluster
+                RowLayout {
+                    spacing: Tokens.spacing.normal
+
+                    RowLayout {
+                        spacing: Tokens.spacing.smaller
+
+                        MaterialIcon {
+                            text: "local_fire_department"
+                            font.pointSize: Tokens.font.size.normal
+                            color: Colours.palette.m3primary
+                        }
+
+                        StyledText {
+                            text: root.svc.pomodoroCount
+                            font.pointSize: Tokens.font.size.normal
+                            color: Colours.palette.m3onSurfaceVariant
+                        }
+                    }
+
+                    RowLayout {
+                        spacing: Tokens.spacing.smaller
+
+                        MaterialIcon {
+                            text: "sync"
+                            font.pointSize: Tokens.font.size.normal
+                            color: Colours.palette.m3secondary
+                        }
+
+                        StyledText {
+                            text: root.svc.cycleCount
+                            font.pointSize: Tokens.font.size.normal
+                            color: Colours.palette.m3onSurfaceVariant
+                        }
+                    }
+
+                    // ↺ Reset — lives in header so it doesn't offset the centered playback controls
+                    IconButton {
+                        type: IconButton.Text
+                        icon: "restart_alt"
+                        font.pointSize: Tokens.font.size.normal
+                        onClicked: root.svc.resetCurrent()
+                    }
+                }
+            }
+
+            // ── Phase dot strip ───────────────────────────────────────────
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Tokens.spacing.small
+
+                Repeater {
+                    model: root.svc.phases.length
+
+                    Item {
+                        id: dotItem
+
+                        required property int index
+
+                        readonly property bool isCurrent: dotItem.index === root.svc.phaseIndex && !root.svc.idleMode
+
+                        readonly property bool isDone: dotItem.index < root.svc.phaseIndex || (root.svc.idleMode && dotItem.index <= root.svc.phaseIndex)
+
+                        readonly property color dotColor: {
+                            if (dotItem.isCurrent)
+                                return root.phaseColor;
+                            if (dotItem.isDone)
+                                return Qt.alpha(root.phaseColor, 0.35);
+                            return Qt.alpha(Colours.palette.m3onSurfaceVariant, 0.18);
+                        }
+
+                        Layout.fillWidth: true
+                        implicitHeight: 8
+
+                        StyledRect {
+                            anchors.fill: parent
+                            radius: Tokens.rounding.full
+                            color: dotItem.dotColor
+
+                            Behavior on color {
+                                CAnim {
+                                    duration: Tokens.anim.durations.normal
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ── Timer ring ────────────────────────────────────────────────
+            Item {
+                id: ringItem
+
+                // Geometry for annular hit-test (matches CircularProgress internals)
+                // arcRadius = (size - strokeWidth) / 2 = (220 - 12) / 2 = 104
+                readonly property real ringRadius: 104
+                readonly property real ringStroke: 12
+                readonly property real innerHitRadius: ringRadius - ringStroke * 3
+                readonly property real outerHitRadius: ringRadius + ringStroke * 2.5
+
+                Layout.alignment: Qt.AlignHCenter
+                implicitWidth: 220
+                implicitHeight: 220
+
+                CircularProgress {
+                    id: timerRing
+
+                    anchors.fill: parent
+                    value: root.svc.idleMode ? 1.0 : root.svc.animatedProgress
+                    startAngle: -90
+                    strokeWidth: 12
+                    fgColour: root.svc.idleMode ? Qt.alpha(root.phaseColor, 0.22) : root.phaseColor
+                    bgColour: Qt.alpha(Colours.palette.m3onSurfaceVariant, 0.12)
+
+                    Behavior on fgColour {
+                        CAnim {
+                            duration: Tokens.anim.durations.normal
+                        }
+                    }
+                }
+
+                ColumnLayout {
+                    anchors.centerIn: parent
+                    spacing: Tokens.spacing.smaller
+
+                    StyledText {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: root.svc.idleMode ? `+${root.svc.formatTime(root.svc.idleElapsed)}` : root.svc.formatTime(root.svc.timeRemaining)
+                        font.pointSize: Tokens.font.size.extraLarge * 1.35
+                        font.weight: Font.Medium
+                        color: root.svc.idleMode ? Colours.palette.m3onSurfaceVariant : root.phaseColor
+
+                        Behavior on color {
+                            CAnim {
+                                duration: Tokens.anim.durations.normal
+                            }
+                        }
+                    }
+
+                    StyledText {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: root.svc.idleMode ? qsTr("Rest ended") : root.svc.currentPhase.name
+                        font.pointSize: Tokens.font.size.small
+                        color: Colours.palette.m3onSurfaceVariant
+                    }
+
+                    Item {
+                        Layout.alignment: Qt.AlignHCenter
+                        implicitWidth: 8
+                        implicitHeight: 8
+
+                        StyledRect {
+                            anchors.fill: parent
+                            radius: Tokens.rounding.full
+                            color: (root.svc.isRunning && !root.svc.idleMode) ? root.phaseColor : Qt.alpha(Colours.palette.m3onSurfaceVariant, 0.25)
+
+                            Behavior on color {
+                                CAnim {
+                                    duration: Tokens.anim.durations.normal
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // ── Ring drag-to-seek (annular zone only) ─────────────────
+                MouseArea {
+                    id: ringDrag
+
+                    property bool dragging: false
+
+                    function distFromCenter(mx, my) {
+                        const dx = mx - width / 2;
+                        const dy = my - height / 2;
+                        return Math.sqrt(dx * dx + dy * dy);
+                    }
+
+                    function onRing(mx, my) {
+                        const d = distFromCenter(mx, my);
+                        return d >= ringItem.innerHitRadius && d <= ringItem.outerHitRadius;
+                    }
+
+                    function angleToProgress(mx, my) {
+                        const cx = width / 2;
+                        const cy = height / 2;
+                        return (((Math.atan2(my - cy, mx - cx) * 180 / Math.PI) + 90) + 360) % 360 / 360;
+                    }
+
+                    anchors.fill: parent
+                    hoverEnabled: true
+
+                    cursorShape: {
+                        if (root.svc.idleMode)
+                            return Qt.ArrowCursor;
+                        return onRing(mouseX, mouseY) ? Qt.SizeAllCursor : Qt.ArrowCursor;
+                    }
+
+                    onPressed: mouse => {
+                        if (root.svc.idleMode || !onRing(mouse.x, mouse.y)) {
+                            mouse.accepted = false;
+                            return;
+                        }
+                        dragging = true;
+                        root.svc.smoothProgress = false;
+                        root.svc.elapsed = Math.round(angleToProgress(mouse.x, mouse.y) * root.svc.currentPhase.duration);
+                    }
+
+                    onPositionChanged: mouse => {
+                        if (!dragging)
+                            return;
+                        root.svc.elapsed = Math.round(angleToProgress(mouse.x, mouse.y) * root.svc.currentPhase.duration);
+                    }
+
+                    onReleased: {
+                        if (dragging) {
+                            dragging = false;
+                            Qt.callLater(function () {
+                                root.svc.smoothProgress = true;
+                            });
+                        }
+                    }
+                }
+            }
+
+            // ── Idle banner ───────────────────────────────────────────────
+            StyledRect {
+                Layout.fillWidth: true
+                implicitHeight: idleRow.implicitHeight + Tokens.padding.normal * 2
+                radius: Tokens.rounding.normal
+                color: Qt.alpha(Colours.palette.m3tertiary, 0.1)
+                visible: root.svc.idleMode
+
+                RowLayout {
+                    id: idleRow
+
+                    anchors {
+                        left: parent.left
+                        right: parent.right
+                        verticalCenter: parent.verticalCenter
+                        margins: Tokens.padding.normal
+                    }
+                    spacing: Tokens.spacing.small
+
+                    MaterialIcon {
+                        text: "coffee"
+                        font.pointSize: Tokens.font.size.normal
+                        color: Colours.palette.m3tertiary
+                    }
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        text: qsTr("Break ended — press ▶ to start next session")
+                        font.pointSize: Tokens.font.size.small
+                        color: Colours.palette.m3tertiary
+                        wrapMode: Text.WordWrap
+                    }
+                }
+            }
+
+            // ── Controls (prev / play-pause / next) — centred, no asymmetric buttons ──
+            RowLayout {
+                Layout.alignment: Qt.AlignHCenter
+                Layout.fillWidth: false
+                Layout.bottomMargin: Tokens.spacing.normal
+                spacing: Tokens.spacing.small
+
+                // ← Prev
+                Item {
+                    implicitWidth: prevIcon.implicitWidth + Tokens.padding.small
+                    implicitHeight: prevIcon.implicitHeight + Tokens.padding.small
+
+                    MaterialIcon {
+                        id: prevIcon
+
+                        anchors.centerIn: parent
+                        text: "skip_previous"
+                        font.pointSize: Math.round(Tokens.font.size.extraLarge * 1.1)
+                        color: Colours.palette.m3onSurfaceVariant
+                    }
+
+                    StateLayer {
+                        color: Colours.palette.m3onSurfaceVariant
+                        onClicked: root.svc.goToPrev()
+                    }
+                }
+
+                // ▶/⏸ Play-Pause — always circular, bypasses Tokens.rounding.scale
+                Item {
+                    id: playBtnItem
+
+                    readonly property real btnSize: playBtnIcon.implicitHeight + Tokens.padding.small * 2
+
+                    implicitWidth: btnSize
+                    implicitHeight: btnSize
+
+                    StyledRect {
+                        anchors.fill: parent
+                        radius: width / 2
+                        color: root.phaseColor
+
+                        Behavior on color {
+                            CAnim {
+                                duration: Tokens.anim.durations.normal
+                            }
+                        }
+                    }
+
+                    MaterialIcon {
+                        id: playBtnIcon
+
+                        anchors.centerIn: parent
+                        text: root.svc.isRunning ? "pause" : "play_arrow"
+                        color: root.onPhaseColor
+                        font.pointSize: Math.round(Tokens.font.size.extraLarge * 1.3)
+
+                        Behavior on color {
+                            CAnim {
+                                duration: Tokens.anim.durations.normal
+                            }
+                        }
+                    }
+
+                    StateLayer {
+                        radius: width / 2
+                        color: root.onPhaseColor
+                        onClicked: root.svc.togglePlayPause()
+                    }
+                }
+
+                // → Next
+                Item {
+                    implicitWidth: nextIcon.implicitWidth + Tokens.padding.small
+                    implicitHeight: nextIcon.implicitHeight + Tokens.padding.small
+
+                    MaterialIcon {
+                        id: nextIcon
+
+                        anchors.centerIn: parent
+                        text: "skip_next"
+                        font.pointSize: Math.round(Tokens.font.size.extraLarge * 1.1)
+                        color: Colours.palette.m3onSurfaceVariant
+                    }
+
+                    StateLayer {
+                        color: Colours.palette.m3onSurfaceVariant
+                        onClicked: root.svc.skipToNext()
+                    }
+                }
+            }
+
+            // ── Settings ──────────────────────────────────────────────────
+            CollapsibleSection {
+                id: settingsSection
+                Layout.fillWidth: true
+
+                title: qsTr("Settings")
+                showBackground: true
+
+                SpinBoxRow {
+                    label: qsTr("Work (min)")
+                    value: PomodoroService.workDuration
+                    min: 1
+                    max: 120
+                    onValueModified: value => {
+                        PomodoroService.workDuration = value;
+                    }
+                }
+
+                SpinBoxRow {
+                    label: qsTr("Short break (min)")
+                    value: PomodoroService.shortBreakDuration
+                    min: 1
+                    max: 60
+                    onValueModified: value => {
+                        PomodoroService.shortBreakDuration = value;
+                    }
+                }
+
+                SpinBoxRow {
+                    label: qsTr("Long break (min)")
+                    value: PomodoroService.longBreakDuration
+                    min: 1
+                    max: 120
+                    onValueModified: value => {
+                        PomodoroService.longBreakDuration = value;
+                    }
+                }
+
+                SwitchRow {
+                    label: qsTr("Long break after cycle")
+                    checked: PomodoroService.useLongBreak
+                    onToggled: checked => {
+                        PomodoroService.useLongBreak = checked;
+                    }
+                }
+
+                StyledRect {
+                    Layout.fillWidth: true
+                    implicitHeight: soundRow.implicitHeight + Tokens.padding.large * 2
+                    radius: Tokens.rounding.normal
+                    color: Colours.layer(Colours.palette.m3surfaceContainer, 2)
+
+                    RowLayout {
+                        id: soundRow
+
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.margins: Tokens.padding.large
+                        spacing: Tokens.spacing.normal
+
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: qsTr("Sound notifications")
+                        }
+
+                        CustomSpinBox {
+                            min: 0
+                            max: 100
+                            step: 5
+                            value: PomodoroService.soundVolume
+                            enabled: PomodoroService.soundEnabled
+                            opacity: PomodoroService.soundEnabled ? 1.0 : 0.4
+                            onValueModified: value => {
+                                PomodoroService.soundVolume = value;
+                            }
+
+                            Behavior on opacity {
+                                CAnim {}
+                            }
+                        }
+
+                        StyledSwitch {
+                            checked: PomodoroService.soundEnabled
+                            onToggled: PomodoroService.soundEnabled = checked
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/services/PomodoroService.qml
+++ b/services/PomodoroService.qml
@@ -1,0 +1,201 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+Singleton {
+    id: root
+
+    // ── Configurable durations (bound to persisted config) ─────────────────
+    property int workDuration: 25
+    property int shortBreakDuration: 5
+    property int longBreakDuration: 15
+    property bool useLongBreak: true
+    property bool soundEnabled: true
+    property int soundVolume: 80
+
+    // ── Phases ────────────────────────────────────────────────────────────
+    readonly property var phases: [
+        {
+            name: "Work",
+            duration: workDuration * 60,
+            type: "work"
+        },
+        {
+            name: "Break",
+            duration: shortBreakDuration * 60,
+            type: "break"
+        },
+        {
+            name: "Work",
+            duration: workDuration * 60,
+            type: "work"
+        },
+        {
+            name: "Break",
+            duration: shortBreakDuration * 60,
+            type: "break"
+        },
+        {
+            name: "Work",
+            duration: workDuration * 60,
+            type: "work"
+        },
+        {
+            name: useLongBreak ? "Long Break" : "Break",
+            duration: (useLongBreak ? longBreakDuration : shortBreakDuration) * 60,
+            type: "break"
+        }
+    ]
+
+    // ── State ─────────────────────────────────────────────────────────────
+    property int phaseIndex: 0
+    property int elapsed: 0
+    property bool isRunning: false
+    property bool idleMode: false
+    property int idleElapsed: 0
+    property int pomodoroCount: 0
+    property int cycleCount: 0
+
+    // ── Animated progress (smooth ring) ───────────────────────────────────
+    property bool smoothProgress: true
+    property real animatedProgress: 0
+
+    // ── Derived ───────────────────────────────────────────────────────────
+    readonly property var currentPhase: phases[phaseIndex]
+    readonly property real progress: currentPhase.duration > 0 ? elapsed / currentPhase.duration : 0
+    readonly property int timeRemaining: currentPhase.duration - elapsed
+
+    // ── Logic ─────────────────────────────────────────────────────────────
+    function playSound() {
+        if (!soundEnabled)
+            return;
+        soundProcess.running = false;
+        Qt.callLater(function () {
+            soundProcess.running = true;
+        });
+    }
+
+    function snapRingToZero() {
+        smoothProgress = false;
+        animatedProgress = 0;
+        Qt.callLater(function () {
+            root.smoothProgress = true;
+        });
+    }
+
+    function phaseCompleted() {
+        playSound();
+        if (currentPhase.type === "work") {
+            pomodoroCount++;
+            snapRingToZero();
+            elapsed = 0;
+            phaseIndex = (phaseIndex + 1) % phases.length;
+            idleMode = false;
+            isRunning = true;
+        } else {
+            if (phaseIndex === phases.length - 1)
+                cycleCount++;
+            isRunning = false;
+            idleMode = true;
+            idleElapsed = 0;
+        }
+    }
+
+    function goToPrev() {
+        if (idleMode) {
+            idleMode = false;
+            idleElapsed = 0;
+            elapsed = 0;
+            return;
+        }
+        snapRingToZero();
+        if (elapsed > 5) {
+            elapsed = 0;
+        } else {
+            phaseIndex = (phaseIndex - 1 + phases.length) % phases.length;
+            elapsed = 0;
+        }
+    }
+
+    function skipToNext() {
+        const wasActive = isRunning || idleMode;
+        snapRingToZero();
+        elapsed = 0;
+        phaseIndex = (phaseIndex + 1) % phases.length;
+        idleMode = false;
+        idleElapsed = 0;
+        isRunning = wasActive;
+    }
+
+    function togglePlayPause() {
+        if (idleMode) {
+            snapRingToZero();
+            elapsed = 0;
+            phaseIndex = (phaseIndex + 1) % phases.length;
+            idleMode = false;
+            idleElapsed = 0;
+            isRunning = true;
+        } else {
+            isRunning = !isRunning;
+        }
+    }
+
+    function resetCurrent() {
+        if (idleMode) {
+            idleMode = false;
+            idleElapsed = 0;
+        }
+        snapRingToZero();
+        elapsed = 0;
+    }
+
+    function formatTime(secs) {
+        const s = Math.max(0, Math.floor(secs));
+        return `${String(Math.floor(s / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`;
+    }
+
+    onPhasesChanged: {
+        const newDuration = phases[phaseIndex].duration;
+        if (elapsed >= newDuration)
+            elapsed = Math.max(0, newDuration - 1);
+    }
+
+    onProgressChanged: animatedProgress = progress
+
+    Behavior on animatedProgress {
+        enabled: root.smoothProgress
+
+        NumberAnimation {
+            duration: 950
+            easing.type: Easing.Linear
+        }
+    }
+
+    // ── Tick ──────────────────────────────────────────────────────────────
+    Timer {
+        id: ticker
+
+        interval: 1000
+        repeat: true
+        running: root.isRunning || root.idleMode
+
+        onTriggered: {
+            if (root.idleMode) {
+                root.idleElapsed++;
+                return;
+            }
+            root.elapsed++;
+            if (root.elapsed >= root.currentPhase.duration)
+                root.phaseCompleted();
+        }
+    }
+
+    // ── Sound ──────────────────────────────────────────────────────────────
+    Process {
+        id: soundProcess
+
+        command: ["mpv", "--no-video", "--really-quiet", "--no-terminal", "--volume=" + root.soundVolume, "/usr/share/sounds/freedesktop/stereo/complete.oga"]
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Pomodoro timer as a new tab in the dashboard.

- Circular progress ring with drag-to-seek support
- Work / short break / long break phases with a dot strip indicator
- Play/pause, skip, and reset controls
- Idle mode tracking after a break ends
- Settings section: configurable durations, long break toggle, sound notifications with volume control
- Persistent cycle and pomodoro counters

## Test plan

- [ ] Open dashboard and switch to the Pomodoro tab
- [ ] Start, pause, and skip phases — ring and dot strip update correctly
- [ ] Drag the ring to seek within the current phase
- [ ] Open Settings, adjust durations via SpinBox (keyboard input works)
- [ ] Toggle long break and sound, verify behaviour
- [ ] Let a phase complete — sound plays, idle mode activates
- [ ] Verify Media and other tabs are unaffected