### PR TITLE
add video wallpaper support

### DIFF
--- a/modules/background/Background.qml
+++ b/modules/background/Background.qml
@@ -44,6 +44,11 @@ Variants {
                 sourceComponent: Wallpaper {}
             }
 
+            VideoBackground {
+                anchors.fill: parent
+                screen: win.modelData
+            }
+
             Visualiser {
                 anchors.fill: parent
                 screen: win.modelData

--- a/modules/background/VideoBackground.qml
+++ b/modules/background/VideoBackground.qml
@@ -1,0 +1,124 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtMultimedia
+import Quickshell
+import qs.services
+
+Item {
+    id: root
+
+    required property ShellScreen screen
+    property bool startupRevealPending: true
+
+    readonly property string monitorName: Hypr.monitorFor(screen)?.name ?? screen.name
+    readonly property string assignedSource: VideoWallpaper.sourceForMonitor(monitorName, screen.name)
+    readonly property bool shouldBeVisible: VideoWallpaper.visualActive
+        && VideoWallpaper.shouldDisplayOn(monitorName, screen.name)
+        && assignedSource !== ""
+    readonly property url resolvedSource: {
+        const src = assignedSource;
+        if (!src)
+            return "";
+        if (src.startsWith("/") || src.startsWith("file:/"))
+            return Qt.resolvedUrl(src.startsWith("/") ? `file://${src}` : src);
+        return Qt.resolvedUrl(src);
+    }
+
+    anchors.fill: parent
+    opacity: shouldBeVisible && !startupRevealPending ? 1 : 0
+    visible: opacity > 0 || player.playbackState === MediaPlayer.PlayingState
+
+    Behavior on opacity {
+        NumberAnimation {
+            duration: Math.max(0, VideoWallpaper.fadeDuration)
+        }
+    }
+
+    MediaPlayer {
+        id: player
+
+        source: root.resolvedSource
+        videoOutput: output
+        playbackRate: VideoWallpaper.playbackRate
+        loops: VideoWallpaper.loop ? MediaPlayer.Infinite : 1
+
+        Component.onCompleted: syncPlayback()
+    }
+
+    VideoOutput {
+        id: output
+
+        anchors.fill: parent
+        fillMode: VideoWallpaper.fitMode === "Fit" ? VideoOutput.PreserveAspectFit
+            : VideoWallpaper.fitMode === "Stretch" ? VideoOutput.Stretch
+            : VideoOutput.PreserveAspectCrop
+    }
+
+    function syncPlayback() {
+        if (!root.resolvedSource) {
+            player.stop();
+            return;
+        }
+
+        if (!root.shouldBeVisible || VideoWallpaper.effectivePaused) {
+            player.pause();
+            return;
+        }
+
+        player.play();
+    }
+
+    Component.onCompleted: Qt.callLater(() => {
+        root.startupRevealPending = false;
+    })
+
+    onAssignedSourceChanged: syncPlayback()
+
+    onResolvedSourceChanged: syncPlayback()
+    onShouldBeVisibleChanged: syncPlayback()
+
+    Connections {
+        target: VideoWallpaper
+
+        function onPausedChanged() {
+            root.syncPlayback();
+        }
+
+        function onRunningChanged() {
+            root.syncPlayback();
+        }
+
+        function onSourceChanged() {
+            root.syncPlayback();
+        }
+
+        function onActiveSourceChanged() {
+            root.syncPlayback();
+        }
+
+        function onVisualActiveChanged() {
+            root.syncPlayback();
+        }
+
+        function onMonitorSourceMapChanged() {
+            root.syncPlayback();
+        }
+
+        function onPerformanceLimitedChanged() {
+            root.syncPlayback();
+        }
+
+        function onOutputChanged() {
+            root.syncPlayback();
+        }
+
+        function onPerformanceModeChanged() {
+            root.syncPlayback();
+        }
+
+        function onPrimaryMonitorNameChanged() {
+            root.syncPlayback();
+        }
+    }
+}

--- a/modules/controlcenter/PaneRegistry.qml
+++ b/modules/controlcenter/PaneRegistry.qml
@@ -31,6 +31,12 @@ QtObject {
             readonly property string component: "appearance/AppearancePane.qml"
         },
         QtObject {
+            readonly property string id: "videowallpaper"
+            readonly property string label: "\u00A0\u00A0\u00A0video\nWallpaper"
+            readonly property string icon: "movie"
+            readonly property string component: "videowallpaper/VideoWallpaperPane.qml"
+        },
+        QtObject {
             readonly property string id: "taskbar"
             readonly property string label: "taskbar"
             readonly property string icon: "task_alt"

--- a/modules/controlcenter/components/VideoWallpaperGrid.qml
+++ b/modules/controlcenter/components/VideoWallpaperGrid.qml
@@ -1,0 +1,369 @@
+pragma ComponentBehavior: Bound
+
+import ".."
+import QtQuick
+import Caelestia.Models
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.utils
+
+GridView {
+    id: root
+
+    required property Session session
+
+    property string searchText: ""
+    property string sortMode: "name"
+    property string selectedPath: ""
+
+    signal sourceSelected(string path)
+    readonly property string videoDir: `${Paths.wallsdir}/Videos`
+    readonly property int minCellWidth: 200 + Tokens.spacing.normal
+    readonly property int columnsCount: Math.max(1, Math.floor(width / minCellWidth))
+    readonly property var allowedSuffixes: ["mp4", "mkv", "webm", "mov", "avi", "m4v"]
+    readonly property var videoEntries: buildEntries()
+
+    function modifiedStamp(entry) {
+        const raw = entry.lastModifiedMs || entry.lastModified || entry.modified || entry.mtime || 0;
+        const numeric = Number(raw);
+        if (!isNaN(numeric) && numeric > 0)
+            return numeric;
+        const parsed = Date.parse(String(raw || ""));
+        return isNaN(parsed) ? 0 : parsed;
+    }
+
+    function buildEntries() {
+        const entries = [];
+        const sourceEntries = sourceModel.entries || [];
+        const needle = String(searchText || "").trim().toLowerCase();
+
+        for (let i = 0; i < sourceEntries.length; i++) {
+            const entry = sourceEntries[i];
+            if (!entry || entry.isDir)
+                continue;
+            const suffix = String(entry.suffix || "").toLowerCase();
+            if (!allowedSuffixes.includes(suffix))
+                continue;
+            if (needle.length > 0 && String(entry.name || "").toLowerCase().indexOf(needle) === -1)
+                continue;
+            entries.push(entry);
+        }
+
+        entries.sort((a, b) => {
+            switch (sortMode) {
+            case "recent":
+                return modifiedStamp(b) - modifiedStamp(a);
+            case "duration": {
+                const aMeta = VideoWallpaper.metadataFor(a.path);
+                const bMeta = VideoWallpaper.metadataFor(b.path);
+                const delta = Number(bMeta ? bMeta.duration : 0) - Number(aMeta ? aMeta.duration : 0);
+                if (delta !== 0)
+                    return delta;
+                break;
+            }
+            case "resolution": {
+                const aMeta = VideoWallpaper.metadataFor(a.path);
+                const bMeta = VideoWallpaper.metadataFor(b.path);
+                const delta = Number(bMeta ? bMeta.resolutionPixels : 0) - Number(aMeta ? aMeta.resolutionPixels : 0);
+                if (delta !== 0)
+                    return delta;
+                break;
+            }
+            default:
+                break;
+            }
+            return String(a.name || "").localeCompare(String(b.name || ""), undefined, { sensitivity: "base" });
+        });
+
+        return entries;
+    }
+
+    function visiblePaths(limit) {
+        const paths = [];
+        const maxItems = Math.max(0, Number(limit || 0));
+        const total = videoEntries.length;
+        if (!total)
+            return paths;
+
+        const firstRow = Math.max(0, Math.floor(contentY / cellHeight));
+        const lastRow = Math.max(firstRow, Math.ceil((contentY + height) / cellHeight));
+        const firstIndex = Math.max(0, firstRow * columnsCount);
+        const lastIndex = Math.min(total, (lastRow + 1) * columnsCount);
+        for (let i = firstIndex; i < lastIndex; i++) {
+            paths.push(videoEntries[i].path);
+            if (maxItems > 0 && paths.length >= maxItems)
+                break;
+        }
+        return paths;
+    }
+
+    function assignedOutputsForSource(path) {
+        if (!path)
+            return [];
+
+        const names = Hypr.monitorNames();
+        const matches = [];
+        for (let i = 0; i < names.length; i++) {
+            if (VideoWallpaper.sourceForOutput(names[i]) === path)
+                matches.push(names[i]);
+        }
+        return matches;
+    }
+
+    function assignedOutputsLabel(path) {
+        const outputs = assignedOutputsForSource(path);
+        if (!outputs.length)
+            return "";
+        if (outputs.length === 1)
+            return outputs[0];
+        return qsTr("%1 monitors").arg(outputs.length);
+    }
+
+    function assignedOutputsTooltip(path) {
+        const outputs = assignedOutputsForSource(path);
+        if (!outputs.length)
+            return "";
+        return outputs.join("\n");
+    }
+
+    cellWidth: width / columnsCount
+    cellHeight: 140 + Tokens.spacing.normal
+    model: root.videoEntries
+    clip: true
+
+    FileSystemModel {
+        id: sourceModel
+
+        path: root.videoDir
+    }
+
+    StyledScrollBar.vertical: StyledScrollBar {
+        flickable: root
+    }
+
+    onVideoEntriesChanged: {
+        const paths = [];
+        for (let i = 0; i < videoEntries.length && i < 12; i++)
+            paths.push(videoEntries[i].path);
+        VideoWallpaper.preloadMetadata(paths);
+    }
+
+    delegate: Item {
+        id: delegateRoot
+
+        required property var modelData
+        required property int index
+
+        readonly property bool isSelected: modelData && modelData.path === root.selectedPath
+        readonly property bool isActive: modelData && VideoWallpaper.isSourceActive(modelData.path)
+        readonly property var assignedOutputs: modelData ? root.assignedOutputsForSource(modelData.path) : []
+        readonly property string assignedOutputsLabel: modelData ? root.assignedOutputsLabel(modelData.path) : ""
+        readonly property string assignedOutputsTooltip: modelData ? root.assignedOutputsTooltip(modelData.path) : ""
+        readonly property string thumbnailSource: modelData ? VideoWallpaper.thumbnailFor(modelData.path) : ""
+        readonly property real itemMargin: Tokens.spacing.normal / 2
+        readonly property real itemRadius: Tokens.rounding.normal
+
+        width: root.cellWidth
+        height: root.cellHeight
+
+        StateLayer {
+            onClicked: {
+                root.sourceSelected(modelData.path);
+            }
+
+            anchors.fill: parent
+            anchors.leftMargin: itemMargin
+            anchors.rightMargin: itemMargin
+            anchors.topMargin: itemMargin
+            anchors.bottomMargin: itemMargin
+            radius: itemRadius
+        }
+
+        StyledClippingRect {
+            anchors.fill: parent
+            anchors.leftMargin: itemMargin
+            anchors.rightMargin: itemMargin
+            anchors.topMargin: itemMargin
+            anchors.bottomMargin: itemMargin
+            color: Colours.tPalette.m3surfaceContainer
+            radius: itemRadius
+            antialiasing: true
+            layer.enabled: true
+            layer.smooth: true
+
+            Item {
+                anchors.fill: parent
+
+                Image {
+                    anchors.fill: parent
+                    visible: thumbnailSource.length > 0
+                    source: Qt.resolvedUrl(thumbnailSource)
+                    fillMode: Image.PreserveAspectCrop
+                    asynchronous: false
+                    cache: false
+
+                    onStatusChanged: {
+                        if (status === Image.Error)
+                            VideoWallpaper.ensureThumbnail(modelData.path);
+                    }
+                }
+
+                MaterialIcon {
+                    anchors.centerIn: parent
+                    anchors.verticalCenterOffset: -Tokens.padding.large
+                    visible: thumbnailSource.length === 0
+                    text: "movie"
+                    color: Colours.palette.m3onSurfaceVariant
+                    font.pointSize: Tokens.font.size.extraLarge * 3
+                    fill: 0
+                }
+            }
+
+            Rectangle {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                implicitHeight: filenameText.implicitHeight + Tokens.padding.normal * 1.5
+                radius: 0
+
+                gradient: Gradient {
+                    GradientStop { position: 0.0; color: Qt.rgba(Colours.palette.m3surface.r, Colours.palette.m3surface.g, Colours.palette.m3surface.b, 0) }
+                    GradientStop { position: 0.3; color: Qt.rgba(Colours.palette.m3surface.r, Colours.palette.m3surface.g, Colours.palette.m3surface.b, 0.7) }
+                    GradientStop { position: 0.6; color: Qt.rgba(Colours.palette.m3surface.r, Colours.palette.m3surface.g, Colours.palette.m3surface.b, 0.9) }
+                    GradientStop { position: 1.0; color: Qt.rgba(Colours.palette.m3surface.r, Colours.palette.m3surface.g, Colours.palette.m3surface.b, 0.95) }
+                }
+            }
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            anchors.leftMargin: itemMargin
+            anchors.rightMargin: itemMargin
+            anchors.topMargin: itemMargin
+            anchors.bottomMargin: itemMargin
+            color: "transparent"
+            radius: itemRadius + border.width
+            border.width: isSelected ? 2 : 0
+            border.color: Colours.palette.m3primary
+            antialiasing: true
+            smooth: true
+
+            Behavior on border.width {
+                NumberAnimation {
+                    duration: 150
+                    easing.type: Easing.OutQuad
+                }
+            }
+
+            Rectangle {
+                anchors.left: parent.left
+                anchors.top: parent.top
+                anchors.margins: Tokens.padding.small
+                visible: isActive
+                radius: Tokens.rounding.full
+                color: Qt.rgba(Colours.palette.m3primary.r, Colours.palette.m3primary.g, Colours.palette.m3primary.b, 0.95)
+                implicitWidth: activeLabel.implicitWidth + Tokens.padding.normal * 2
+                implicitHeight: activeLabel.implicitHeight + Tokens.padding.small
+
+                StyledText {
+                    id: activeLabel
+
+                    anchors.centerIn: parent
+                    text: qsTr("Active")
+                    color: Colours.palette.m3onPrimary
+                    font.pointSize: Tokens.font.size.small
+                    font.weight: 700
+                }
+            }
+
+            Rectangle {
+                id: assignedBadge
+
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.margins: Tokens.padding.small
+                visible: assignedOutputs.length > 0
+                radius: Tokens.rounding.full
+                color: Qt.rgba(Colours.palette.m3secondaryContainer.r, Colours.palette.m3secondaryContainer.g, Colours.palette.m3secondaryContainer.b, 0.95)
+                implicitWidth: assignedLabel.implicitWidth + Tokens.padding.normal * 2
+                implicitHeight: assignedLabel.implicitHeight + Tokens.padding.small
+
+                StyledText {
+                    id: assignedLabel
+
+                    anchors.centerIn: parent
+                    text: assignedOutputsLabel
+                    color: Colours.palette.m3onSecondaryContainer
+                    font.pointSize: Tokens.font.size.small
+                    font.weight: 700
+                }
+
+                MouseArea {
+                    id: assignedBadgeHover
+
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    acceptedButtons: Qt.NoButton
+                    cursorShape: Qt.PointingHandCursor
+                    enabled: delegateRoot.assignedOutputs.length > 1
+                }
+
+                Tooltip {
+                    target: assignedBadgeHover
+                    text: delegateRoot.assignedOutputsTooltip
+                    delay: 250
+                }
+            }
+
+            MaterialIcon {
+                id: currentIcon
+
+                anchors.centerIn: parent
+                visible: isSelected
+                text: "check_circle"
+                color: Colours.palette.m3primary
+                font.pointSize: Tokens.font.size.extraLarge
+                fill: 1
+            }
+        }
+
+        StyledText {
+            id: filenameText
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            anchors.leftMargin: Tokens.padding.normal + Tokens.spacing.normal / 2
+            anchors.rightMargin: Tokens.padding.normal + Tokens.spacing.normal / 2
+            anchors.bottomMargin: Tokens.padding.normal
+            text: modelData.name
+            font.pointSize: Tokens.font.size.smaller
+            font.weight: 500
+            color: isSelected ? Colours.palette.m3primary : Colours.palette.m3onSurface
+            elide: Text.ElideMiddle
+            maximumLineCount: 1
+            horizontalAlignment: Text.AlignHCenter
+        }
+
+        MouseArea {
+            id: filenameHover
+
+            anchors.left: filenameText.left
+            anchors.right: filenameText.right
+            anchors.top: filenameText.top
+            anchors.bottom: filenameText.bottom
+            hoverEnabled: true
+            acceptedButtons: Qt.NoButton
+            cursorShape: Qt.PointingHandCursor
+        }
+
+        Tooltip {
+            target: filenameHover
+            text: String(delegateRoot.modelData?.name || "")
+            delay: 350
+        }
+
+    }
+}

--- a/modules/controlcenter/videowallpaper/VideoWallpaperPane.qml
+++ b/modules/controlcenter/videowallpaper/VideoWallpaperPane.qml
@@ -1,0 +1,604 @@
+pragma ComponentBehavior: Bound
+
+import ".."
+import "../components"
+import "../../files" as FilesModule
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Caelestia.Config
+import qs.components
+import qs.components.containers
+import qs.components.controls
+import qs.services
+import qs.utils
+
+Item {
+    id: root
+
+    required property Session session
+
+    property string selectedOutput: VideoWallpaper.output
+    property string selectedPath: VideoWallpaper.sourceForOutput(VideoWallpaper.output)
+    property bool pendingSelection: false
+    property string searchText: ""
+    readonly property string videoDir: `${Paths.wallsdir}/Videos`
+    readonly property var selectedMetadata: VideoWallpaper.metadataFor(selectedPath)
+    readonly property bool hasSelection: !!selectedPath
+    readonly property bool selectedIsActive: hasSelection && VideoWallpaper.isSourceActive(selectedPath)
+    readonly property string selectedName: VideoWallpaper.fileNameFor(selectedPath)
+    readonly property var monitorAssignments: {
+        const names = Hypr.monitorNames();
+        const items = [];
+        for (let i = 0; i < names.length; i++) {
+            const name = names[i];
+            const assignedPath = VideoWallpaper.sourceForOutput(name);
+            items.push({
+                monitor: name,
+                path: assignedPath,
+                name: assignedPath ? VideoWallpaper.fileNameFor(assignedPath) : qsTr("No video")
+            });
+        }
+        return items;
+    }
+    readonly property var outputOptions: {
+        const options = [{
+                label: "ALL",
+                state: root.selectedOutput === "ALL",
+                onToggled: function () { root.applyOutput("ALL"); }
+            }];
+        const monitors = Hypr.monitorNames();
+        for (let i = 0; i < monitors.length; i++) {
+            const name = monitors[i];
+            options.push({
+                label: name,
+                state: root.selectedOutput === name,
+                onToggled: function () { root.applyOutput(name); }
+            });
+        }
+        return options;
+    }
+
+    function applyOutput(value) {
+        root.selectedOutput = value;
+        if (!root.pendingSelection) {
+            root.selectedPath = VideoWallpaper.sourceForOutput(value);
+        }
+    }
+
+    function formatBytes(value) {
+        const size = Number(value || 0);
+        if (size <= 0)
+            return "-";
+        const units = ["B", "KB", "MB", "GB", "TB"];
+        let index = 0;
+        let amount = size;
+        while (amount >= 1024 && index < units.length - 1) {
+            amount /= 1024;
+            index++;
+        }
+        return `${amount >= 10 || index === 0 ? Math.round(amount) : amount.toFixed(1)} ${units[index]}`;
+    }
+
+    function formatDuration(value) {
+        const totalSeconds = Math.max(0, Math.round(Number(value || 0)));
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutes = Math.floor((totalSeconds % 3600) / 60);
+        const seconds = totalSeconds % 60;
+        if (hours > 0)
+            return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+        return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+    }
+
+    function parentDirectory(path) {
+        const text = String(path || "");
+        if (!text)
+            return root.videoDir;
+        const normalized = text.endsWith("/") ? text.slice(0, -1) : text;
+        const lastSlash = normalized.lastIndexOf("/");
+        if (lastSlash <= 0)
+            return "/";
+        return normalized.slice(0, lastSlash);
+    }
+
+    function openVideoFolder() {
+        FilesModule.WindowFactory.create(null, {
+            initialPath: root.videoDir
+        });
+    }
+
+    function openSelectedInExplorer() {
+        if (!root.selectedPath)
+            return;
+        FilesModule.WindowFactory.create(null, {
+            initialPath: parentDirectory(root.selectedPath),
+            initialSelectionPath: root.selectedPath
+        });
+    }
+
+    function outputAssignmentLabel(item) {
+        if (!item)
+            return "-";
+        if (!item.path)
+            return qsTr("No video");
+        return item.name;
+    }
+
+    anchors.fill: parent
+
+    onSelectedPathChanged: {
+        if (selectedPath) {
+            VideoWallpaper.ensureThumbnail(selectedPath);
+            VideoWallpaper.ensureMetadata(selectedPath);
+        }
+    }
+
+    Connections {
+        target: VideoWallpaper
+
+        function onSourceChanged() {
+            if (root.selectedOutput === "ALL" && !root.pendingSelection)
+                root.selectedPath = VideoWallpaper.sourceForOutput("ALL");
+        }
+
+        function onOutputChanged() {
+            if (!root.pendingSelection) {
+                root.selectedOutput = VideoWallpaper.output;
+                root.selectedPath = VideoWallpaper.sourceForOutput(VideoWallpaper.output);
+            }
+        }
+
+        function onMonitorSourceMapChanged() {
+            if (root.selectedOutput !== "ALL" && !root.pendingSelection)
+                root.selectedPath = VideoWallpaper.sourceForOutput(root.selectedOutput);
+        }
+
+        function onMetadataCacheChanged() {}
+    }
+
+    SplitPaneLayout {
+        anchors.fill: parent
+
+        leftContent: Component {
+            StyledFlickable {
+                id: leftFlickable
+
+                flickableDirection: Flickable.VerticalFlick
+                contentHeight: leftContent.height
+
+                StyledScrollBar.vertical: StyledScrollBar {
+                    flickable: leftFlickable
+                }
+
+                ColumnLayout {
+                    id: leftContent
+
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    spacing: Tokens.spacing.normal
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Tokens.spacing.smaller
+
+                        StyledText {
+                            text: qsTr("Video Wallpaper")
+                            font.pointSize: Tokens.font.size.large
+                            font.weight: 500
+                        }
+
+                        Item {
+                            Layout.fillWidth: true
+                        }
+                    }
+
+                    StyledClippingRect {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 220
+                        radius: Tokens.rounding.normal
+                        color: Colours.layer(Colours.palette.m3surfaceContainer, 2)
+                        clip: true
+
+                        Item {
+                            anchors.fill: parent
+
+                            Image {
+                                anchors.fill: parent
+                                visible: root.hasSelection
+                                source: root.hasSelection ? Qt.resolvedUrl(VideoWallpaper.thumbnailFor(root.selectedPath)) : ""
+                                fillMode: Image.PreserveAspectCrop
+                                asynchronous: false
+                                cache: false
+
+                                onStatusChanged: {
+                                    if (status === Image.Error && root.selectedPath)
+                                        VideoWallpaper.ensureThumbnail(root.selectedPath);
+                                }
+                            }
+
+                            Rectangle {
+                                anchors.fill: parent
+                                color: Qt.rgba(Colours.palette.m3surface.r, Colours.palette.m3surface.g, Colours.palette.m3surface.b, root.hasSelection ? 0.18 : 0.45)
+                            }
+
+                            MaterialIcon {
+                                anchors.centerIn: parent
+                                visible: !root.hasSelection
+                                text: "movie"
+                                color: Colours.palette.m3onSurfaceVariant
+                                font.pointSize: Tokens.font.size.extraLarge * 3
+                                fill: 0
+                            }
+
+                            Column {
+                                anchors.left: parent.left
+                                anchors.right: parent.right
+                                anchors.bottom: parent.bottom
+                                anchors.margins: Tokens.padding.large
+                                spacing: Tokens.spacing.small
+
+                                StyledText {
+                                    text: root.hasSelection ? root.selectedName : qsTr("No video selected")
+                                    font.pointSize: Tokens.font.size.large
+                                    font.weight: 700
+                                    color: Colours.palette.m3onSurface
+                                    elide: Text.ElideMiddle
+                                }
+
+                                StyledText {
+                                    visible: root.hasSelection
+                                    text: root.selectedIsActive
+                                        ? qsTr("Active on %1").arg(VideoWallpaper.activeOutputsTextForSource(root.selectedPath))
+                                        : qsTr("Selected for %1").arg(root.selectedOutput)
+                                    color: root.selectedIsActive ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                                    font.pointSize: Tokens.font.size.small
+                                    font.weight: 600
+                                }
+                            }
+                        }
+                    }
+
+                    CollapsibleSection {
+                        Layout.fillWidth: true
+                        title: qsTr("Selection")
+                        expanded: true
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: Tokens.spacing.small
+
+                            RowLayout {
+                                Layout.fillWidth: true
+                                spacing: Tokens.spacing.small
+
+                                StyledText {
+                                    text: root.hasSelection ? root.selectedName : qsTr("No video selected")
+                                    font.pointSize: Tokens.font.size.small
+                                    font.weight: 600
+                                    color: Colours.palette.m3onSurfaceVariant
+                                    elide: Text.ElideMiddle
+                                    Layout.fillWidth: true
+                                }
+
+                                StyledRect {
+                                    radius: Tokens.rounding.full
+                                    color: VideoWallpaper.running ? Colours.palette.m3primary : Colours.palette.m3surfaceVariant
+                                    implicitWidth: backendLabel.implicitWidth + Tokens.padding.large * 2
+                                    implicitHeight: backendLabel.implicitHeight + Tokens.padding.smaller * 2
+
+                                    StyledText {
+                                        id: backendLabel
+
+                                        anchors.centerIn: parent
+                                        text: VideoWallpaper.backendStatus
+                                        color: VideoWallpaper.running ? Colours.palette.m3onPrimary : Colours.palette.m3onSurfaceVariant
+                                        font.pointSize: Tokens.font.size.small
+                                        font.weight: 600
+                                    }
+                                }
+                            }
+
+                            GridLayout {
+                                Layout.fillWidth: true
+                                columns: 2
+                                columnSpacing: Tokens.spacing.small
+                                rowSpacing: Tokens.spacing.small
+
+                                component MetricCard: StyledRect {
+                                    required property string label
+                                    required property string value
+
+                                    Layout.fillWidth: true
+                                    radius: Tokens.rounding.normal
+                                    color: Colours.layer(Colours.palette.m3surfaceContainerHighest, 1)
+                                    implicitHeight: metricColumn.implicitHeight + Tokens.padding.normal * 2
+
+                                    ColumnLayout {
+                                        id: metricColumn
+
+                                        anchors.fill: parent
+                                        anchors.margins: Tokens.padding.normal
+                                        spacing: Tokens.spacing.smaller / 2
+
+                                        StyledText {
+                                            text: parent.parent.label
+                                            color: Colours.palette.m3onSurfaceVariant
+                                            font.pointSize: Tokens.font.size.small
+                                        }
+
+                                        StyledText {
+                                            text: parent.parent.value
+                                            color: Colours.palette.m3onSurface
+                                            font.pointSize: Tokens.font.size.normal
+                                            font.weight: 600
+                                            elide: Text.ElideMiddle
+                                        }
+                                    }
+                                }
+
+                                MetricCard {
+                                    label: qsTr("Target")
+                                    value: root.selectedOutput
+                                }
+
+                                MetricCard {
+                                    label: qsTr("Duration")
+                                    value: root.selectedMetadata ? root.formatDuration(root.selectedMetadata.duration) : (root.hasSelection ? qsTr("Loading…") : "-")
+                                }
+
+                                MetricCard {
+                                    label: qsTr("Resolution")
+                                    value: root.selectedMetadata && root.selectedMetadata.width > 0 ? `${root.selectedMetadata.width}×${root.selectedMetadata.height}` : (root.hasSelection ? qsTr("Loading…") : "-")
+                                }
+
+                                MetricCard {
+                                    label: qsTr("FPS")
+                                    value: root.selectedMetadata && root.selectedMetadata.fps > 0 ? Number(root.selectedMetadata.fps).toFixed(2) : "-"
+                                }
+
+                                MetricCard {
+                                    label: qsTr("Codec")
+                                    value: root.selectedMetadata && root.selectedMetadata.codec ? root.selectedMetadata.codec : "-"
+                                }
+
+                                MetricCard {
+                                    label: qsTr("Size")
+                                    value: root.selectedMetadata ? root.formatBytes(root.selectedMetadata.size) : (root.hasSelection ? qsTr("Loading…") : "-")
+                                }
+                            }
+                        }
+                    }
+
+                    CollapsibleSection {
+                        Layout.fillWidth: true
+                        title: qsTr("Actions")
+                        expanded: true
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: Tokens.spacing.small
+
+                            TextButton {
+                                text: qsTr("Apply")
+                                enabled: root.hasSelection
+                                onClicked: {
+                                    VideoWallpaper.applySelection(root.selectedOutput, root.selectedPath);
+                                    root.pendingSelection = false;
+                                }
+                            }
+
+                            TextButton {
+                                text: VideoWallpaper.paused ? qsTr("Resume") : qsTr("Pause")
+                                enabled: VideoWallpaper.running
+                                onClicked: VideoWallpaper.togglePause()
+                            }
+
+                            TextButton {
+                                text: qsTr("Stop")
+                                enabled: VideoWallpaper.running
+                                onClicked: VideoWallpaper.stop()
+                            }
+                        }
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: Tokens.spacing.small
+                        }
+                    }
+
+                    CollapsibleSection {
+                        Layout.fillWidth: true
+                        title: qsTr("Output")
+                        expanded: true
+
+                        StyledRect {
+                            Layout.fillWidth: true
+                            implicitHeight: outputLayout.implicitHeight + Tokens.padding.large * 2
+                            radius: Tokens.rounding.normal
+                            color: Colours.layer(Colours.palette.m3surfaceContainer, 2)
+                            clip: true
+
+                            RowLayout {
+                                id: outputLayout
+
+                                anchors.fill: parent
+                                anchors.margins: Tokens.padding.large
+                                spacing: Tokens.spacing.small
+
+                                Repeater {
+                                    model: root.outputOptions
+
+                                    delegate: TextButton {
+                                        required property var modelData
+
+                                        Layout.fillWidth: true
+                                        text: modelData.label
+                                        checked: root.selectedOutput === modelData.label
+                                        toggle: false
+                                        type: TextButton.Tonal
+                                        radius: stateLayer.pressed ? Tokens.rounding.small / 2 : internalChecked ? Tokens.rounding.small : Tokens.rounding.normal
+                                        inactiveColour: Colours.layer(Colours.palette.m3surfaceContainerHighest, 2)
+                                        Layout.preferredWidth: implicitWidth + (stateLayer.pressed ? Tokens.padding.large : internalChecked ? Tokens.padding.smaller : 0)
+
+                                        onClicked: modelData.onToggled(true)
+
+                                        Behavior on Layout.preferredWidth {
+                                            Anim {
+                                                duration: Tokens.anim.durations.expressiveFastSpatial
+                                                easing: Tokens.anim.expressiveFastSpatial
+                                            }
+                                        }
+
+                                        Behavior on radius {
+                                            Anim {
+                                                duration: Tokens.anim.durations.expressiveFastSpatial
+                                                easing: Tokens.anim.expressiveFastSpatial
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                    }
+
+                    CollapsibleSection {
+                        Layout.fillWidth: true
+                        title: qsTr("Playback")
+                        expanded: true
+
+                        SplitButtonRow {
+                            id: fitModeSelector
+
+                            function syncActiveItem(): void {
+                                active = VideoWallpaper.fitMode === "Fit" ? fitModeFitItem : VideoWallpaper.fitMode === "Stretch" ? fitModeStretchItem : fitModeCropItem;
+                            }
+
+                            label: qsTr("Fit mode")
+                            menuItems: [fitModeCropItem, fitModeFitItem, fitModeStretchItem]
+
+                            Component.onCompleted: syncActiveItem()
+
+                            Connections {
+                                target: VideoWallpaper
+
+                                function onFitModeChanged(): void {
+                                    fitModeSelector.syncActiveItem();
+                                }
+                            }
+
+                            MenuItem {
+                                id: fitModeCropItem
+
+                                text: qsTr("Crop")
+                                icon: "crop"
+                                activeText: qsTr("Crop")
+                                onClicked: VideoWallpaper.fitMode = "Crop"
+                            }
+
+                            MenuItem {
+                                id: fitModeFitItem
+
+                                text: qsTr("Fit")
+                                icon: "fit_screen"
+                                activeText: qsTr("Fit")
+                                onClicked: VideoWallpaper.fitMode = "Fit"
+                            }
+
+                            MenuItem {
+                                id: fitModeStretchItem
+
+                                text: qsTr("Stretch")
+                                icon: "open_in_full"
+                                activeText: qsTr("Stretch")
+                                onClicked: VideoWallpaper.fitMode = "Stretch"
+                            }
+                        }
+
+                        SwitchRow {
+                            label: qsTr("Loop")
+                            checked: VideoWallpaper.loop
+                            onToggled: checked => VideoWallpaper.loop = checked
+                        }
+
+                        SwitchRow {
+                            label: qsTr("Start automatically")
+                            checked: VideoWallpaper.autoStart
+                            onToggled: checked => VideoWallpaper.autoStart = checked
+                        }
+
+                        SliderInput {
+                            Layout.fillWidth: true
+                            label: qsTr("Playback rate")
+                            value: VideoWallpaper.playbackRate
+                            from: 0.25
+                            to: 2.0
+                            stepSize: 0.05
+                            suffix: "×"
+                            decimals: 2
+                            validator: DoubleValidator {
+                                bottom: 0.25
+                                top: 2.0
+                                decimals: 2
+                            }
+                            formatValueFunction: val => Number(val).toFixed(2)
+                            parseValueFunction: text => Number(text)
+                            onValueModified: newValue => VideoWallpaper.playbackRate = newValue
+                        }
+
+                        SliderInput {
+                            Layout.fillWidth: true
+                            label: qsTr("Fade duration")
+                            value: VideoWallpaper.fadeDuration
+                            from: 0
+                            to: 2000
+                            stepSize: 50
+                            suffix: "ms"
+                            validator: IntValidator {
+                                bottom: 0
+                                top: 2000
+                            }
+                            formatValueFunction: val => Math.round(val).toString()
+                            parseValueFunction: text => parseInt(text)
+                            onValueModified: newValue => VideoWallpaper.fadeDuration = newValue
+                        }
+                    }
+                }
+            }
+        }
+
+        rightContent: Component {
+            Item {
+                ColumnLayout {
+                    anchors.fill: parent
+                    anchors.margins: Tokens.padding.large
+                    spacing: Tokens.spacing.normal
+
+                    RowLayout {
+                        Layout.fillWidth: true
+
+                        StyledTextField {
+                            Layout.fillWidth: true
+                            placeholderText: qsTr("Search videos")
+                            text: root.searchText
+                            onTextChanged: root.searchText = text
+                        }
+                    }
+
+                    VideoWallpaperGrid {
+                        id: videoGrid
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        session: root.session
+                        searchText: root.searchText
+                        selectedPath: root.selectedPath
+                        onSourceSelected: path => {
+                            root.selectedPath = path;
+                            root.pendingSelection = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/services/VideoWallpaper.qml
+++ b/services/VideoWallpaper.qml
@@ -1,0 +1,831 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.utils
+import qs.services
+
+QtObject {
+    id: root
+
+    property string source: ""
+    property string activeSource: ""
+    property string output: "ALL"
+    property var monitorSourceMap: ({})
+    property string fitMode: "Crop"
+    property real playbackRate: 1.0
+    property bool loop: true
+    property int fadeDuration: 250
+    property bool running: false
+    property bool paused: false
+    property bool visualActive: false
+    property bool autoStart: false
+    property string sortMode: "name"
+    property string performanceMode: "Aggressive"
+
+    property string pendingMode: ""
+    property string pendingSource: ""
+    property string pendingOutput: ""
+    property var thumbnailCache: ({})
+    property var thumbnailJobs: []
+    property string activeThumbnailSource: ""
+    property string activeThumbnailCachePath: ""
+    property var metadataCache: ({})
+    property var metadataJobs: []
+    property string activeMetadataSource: ""
+    property bool configLoaded: false
+    property bool applyingConfig: false
+    property bool mutatingState: false
+
+    property string backendStatus: "Stopped"
+
+    readonly property string configPath: `${Paths.config}/video-wallpaper.json`
+    readonly property bool activeWallpaper: running && visualActive
+    readonly property string thumbnailCacheDir: `${Paths.imagecache}/videowallpaper`
+    readonly property string thumbnailCacheVersion: "v2"
+    readonly property bool performanceLimited: GameMode.enabled
+    readonly property bool effectivePaused: paused || (running && performanceLimited)
+    readonly property string primaryMonitorName: {
+        const names = Hypr.monitorNames();
+        return names.length ? names[0] : "";
+    }
+
+    function monitorSourceKeys() {
+        return Object.keys(monitorSourceMap || {});
+    }
+
+    function defaultConfigObject() {
+        return {
+            source: "",
+            output: "ALL",
+            monitorSources: [],
+            fitMode: "Crop",
+            playbackRate: 1.0,
+            loop: true,
+            fadeDuration: 250,
+            autoStart: false,
+            sortMode: "name",
+            performanceMode: "Aggressive"
+        };
+    }
+
+    function readConfigObject() {
+        const raw = String(configFile.text() || "").trim();
+        if (!raw)
+            return defaultConfigObject();
+
+        try {
+            return Object.assign(defaultConfigObject(), JSON.parse(raw));
+        } catch (error) {
+            console.warn(`Failed to parse video wallpaper config: ${error}`);
+            return defaultConfigObject();
+        }
+    }
+
+    function writeConfigObject(value) {
+        configFile.setText(JSON.stringify(Object.assign(defaultConfigObject(), value || {}), null, 4) + "\n");
+    }
+
+    function hasPerMonitorAssignments() {
+        return monitorSourceKeys().length > 0;
+    }
+
+    function preferredAssignedSource() {
+        const keys = monitorSourceKeys();
+        if (!keys.length)
+            return "";
+
+        if (primaryMonitorName) {
+            const primarySource = String(monitorSourceMap[primaryMonitorName] || "");
+            if (primarySource)
+                return primarySource;
+        }
+
+        return String(monitorSourceMap[keys[0]] || "");
+    }
+
+    function normalizedOutputForConfig() {
+        if (!hasPerMonitorAssignments())
+            return "ALL";
+
+        const currentOutput = String(output || "");
+        if (currentOutput && currentOutput !== "ALL" && String(monitorSourceMap[currentOutput] || ""))
+            return currentOutput;
+
+        if (primaryMonitorName && String(monitorSourceMap[primaryMonitorName] || ""))
+            return primaryMonitorName;
+
+        const keys = monitorSourceKeys();
+        return keys.length ? keys[0] : "ALL";
+    }
+
+    function globalSource() {
+        return hasPerMonitorAssignments() ? "" : String(source || "");
+    }
+
+    function assignedSourceForMonitor(monitorName) {
+        const targetName = String(monitorName || "");
+        if (!targetName)
+            return "";
+        return String(monitorSourceMap[targetName] || "");
+    }
+
+    function activeOutputNames() {
+        const names = Hypr.monitorNames();
+        if (!running || !visualActive)
+            return [];
+
+        if (hasPerMonitorAssignments()) {
+            const assignedNames = [];
+            for (let i = 0; i < names.length; i++) {
+                if (String(monitorSourceMap[names[i]] || ""))
+                    assignedNames.push(names[i]);
+            }
+            if (performanceMode === "Aggressive"
+                && assignedNames.length > 1
+                && primaryMonitorName
+                && assignedNames.includes(primaryMonitorName))
+                return [primaryMonitorName];
+            return assignedNames;
+        }
+
+        if (!source)
+            return [];
+
+        const activeNames = [];
+        for (let i = 0; i < names.length; i++) {
+            activeNames.push(names[i]);
+        }
+        if (performanceMode === "Aggressive"
+            && activeNames.length > 1
+            && primaryMonitorName
+            && activeNames.includes(primaryMonitorName))
+            return [primaryMonitorName];
+        return activeNames;
+    }
+
+    function usesPrimaryOnly() {
+        const activeNames = activeOutputNames();
+        return performanceMode === "Aggressive"
+            && Hypr.monitorNames().length > 1
+            && !!primaryMonitorName
+            && activeNames.length === 1
+            && activeNames[0] === primaryMonitorName;
+    }
+
+    function shouldDisplayOn(monitorName, screenName) {
+        const targetName = String(monitorName || screenName || "");
+        if (!targetName)
+            return false;
+        return activeOutputNames().includes(targetName);
+    }
+
+    function monitorSourcesToList() {
+        const items = [];
+        const keys = Object.keys(monitorSourceMap || {});
+        for (let i = 0; i < keys.length; i++) {
+            const monitor = keys[i];
+            const assignedSource = String(monitorSourceMap[monitor] || "");
+            if (!assignedSource)
+                continue;
+            items.push({
+                monitor: monitor,
+                source: assignedSource
+            });
+        }
+        return items;
+    }
+
+    function monitorSourcesFromValue(value) {
+        const result = {};
+        if (!Array.isArray(value))
+            return result;
+        for (let i = 0; i < value.length; i++) {
+            const entry = value[i];
+            const monitor = String(entry?.monitor || "");
+            const assignedSource = String(entry?.source || "");
+            if (!monitor || !assignedSource)
+                continue;
+            result[monitor] = assignedSource;
+        }
+        return result;
+    }
+
+    function sourceForOutput(outputName) {
+        const targetName = String(outputName || "");
+        if (!targetName)
+            return "";
+
+        if (targetName === "ALL")
+            return globalSource();
+
+        if (hasPerMonitorAssignments())
+            return assignedSourceForMonitor(targetName);
+
+        return globalSource();
+    }
+
+    function sourceForMonitor(monitorName, screenName) {
+        return sourceForOutput(String(monitorName || screenName || ""));
+    }
+
+    function activeOutputsForSource(path) {
+        if (!path || !running || !visualActive)
+            return [];
+        const names = Hypr.monitorNames();
+        const matches = [];
+        for (let i = 0; i < names.length; i++) {
+            if (sourceForOutput(names[i]) === path)
+                matches.push(names[i]);
+        }
+        if (performanceMode === "Aggressive" && matches.length > 1 && primaryMonitorName)
+            return matches.includes(primaryMonitorName) ? [primaryMonitorName] : [];
+        return matches;
+    }
+
+    function activeOutputsTextForSource(path) {
+        const names = activeOutputsForSource(path);
+        if (!names.length)
+            return "";
+        const allNames = Hypr.monitorNames();
+        if (names.length === allNames.length)
+            return "ALL";
+        return names.join(", ");
+    }
+
+    function isSourceActive(path) {
+        return activeOutputsForSource(path).length > 0;
+    }
+
+    function setSourceForOutput(outputName, path) {
+        const targetName = String(outputName || "");
+        const assignedSource = String(path || "");
+        if (!assignedSource)
+            return;
+
+        ensureThumbnail(assignedSource);
+        ensureMetadata(assignedSource);
+
+        if (targetName === "ALL" || !targetName) {
+            source = assignedSource;
+            output = "ALL";
+            monitorSourceMap = ({});
+        } else {
+            const nextMap = Object.assign({}, monitorSourceMap);
+            nextMap[targetName] = assignedSource;
+            monitorSourceMap = nextMap;
+            output = targetName;
+            source = "";
+        }
+
+        activeSource = assignedSource;
+        scheduleConfigSave();
+        syncPlaybackBackend();
+    }
+
+    function applySelection(outputName, path) {
+        const targetName = String(outputName || "");
+        const assignedSource = String(path || "");
+        if (!assignedSource)
+            return;
+
+        const currentAssignedSource = sourceForOutput(targetName);
+        const shouldSwitch = running
+            && visualActive
+            && currentAssignedSource
+            && currentAssignedSource !== assignedSource;
+
+        mutatingState = true;
+        if (shouldSwitch) {
+            pendingMode = "switch";
+            pendingSource = assignedSource;
+            pendingOutput = targetName || "ALL";
+            running = true;
+            paused = false;
+            backendStatus = qsTr("Running");
+            visualActive = false;
+            transitionTimer.restart();
+        } else {
+            setSourceForOutput(targetName, assignedSource);
+            start(assignedSource);
+            writeConfig();
+        }
+        mutatingState = false;
+    }
+
+    function finishTransition() {
+        switch (pendingMode) {
+        case "stop":
+            activeSource = "";
+            break;
+        case "pause":
+            break;
+        case "resume":
+            if (!activeSource)
+                activeSource = preferredAssignedSource() || source;
+            visualActive = true;
+            break;
+        case "start":
+            if (pendingSource && !hasPerMonitorAssignments())
+                source = pendingSource;
+            if (!activeSource)
+                activeSource = preferredAssignedSource() || source;
+            visualActive = true;
+            break;
+        case "switch":
+            if (pendingSource) {
+                setSourceForOutput(pendingOutput || "ALL", pendingSource);
+                activeSource = preferredAssignedSource() || source;
+            }
+            visualActive = true;
+            break;
+        default:
+            break;
+        }
+
+        pendingMode = "";
+        pendingSource = "";
+        pendingOutput = "";
+        syncPlaybackBackend();
+        if (mutatingState)
+            return;
+        writeConfig();
+    }
+
+    function start(path) {
+        const nextSource = String(path || preferredAssignedSource() || source || "");
+        if (!nextSource)
+            return;
+
+        if (path)
+            activeSource = nextSource;
+        if (!source && !hasPerMonitorAssignments())
+            source = nextSource;
+        running = true;
+        paused = false;
+        if (!activeSource)
+            activeSource = nextSource;
+        visualActive = true;
+        syncPlaybackBackend();
+    }
+
+    function stop() {
+        if (!activeSource && !visualActive) {
+            running = false;
+            paused = false;
+            backendStatus = qsTr("Stopped");
+            return;
+        }
+
+        running = false;
+        paused = false;
+        backendStatus = qsTr("Stopped");
+        pendingMode = "stop";
+        visualActive = false;
+        transitionTimer.restart();
+    }
+
+    function pause() {
+        if (!running)
+            return;
+        paused = true;
+        backendStatus = qsTr("Paused");
+        syncPlaybackBackend();
+    }
+
+    function resume() {
+        if (!running || (!source && !Object.keys(monitorSourceMap || {}).length))
+            return;
+        paused = false;
+        if (!activeSource)
+            activeSource = preferredAssignedSource() || source;
+        syncPlaybackBackend();
+    }
+
+    function togglePause() {
+        if (!running)
+            return;
+        if (paused)
+            resume();
+        else
+            pause();
+    }
+
+    function selectSource(path) {
+        if (!path)
+            return;
+
+        activeSource = path;
+        if (running) {
+            paused = false;
+            visualActive = true;
+            syncPlaybackBackend();
+        }
+    }
+
+    function fileNameFor(path) {
+        const text = String(path || "");
+        const parts = text.split("/");
+        return parts.length > 0 ? parts[parts.length - 1] : text;
+    }
+
+    function cacheKeyFor(path) {
+        let h1 = 0xdeadbeef, h2 = 0x41c6ce57, ch;
+        for (let i = 0; i < path.length; i++) {
+            ch = path.charCodeAt(i);
+            h1 = Math.imul(h1 ^ ch, 2654435761);
+            h2 = Math.imul(h2 ^ ch, 1597334677);
+        }
+        h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+        h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+        h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+        h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+        return (h2 >>> 0).toString(16).padStart(8, "0") + (h1 >>> 0).toString(16).padStart(8, "0");
+    }
+
+    function cachePathFor(path) {
+        return `${thumbnailCacheDir}/${cacheKeyFor(path)}-${thumbnailCacheVersion}.jpg`;
+    }
+
+    function thumbnailFor(path) {
+        if (!path)
+            return "";
+        return thumbnailCache[path] || cachePathFor(path);
+    }
+
+    function ensureThumbnail(path) {
+        if (!path || thumbnailCache[path] || activeThumbnailSource === path || thumbnailJobs.includes(path))
+            return;
+        queueThumbnailGeneration(path, cachePathFor(path));
+    }
+
+    function queueThumbnailGeneration(path, cachePath) {
+        if (!path || thumbnailCache[path] || activeThumbnailSource === path || thumbnailJobs.includes(path))
+            return;
+        const nextJobs = thumbnailJobs.slice();
+        nextJobs.push(path);
+        thumbnailJobs = nextJobs;
+        if (!activeThumbnailSource)
+            startNextThumbnailJob(cachePath);
+    }
+
+    function startNextThumbnailJob(preferredCachePath) {
+        if (activeThumbnailSource || !thumbnailJobs.length)
+            return;
+
+        const nextPath = thumbnailJobs[0];
+        activeThumbnailSource = nextPath;
+        activeThumbnailCachePath = preferredCachePath || cachePathFor(nextPath);
+        thumbnailGen.command = [
+            "/usr/bin/bash",
+            "-lc",
+            "mkdir -p \"$1\" && ffmpeg -y -loglevel error -i \"$2\" -vf \"select='eq(n\\,0)',scale=640:-1\" -frames:v 1 \"$3\"",
+            "--",
+            thumbnailCacheDir,
+            nextPath,
+            activeThumbnailCachePath
+        ];
+        thumbnailGen.running = true;
+    }
+
+    function finishThumbnailJob(success) {
+        const path = activeThumbnailSource;
+        const cachePath = activeThumbnailCachePath;
+
+        if (path) {
+            thumbnailJobs = thumbnailJobs.filter(function(item) { return item !== path; });
+            if (success)
+                thumbnailCache = Object.assign({}, thumbnailCache, { [path]: `${cachePath}?v=${Date.now()}` });
+        }
+
+        activeThumbnailSource = "";
+        activeThumbnailCachePath = "";
+        startNextThumbnailJob();
+    }
+
+    function metadataFor(path) {
+        if (!path)
+            return null;
+        return metadataCache[path] || null;
+    }
+
+    function preloadMetadata(paths) {
+        const items = paths || [];
+        for (let i = 0; i < items.length; i++)
+            ensureMetadata(items[i]);
+    }
+
+    function ensureMetadata(path) {
+        if (!path || metadataCache[path] || activeMetadataSource === path || metadataJobs.includes(path))
+            return;
+        const nextJobs = metadataJobs.slice();
+        nextJobs.push(path);
+        metadataJobs = nextJobs;
+        if (!activeMetadataSource)
+            startNextMetadataJob();
+    }
+
+    function parseFrameRate(value) {
+        const text = String(value || "");
+        if (!text)
+            return 0;
+        if (text.indexOf("/") !== -1) {
+            const parts = text.split("/");
+            const numerator = Number(parts[0] || 0);
+            const denominator = Number(parts[1] || 1);
+            if (denominator === 0)
+                return 0;
+            return numerator / denominator;
+        }
+        return Number(text || 0);
+    }
+
+    function parseMetadataOutput(text, path) {
+        const data = {
+            path: path,
+            duration: 0,
+            size: 0,
+            width: 0,
+            height: 0,
+            fps: 0,
+            codec: ""
+        };
+        const lines = String(text || "").split("\n");
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+            const tabIndex = line.indexOf("\t");
+            if (tabIndex === -1)
+                continue;
+            const key = line.slice(0, tabIndex);
+            const value = line.slice(tabIndex + 1).trim();
+            switch (key) {
+            case "duration":
+                data.duration = Number(value || 0);
+                break;
+            case "size":
+                data.size = Number(value || 0);
+                break;
+            case "width":
+                data.width = Number(value || 0);
+                break;
+            case "height":
+                data.height = Number(value || 0);
+                break;
+            case "fps":
+                data.fps = parseFrameRate(value);
+                break;
+            case "codec":
+                data.codec = value;
+                break;
+            default:
+                break;
+            }
+        }
+        data.resolutionPixels = data.width * data.height;
+        return data;
+    }
+
+    function startNextMetadataJob() {
+        if (activeMetadataSource || !metadataJobs.length)
+            return;
+
+        const nextPath = metadataJobs[0];
+        activeMetadataSource = nextPath;
+        metadataProbe.command = [
+            "/usr/bin/bash",
+            "-lc",
+            "ffprobe -v error -select_streams v:0 -show_entries stream=width,height,avg_frame_rate,codec_name -show_entries format=duration,size -of default=noprint_wrappers=1:nokey=0 \"$1\" | sed -e 's/^avg_frame_rate=/fps\\t/' -e 's/^codec_name=/codec\\t/' -e 's/^width=/width\\t/' -e 's/^height=/height\\t/' -e 's/^duration=/duration\\t/' -e 's/^size=/size\\t/'",
+            "--",
+            nextPath
+        ];
+        metadataProbe.running = true;
+    }
+
+    function finishMetadataJob(success, text) {
+        const path = activeMetadataSource;
+
+        if (path) {
+            metadataJobs = metadataJobs.filter(function(item) { return item !== path; });
+            if (success) {
+                metadataCache = Object.assign({}, metadataCache, { [path]: parseMetadataOutput(text, path) });
+                if (path === activeSource || path === source)
+                    syncPlaybackBackend();
+            }
+        }
+
+        activeMetadataSource = "";
+        startNextMetadataJob();
+    }
+
+    function performanceStatusText() {
+        if (!running)
+            return qsTr("Stopped");
+        if (paused)
+            return qsTr("Paused");
+        if (performanceLimited)
+            return qsTr("Paused for game mode");
+        if (usesPrimaryOnly())
+            return qsTr("Primary only");
+        return qsTr("Running");
+    }
+
+    function syncPlaybackBackend() {
+        if (!running || (!source && !Object.keys(monitorSourceMap || {}).length)) {
+            visualActive = false;
+            backendStatus = performanceStatusText();
+            return;
+        }
+
+        if (effectivePaused) {
+            visualActive = true;
+            backendStatus = performanceStatusText();
+            return;
+        }
+
+        const targetSource = activeSource || preferredAssignedSource() || source;
+        if (!targetSource) {
+            visualActive = false;
+            backendStatus = performanceStatusText();
+            return;
+        }
+
+        visualActive = true;
+        backendStatus = performanceStatusText();
+    }
+
+    function scheduleConfigSave() {
+        if (!configLoaded || applyingConfig || mutatingState)
+            return;
+        saveConfigTimer.restart();
+    }
+
+    function applyConfigState() {
+        const cfg = readConfigObject();
+        applyingConfig = true;
+
+        const restoredMap = monitorSourcesFromValue(cfg.monitorSources || []);
+        const restoredKeys = Object.keys(restoredMap);
+        monitorSourceMap = restoredMap;
+        source = restoredKeys.length ? "" : (cfg.source || "");
+        if (restoredKeys.length) {
+            output = String(cfg.output || "");
+            output = normalizedOutputForConfig();
+        } else {
+            output = "ALL";
+        }
+        fitMode = cfg.fitMode || "Crop";
+        playbackRate = Number(cfg.playbackRate || 1);
+        loop = cfg.loop !== false;
+        fadeDuration = Number(cfg.fadeDuration || 250);
+        autoStart = !!cfg.autoStart;
+        sortMode = cfg.sortMode || "name";
+        performanceMode = cfg.performanceMode || "Aggressive";
+        activeSource = restoredKeys.length ? preferredAssignedSource() : source;
+
+        if (source) {
+            ensureThumbnail(source);
+            ensureMetadata(source);
+        }
+
+        const assignedSourceKeys = monitorSourceKeys();
+        for (let i = 0; i < assignedSourceKeys.length; i++) {
+            const assignedSource = String(monitorSourceMap[assignedSourceKeys[i]] || "");
+            ensureThumbnail(assignedSource);
+            ensureMetadata(assignedSource);
+        }
+
+        if (!configLoaded)
+            configLoaded = true;
+
+        if (source || assignedSourceKeys.length) {
+            if (autoStart)
+                start(assignedSourceKeys.length ? preferredAssignedSource() : source);
+            else
+                syncPlaybackBackend();
+        } else {
+            syncPlaybackBackend();
+        }
+
+        applyingConfig = false;
+    }
+
+    function writeConfig() {
+        const configOutput = normalizedOutputForConfig();
+        writeConfigObject({
+            source: globalSource(),
+            output: configOutput,
+            monitorSources: monitorSourcesToList(),
+            fitMode: fitMode,
+            playbackRate: playbackRate,
+            loop: loop,
+            fadeDuration: fadeDuration,
+            autoStart: autoStart,
+            sortMode: sortMode,
+            performanceMode: performanceMode
+        });
+        output = configOutput;
+    }
+
+    Component.onCompleted: {
+        if (configFile.loaded)
+            applyConfigState();
+        else
+            startupConfigTimer.restart();
+    }
+
+    onSourceChanged: {
+        if (source) {
+            ensureThumbnail(source);
+            ensureMetadata(source);
+        }
+        syncPlaybackBackend();
+        scheduleConfigSave();
+    }
+    onOutputChanged: { syncPlaybackBackend(); scheduleConfigSave(); }
+    onFitModeChanged: scheduleConfigSave()
+    onPlaybackRateChanged: scheduleConfigSave()
+    onLoopChanged: scheduleConfigSave()
+    onFadeDurationChanged: scheduleConfigSave()
+    onAutoStartChanged: scheduleConfigSave()
+    onSortModeChanged: scheduleConfigSave()
+    onPerformanceModeChanged: { syncPlaybackBackend(); scheduleConfigSave(); }
+    onPerformanceLimitedChanged: syncPlaybackBackend()
+    onPrimaryMonitorNameChanged: syncPlaybackBackend()
+
+    readonly property Timer transitionTimer: Timer {
+        id: transitionTimer
+
+        interval: Math.max(1, root.fadeDuration)
+        onTriggered: root.finishTransition()
+    }
+
+    readonly property Timer saveConfigTimer: Timer {
+        id: saveConfigTimer
+
+        interval: 250
+        onTriggered: root.writeConfig()
+    }
+
+    readonly property Timer startupConfigTimer: Timer {
+        id: startupConfigTimer
+
+        interval: 300
+        repeat: false
+        onTriggered: {
+            if (root.configLoaded)
+                return;
+            if (configFile.loaded)
+                root.applyConfigState();
+            else
+                restart();
+        }
+    }
+
+    readonly property FileView configFile: FileView {
+        id: configFile
+
+        path: root.configPath
+        watchChanges: true
+        printErrors: false
+
+        onLoaded: {
+            if (!root.configLoaded)
+                root.applyConfigState();
+        }
+
+        onLoadFailed: error => {
+            if (!root.configLoaded) {
+                root.configLoaded = true;
+                root.applyingConfig = false;
+                root.syncPlaybackBackend();
+                if (error === FileViewError.FileNotFound)
+                    Qt.callLater(() => root.writeConfigObject(root.defaultConfigObject()));
+            }
+        }
+
+        onFileChanged: reload()
+    }
+
+    readonly property Process thumbnailGen: Process {
+        id: thumbnailGen
+
+        running: false
+        onExited: exitCode => root.finishThumbnailJob(exitCode === 0)
+    }
+
+    readonly property Process metadataProbe: Process {
+        id: metadataProbe
+
+        running: false
+
+        stdout: StdioCollector {
+            id: metadataCollector
+        }
+
+        stderr: StdioCollector {}
+
+        onExited: exitCode => root.finishMetadataJob(exitCode === 0, metadataCollector.text)
+    }
+
+}


### PR DESCRIPTION
Summary
-------
a dedicated service for wallpaper playback, a Control Center panel for managing
videos and outputs, and a background renderer that displays the selected video per monitor.

What this adds
--------------
1. Video wallpaper service
- a new global service manages playback state, selection, pause/resume, stop, and persistence
- configuration is stored in `~/.config/caelestia/video-wallpaper.json`
- the service tracks:
  - selected source
  - output selection
  - per-monitor assignments
  - fit mode
  - playback rate
  - loop
  - fade duration
  - auto start

2. Background video rendering
- the background stack now includes a `VideoBackground` renderer
- video playback is handled through `QtMultimedia`
- visibility is driven by the active wallpaper state and the selected output

3. Control Center panel
- a new `Video Wallpaper` panel was added to the Control Center
- it lets the user:
  - browse available videos
  - preview metadata
  - apply a video to one or more outputs
  - pause, resume, and stop playback
  - adjust fit mode, loop, playback rate, fade duration, and auto start

4. Video listing and preview generation
- the panel lists videos from the wallpaper directory
- metadata is collected with `ffprobe`
- thumbnails are generated with `ffmpeg`

5. UI integration
- the feature is integrated into the existing shell structure
- the launcher and file manager can open related internal windows
- state persists across shell restarts

Relevant files
--------------
- `services/VideoWallpaper.qml`
- `modules/background/Background.qml`
- `modules/background/VideoBackground.qml`
- `modules/controlcenter/videowallpaper/VideoWallpaperPane.qml`
- `modules/controlcenter/components/VideoWallpaperGrid.qml`
- `modules/controlcenter/PaneRegistry.qml`