### PR TITLE
lock: fix blur background not working

### DIFF
--- a/modules/lock/Lock.qml
+++ b/modules/lock/Lock.qml
@@ -7,12 +7,25 @@ import Quickshell.Wayland
 import qs.components.misc
 
 Scope {
+    id: root
+
     property alias lock: lock
+    // Set immediately in doLock() and held until unlock to prevent
+    // duplicate lock requests before lock.locked reflects compositor state.
+    property bool lockTriggered: false
+
+    function doLock(): void {
+        if (lock.locked || root.lockTriggered) return;
+        root.lockTriggered = true;
+        lock.locked = true;
+    }
 
     WlSessionLock {
         id: lock
 
         signal unlock
+
+        onLockedChanged: if (!locked) root.lockTriggered = false
 
         LockSurface {
             lock: lock
@@ -22,22 +35,17 @@ Scope {
 
     Pam {
         id: pam
-
         lock: lock
     }
 
-    Loader {
-        asynchronous: true
-        active: true
-        onLoaded: active = false
-
-        // Force a load of a screencopy so the one in the lock works
-        // My guess is the ICC backend loads async on first request, which if the lock is
-        // the first request it fails to capture (because it's async and the compositor
-        // refuses capture when locked)
-        sourceComponent: ScreencopyView {
-            captureSource: Quickshell.screens[0]
-        }
+    // Keeps the ICC backend warmed up so the lock surface's ScreencopyView receives
+    // a frame before the compositor sends stopped. captureSource is nulled while locked
+    // so the ICC context is destroyed before the compositor's stopped event arrives.
+    ScreencopyView {
+        captureSource: lock.locked ? null : Quickshell.screens[0]
+        width: 1
+        height: 1
+        visible: false
     }
 
     // qmllint disable unresolved-type
@@ -45,7 +53,7 @@ Scope {
         // qmllint enable unresolved-type
         name: "lock"
         description: "Lock the current session"
-        onPressed: lock.locked = true
+        onPressed: root.doLock()
     }
 
     // qmllint disable unresolved-type
@@ -58,7 +66,7 @@ Scope {
 
     IpcHandler {
         function lock(): void {
-            lock.locked = true;
+            root.doLock();
         }
 
         function unlock(): void {

--- a/modules/lock/Lock.qml
+++ b/modules/lock/Lock.qml
@@ -15,7 +15,8 @@ Scope {
     property bool lockTriggered: false
 
     function doLock(): void {
-        if (lock.locked || root.lockTriggered) return;
+        if (lock.locked || root.lockTriggered)
+            return;
         root.lockTriggered = true;
         lock.locked = true;
     }
@@ -25,7 +26,8 @@ Scope {
 
         signal unlock
 
-        onLockedChanged: if (!locked) root.lockTriggered = false
+        onLockedChanged: if (!locked)
+            root.lockTriggered = false
 
         LockSurface {
             lock: lock
@@ -35,6 +37,7 @@ Scope {
 
     Pam {
         id: pam
+
         lock: lock
     }
 


### PR DESCRIPTION
Fixes #1409. 4763a690 didn't fix it for me, the background still showed without blur.
This replaces the one-shot loader with a persistent ScreencopyView which fixes it for me.

Spamming the lock shortcut while locked can still cause Quickshell to crash, but that seems to be a Quickshell bug.