### PR TITLE
fix: prevent slider snapping back after seek

### DIFF
--- a/modules/dashboard/Media.qml
+++ b/modules/dashboard/Media.qml
@@ -312,21 +312,33 @@ Item {
         StyledSlider {
             id: slider
 
+            property bool isSeeking: false
+
             enabled: !!Players.active
             implicitWidth: 280
             implicitHeight: Tokens.padding.normal * 3
 
             onMoved: {
                 const active = Players.active;
-                if (active?.canSeek && active?.positionSupported)
+                if (active?.canSeek && active?.positionSupported) {
+                    isSeeking = true;
                     active.position = value * active.length;
+                    seekCooldown.restart();
+                }
+            }
+
+            Timer {
+                id: seekCooldown
+
+                interval: 500
+                onTriggered: slider.isSeeking = false;
             }
 
             Binding {
                 target: slider
                 property: "value"
                 value: root.playerProgress
-                when: !slider.pressed
+                when: !slider.pressed && !slider.isSeeking
             }
 
             CustomMouseArea {


### PR DESCRIPTION
## Problem

When seeking via the progress slider, the slider briefly snaps back to the previous position before settling at the correct seek point. This is more pronounced on lower-end hardware where the MPRIS position update takes longer to come through.

## Fix

Added an `isSeeking` property to the slider and a 500ms cooldown `Timer` (consistent with the approach already used in `LyricsService.qml`). The `Binding` is now suspended while `isSeeking` is true, giving Quickshell enough time to receive and reflect the updated MPRIS position before the binding re-activates.

fixed #1485