### PR TITLE
feat(assets): support more shells in wrap_term_launch.sh

### DIFF
--- a/assets/wrap_term_launch.sh
+++ b/assets/wrap_term_launch.sh
@@ -2,4 +2,23 @@
 
 cat ~/.local/state/caelestia/sequences.txt 2>/dev/null
 
-exec "$@"
+COMMAND="$@"
+
+if [ "$1" = "ghostty" ]; then
+	exec ghostty -e ${COMMAND#*ghostty }
+fi
+
+if [ "$1" = "alacritty" ]; then
+	exec alacritty -e ${COMMAND#*alacritty }
+fi
+
+if [ "$1" = "konsole" ]; then
+	exec konsole -e ${COMMAND#*konsole }
+fi
+
+if [ "$1" = "xterm" ]; then
+	exec xterm -e ${COMMAND#*xterm }
+fi
+
+
+exec $COMMAND


### PR DESCRIPTION
Ghostty and other terminals need the `-e` flag.

Useful when launching apps like neovim from application menu, or opening anything terminal related from the menu.

First contribution!