### PR TITLE
fix: inherit global-only config values in per-monitor overlays

### DIFF
--- a/plugin/src/Caelestia/Config/configobject.cpp
+++ b/plugin/src/Caelestia/Config/configobject.cpp
@@ -274,12 +274,20 @@ void ConfigObject::resetOption(const QString& name) {
 
 void ConfigObject::onGlobalPropertiesChanged(const QMap<QString, QVariant>& changed) {
     for (auto it = changed.begin(); it != changed.end(); ++it) {
-        if (m_loadedKeys.contains(it.key()) || isGlobalOnly(it.key()))
+        if (m_loadedKeys.contains(it.key()))
             continue;
 
         int idx = metaObject()->indexOfProperty(it.key().toUtf8().constData());
-        if (idx >= 0) {
-            metaObject()->property(idx).write(this, it.value());
+        if (idx < 0)
+            continue;
+
+        const auto prop = metaObject()->property(idx);
+
+        if (isGlobalOnly(it.key())) {
+            // Getter delegates to global, so just notify bindings to re-read
+            prop.notifySignal().invoke(this);
+        } else {
+            prop.write(this, it.value());
             m_loadedKeys.remove(it.key()); // setter added it — remove since this is a synced value
             qCDebug(lcConfig) << metaObject()->className() << "synced" << it.key() << "=" << it.value()
                               << "from global change";

--- a/plugin/src/Caelestia/Config/configobject.hpp
+++ b/plugin/src/Caelestia/Config/configobject.hpp
@@ -58,9 +58,8 @@ private:                                                                        
                                                                                                                        \
 public:                                                                                                                \
     [[nodiscard]] Type name() const {                                                                                  \
-        if (isOverlay())                                                                                               \
-            qCWarning(caelestia::config::lcConfig, "Reading global-only option '%s' on per-monitor overlay",           \
-                qUtf8Printable(propertyPath(QStringLiteral(#name))));                                                  \
+        if (isOverlay() && globalObject())                                                                             \
+            return qvariant_cast<Type>(globalObject()->property(#name));                                              \
         return m_##name;                                                                                               \
     }                                                                                                                  \
     void set_##name(const Type& val) {                                                                                 \
@@ -127,6 +126,7 @@ protected:
     void markPropertyLoaded(const QString& name);
     void markGlobalOnly(const QString& name);
     void notifyPropertyChanged(const QString& name, const QVariant& value);
+    [[nodiscard]] ConfigObject* globalObject() const { return m_global; }
 
 private:
     void onGlobalPropertiesChanged(const QMap<QString, QVariant>& changed);


### PR DESCRIPTION
`CONFIG_GLOBAL_PROPERTY` marks options that can't be overridden per monitor,
but the overlay was never receiving the user's global value either - it always
kept the C++ default instead.

The getter for such properties on overlays reads from the local field, so
`Config.general.apps.explorer` (for example) always returns `["thunar"]`
regardless of what the user sets in `shell.json`.

The fix makes the getter delegate to the global config when called on an
overlay. A `globalObject()` accessor is added to `ConfigObject` so the
generated getters can reach `m_global`. For live config updates,
`onGlobalPropertiesChanged` now emits the notify signal for global-only
properties instead of skipping them, so QML bindings re-read via the
delegating getter when the global value changes.

The "Reading global-only option" warning is removed from the getter - reading
on an overlay is now the correct path. The setter warning is unchanged;
writing global-only options per monitor is still wrong.

Tested on Hyprland with two monitors - `general.apps.explorer` and
`appearance.transparency.enabled` both reflect the values from `shell.json`
on per-monitor overlay configs, and live edits propagate correctly.