### PR TITLE
fix: global-only config properties not inherited by per-monitor overlays

### DIFF
--- a/plugin/src/Caelestia/Config/configobject.cpp
+++ b/plugin/src/Caelestia/Config/configobject.cpp
@@ -152,9 +152,6 @@ void ConfigObject::syncFromGlobal(ConfigObject* global) {
         auto prop = meta->property(i);
         const auto key = QString::fromUtf8(prop.name());
 
-        if (isGlobalOnly(key))
-            continue;
-
         auto current = prop.read(this);
         auto* subObj = current.value<ConfigObject*>();
 
@@ -188,9 +185,6 @@ void ConfigObject::resyncFromGlobal() {
     for (int i = meta->propertyOffset(); i < meta->propertyCount(); ++i) {
         auto prop = meta->property(i);
         const auto key = QString::fromUtf8(prop.name());
-
-        if (isGlobalOnly(key))
-            continue;
 
         auto current = prop.read(this);
         auto* subObj = current.value<ConfigObject*>();
@@ -274,7 +268,7 @@ void ConfigObject::resetOption(const QString& name) {
 
 void ConfigObject::onGlobalPropertiesChanged(const QMap<QString, QVariant>& changed) {
     for (auto it = changed.begin(); it != changed.end(); ++it) {
-        if (m_loadedKeys.contains(it.key()) || isGlobalOnly(it.key()))
+        if (m_loadedKeys.contains(it.key()))
             continue;
 
         int idx = metaObject()->indexOfProperty(it.key().toUtf8().constData());


### PR DESCRIPTION
Properties declared with `CONFIG_GLOBAL_PROPERTY` are meant to be read-only from a per-monitor
perspective - the user cannot override them per monitor. However, the current sync logic also
prevents these properties from inheriting the user's global value into overlay configs.

The three skip guards in `syncFromGlobal`, `resyncFromGlobal`, and `onGlobalPropertiesChanged`
stop the overlay from ever receiving the global value, leaving it at the C++ default.

A concrete example: `general.apps.explorer` defaults to `["thunar"]` in C++. A user who sets it
to `["dolphin"]` in `shell.json` will find it ignored - clicking "Show in folder" on a recording
in the shell still opens Thunar, because `RecordingList.qml` reads `Config.general.apps.explorer`
from a per-monitor overlay that never received the global value.

The fix removes the `isGlobalOnly` skip from the sync/propagation paths. The skip in `toJsonObject`
is kept (global-only props should not be written into per-monitor JSON), as is the warning in
`loadFromJson` (users should not set these per-monitor).