### PR TITLE
fix(bar): resolve icons advertised with custom theme path

### DIFF
--- a/modules/bar/components/TrayItem.qml
+++ b/modules/bar/components/TrayItem.qml
@@ -26,9 +26,18 @@ MouseArea {
     ColouredIcon {
         id: icon
 
+        readonly property var candidates: Icons.getTrayIconCandidates(root.modelData.id, root.modelData.icon)
+        property int candidateIndex: 0
+
         anchors.fill: parent
-        source: Icons.getTrayIcon(root.modelData.id, root.modelData.icon)
+        source: candidates[candidateIndex] ?? ""
         colour: Colours.palette.m3secondary
         layer.enabled: Config.bar.tray.recolour
+
+        onCandidatesChanged: candidateIndex = 0
+        onStatusChanged: {
+            if (status === Image.Error && candidateIndex < candidates.length - 1)
+                candidateIndex++;
+        }
     }
 }

--- a/utils/Icons.qml
+++ b/utils/Icons.qml
@@ -234,11 +234,41 @@ Singleton {
             if (sub.id === id)
                 return sub.image ? Qt.resolvedUrl(sub.image) : Quickshell.iconPath(sub.icon);
 
-        if (icon.includes("?path=")) {
-            const [name, path] = icon.split("?path=");
-            icon = Qt.resolvedUrl(`${path}/${name.slice(name.lastIndexOf("/") + 1)}`);
-        }
+        // For `name?path=/theme/root` (e.g. Dropbox), the consumer must walk
+        // freedesktop subdirs to find the actual file. Return the original
+        // string so TrayItem can iterate candidates via getTrayIconCandidates.
         return icon;
+    }
+
+    function getTrayIconCandidates(id: string, icon: string): var {
+        for (const sub of GlobalConfig.bar.tray.iconSubs)
+            if (sub.id === id)
+                return [sub.image ? Qt.resolvedUrl(sub.image) : Quickshell.iconPath(sub.icon)];
+
+        if (!icon.includes("?path="))
+            return [icon];
+
+        const [rawName, path] = icon.split("?path=");
+        const name = rawName.slice(rawName.lastIndexOf("/") + 1);
+        const sizes = ["scalable", "symbolic", "48x48", "32x32", "24x24", "22x22", "16x16"];
+        const cats = ["status", "apps", "actions", "devices", "categories", "places", "panel"];
+        const exts = [".png", ".svg"];
+        const out = [];
+
+        // 1. directly in path (legacy behaviour)
+        for (const ext of exts)
+            out.push(Qt.resolvedUrl(`${path}/${name}${ext}`));
+
+        // 2. proper freedesktop layout. The advertised path is the theme root,
+        // so try `hicolor` subtheme plus path itself as a theme dir.
+        for (const theme of ["hicolor", ""]) {
+            const base = theme ? `${path}/${theme}` : path;
+            for (const size of sizes)
+                for (const cat of cats)
+                    for (const ext of exts)
+                        out.push(Qt.resolvedUrl(`${base}/${size}/${cat}/${name}${ext}`));
+        }
+        return out;
     }
 
     function getBatteryIcon(charge: int): string {


### PR DESCRIPTION
## Problem

Tray icons from apps that ship their own icon theme (Dropbox, KeePassXC, and others) never render — only the missing-icon fallback shows up. The bar still receives the item (clicks and the menu work), but the pixmap is blank.

## Root cause

Such apps expose their icon over StatusNotifierItem as:

```
image://icon/<name>?path=/absolute/theme/root
```

For example, Dropbox sends:

```
image://icon/dropboxstatus-idle?path=/home/<user>/.dropbox-dist/dropbox-lnx.x86_64-XXXXXXX/images
```

The advertised `path` is the **theme root** (containing `hicolor/<size>/<category>/...`), not the leaf directory of the file. The previous `Icons.getTrayIcon` split the URL and built `file://<path>/<name>` directly — no extension, wrong directory — so `IconImage` could never load it.

## Fix

- Replace `getTrayIcon` with `getTrayIconCandidates(id, icon)` which returns an ordered list of candidate URLs:
  1. `iconSubs` overrides (unchanged behavior).
  2. The raw `path` root, with `.png` / `.svg`.
  3. Standard freedesktop layout under the path: `[hicolor|""]/<size>/<category>/<name>.<ext>` across common sizes (`16x16` → `scalable`) and categories (`status`, `apps`, `actions`, …).
- `TrayItem` consumes the list and walks to the next candidate on `Image.Error`, stopping at the first that loads.

For icons without `?path=` (most apps using the system theme, or `image://qspixmap/...` from `IconPixmap`), the candidate list is just `[icon]`, so behavior is unchanged.

## Files

- `utils/Icons.qml`: introduces `getTrayIconCandidates`.
- `modules/bar/components/TrayItem.qml`: iterates candidates on load failure.

## Testing

- Dropbox 252.4.3485 on Hyprland: tray icon now renders correctly (resolves to `…/images/hicolor/16x16/status/dropboxstatus-idle.png`).
- Regular apps using `image://icon/<name>` (Arch-Update, etc.): unchanged.
- `image://qspixmap/...` from apps that embed pixmaps via D-Bus: unchanged.
- `iconSubs` substitutions in `bar.tray.iconSubs`: still applied first.

## Notes

The freedesktop spec calls for a full theme lookup using `index.theme`, but doing that in pure QML would mean parsing the theme file and walking directories. The candidate-list approach covers every real-world layout I could find (Dropbox, KeePassXC, Discord-style trays) with negligible cost — `IconImage` only requests the next URL when the previous one errors.