### PR TITLE
feat: add video and gif wallpaper support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Dependencies:
 -   [`bash`](https://www.gnu.org/software/bash)
 -   `qt6-base`
 -   `qt6-declarative`
+-   `qt6-multimedia` (optional - video wallpapers)
+-   [`ffmpeg`](https://ffmpeg.org) (optional - video wallpapers)
 
 Build dependencies:
 

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -4,7 +4,6 @@ import QtQuick
 import Caelestia.Config
 import qs.components
 import qs.components.filedialog
-import qs.components.images
 import qs.services
 import qs.utils
 
@@ -12,7 +11,7 @@ Item {
     id: root
 
     property string source: Wallpapers.current
-    property Image current: one
+    property Item current: one
     property bool completed
 
     onSourceChanged: {
@@ -73,8 +72,8 @@ Item {
                             id: dialog
 
                             title: qsTr("Select a wallpaper")
-                            filterLabel: qsTr("Image files")
-                            filters: Images.validImageExtensions
+                            filterLabel: qsTr("Image/video files")
+                            filters: Images.validWallpaperExtensions
                             onAccepted: path => Wallpapers.setWallpaper(path)
                         }
 
@@ -99,20 +98,22 @@ Item {
         }
     }
 
-    Img {
+    Slot {
         id: one
     }
 
-    Img {
+    Slot {
         id: two
     }
 
-    component Img: CachingImage {
-        id: img
+    component Slot: Item {
+        id: slot
+
+        property string path
 
         function update(): void {
             if (path === root.source)
-                root.current = this;
+                root.current = slot;
             else
                 path = root.source;
         }
@@ -122,26 +123,69 @@ Item {
         opacity: 0
         scale: Wallpapers.showPreview ? 1 : 0.8
 
-        onStatusChanged: {
-            if (status === Image.Ready)
-                root.current = this;
+        onPathChanged: {
+            if (!path)
+                loader.setSource("");
+            else if (Images.isValidVideoByName(path))
+                loader.setSource("WallpaperVideo.qml", {
+                    path
+                });
+            else if (Images.isAnimatedImageByName(path))
+                loader.setSource("WallpaperAnimated.qml", {
+                    path
+                });
+            else
+                loader.setSource("WallpaperImage.qml", {
+                    path
+                });
+        }
+
+        // Unload the hidden slot once faded out so videos/gifs stop decoding
+        onOpacityChanged: {
+            if (opacity === 0 && root.current !== slot)
+                path = "";
         }
 
         states: State {
             name: "visible"
-            when: root.current === img
+            when: root.current === slot
 
             PropertyChanges {
-                img.opacity: 1
-                img.scale: 1
+                slot.opacity: 1
+                slot.scale: 1
             }
         }
 
         transitions: Transition {
             Anim {
-                target: img
+                target: slot
                 properties: "opacity,scale"
             }
+        }
+
+        Loader {
+            id: loader
+
+            anchors.fill: parent
+            asynchronous: true
+
+            onStatusChanged: {
+                if (status === Loader.Error && Images.isValidVideoByName(slot.path)) {
+                    console.warn("Wallpaper: failed to load video player (is QtMultimedia installed?), falling back to a static frame");
+                    setSource("WallpaperImage.qml", {
+                        path: Wallpapers.videoFramePath(slot.path)
+                    });
+                }
+            }
+        }
+
+        Connections {
+            function onReadyChanged(): void {
+                if (loader.item.ready) // qmllint disable missing-property
+                    root.current = slot;
+            }
+
+            target: loader.item
         }
     }
 }

--- a/modules/background/WallpaperAnimated.qml
+++ b/modules/background/WallpaperAnimated.qml
@@ -1,0 +1,15 @@
+import QtQuick
+import Quickshell
+import qs.services
+
+AnimatedImage {
+    id: root
+
+    required property string path
+    readonly property bool ready: status === Image.Ready
+
+    source: path
+    asynchronous: true
+    fillMode: Image.PreserveAspectCrop
+    paused: !Wallpapers.animationsActiveOn((QsWindow.window as QsWindow)?.screen ?? null)
+}

--- a/modules/background/WallpaperImage.qml
+++ b/modules/background/WallpaperImage.qml
@@ -1,0 +1,6 @@
+import QtQuick
+import qs.components.images
+
+CachingImage {
+    readonly property bool ready: status === Image.Ready
+}

--- a/modules/background/WallpaperVideo.qml
+++ b/modules/background/WallpaperVideo.qml
@@ -1,0 +1,35 @@
+import QtQuick
+import QtMultimedia
+import Quickshell
+import qs.services
+
+VideoOutput {
+    id: root
+
+    required property string path
+    readonly property bool ready: player.mediaStatus === MediaPlayer.LoadedMedia || player.mediaStatus === MediaPlayer.BufferingMedia || player.mediaStatus === MediaPlayer.BufferedMedia // qmllint disable unqualified
+    readonly property bool shouldPlay: Wallpapers.animationsActiveOn((QsWindow.window as QsWindow)?.screen ?? null)
+
+    function syncPlayback(): void {
+        if (!ready)
+            return;
+
+        if (shouldPlay)
+            player.play();
+        else
+            player.pause();
+    }
+
+    fillMode: VideoOutput.PreserveAspectCrop // qmllint disable unqualified
+
+    onReadyChanged: syncPlayback()
+    onShouldPlayChanged: syncPlayback()
+
+    MediaPlayer {
+        id: player
+
+        source: root.path
+        videoOutput: root
+        loops: MediaPlayer.Infinite // qmllint disable unqualified
+    }
+}

--- a/modules/controlcenter/components/WallpaperGrid.qml
+++ b/modules/controlcenter/components/WallpaperGrid.qml
@@ -36,6 +36,8 @@ GridView {
         readonly property real itemMargin: Tokens.spacing.normal / 2
         readonly property real itemRadius: Tokens.rounding.normal
 
+        Component.onCompleted: Wallpapers.ensureVideoFrame(modelData.path)
+
         width: root.cellWidth
         height: root.cellHeight
 
@@ -69,7 +71,7 @@ GridView {
             CachingImage {
                 id: cachingImage
 
-                path: modelData.path
+                path: Wallpapers.thumbnailFor(modelData.path)
                 anchors.fill: parent
                 fillMode: Image.PreserveAspectCrop
                 cache: true
@@ -93,7 +95,7 @@ GridView {
                 id: fallbackImage
 
                 anchors.fill: parent
-                source: fallbackTimer.triggered && cachingImage.status !== Image.Ready ? modelData.path : ""
+                source: fallbackTimer.triggered && cachingImage.status !== Image.Ready ? Wallpapers.thumbnailFor(modelData.path) : ""
                 asynchronous: true
                 fillMode: Image.PreserveAspectCrop
                 cache: true

--- a/modules/launcher/items/WallpaperItem.qml
+++ b/modules/launcher/items/WallpaperItem.qml
@@ -6,6 +6,7 @@ import qs.components
 import qs.components.effects
 import qs.components.images
 import qs.services
+import qs.utils
 
 Item {
     id: root
@@ -20,6 +21,7 @@ Item {
     Component.onCompleted: {
         scale = Qt.binding(() => PathView.isCurrentItem ? 1 : PathView.onPath ? 0.8 : 0);
         opacity = Qt.binding(() => PathView.onPath ? 1 : 0);
+        Wallpapers.ensureVideoFrame(modelData.path);
     }
 
     implicitWidth: image.width + Tokens.padding.larger * 2
@@ -57,7 +59,7 @@ Item {
 
         MaterialIcon {
             anchors.centerIn: parent
-            text: "image"
+            text: Images.isValidVideoByName(root.modelData.path) ? "movie" : "image"
             color: Colours.tPalette.m3outline
             font.pointSize: Tokens.font.size.extraLarge * 2
             font.weight: 600
@@ -65,7 +67,7 @@ Item {
 
         CachingImage {
             anchors.fill: parent
-            path: root.modelData.path
+            path: Wallpapers.thumbnailFor(root.modelData.path)
             smooth: !root.PathView.view.moving
             sourceSize: {
                 const dpr = (QsWindow.window as QsWindow)?.devicePixelRatio ?? 1;

--- a/modules/lock/Lock.qml
+++ b/modules/lock/Lock.qml
@@ -5,6 +5,7 @@ import Quickshell
 import Quickshell.Io
 import Quickshell.Wayland
 import qs.components.misc
+import qs.services
 
 Scope {
     property alias lock: lock
@@ -13,6 +14,8 @@ Scope {
         id: lock
 
         signal unlock
+
+        onLockedChanged: Visibilities.sessionLocked = locked
 
         LockSurface {
             lock: lock

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -15,6 +15,7 @@
   libqalculate,
   bash,
   hyprland,
+  ffmpeg,
   material-symbols,
   rubik,
   nerd-fonts,
@@ -48,6 +49,7 @@
       libqalculate
       bash
       hyprland
+      ffmpeg
     ]
     ++ extraRuntimeDeps
     ++ lib.optional withCli caelestia-cli;
@@ -111,7 +113,7 @@ in
     src = ./..;
 
     nativeBuildInputs = [cmake ninja makeWrapper qt6.wrapQtAppsHook];
-    buildInputs = [quickshell extras plugin xkeyboard-config qt6.qtbase];
+    buildInputs = [quickshell extras plugin xkeyboard-config qt6.qtbase qt6.qtmultimedia];
     propagatedBuildInputs = runtimeDeps;
 
     cmakeFlags =

--- a/plugin/src/Caelestia/Models/filesystemmodel.cpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.cpp
@@ -339,7 +339,8 @@ void FileSystemModel::updateEntriesForDir(const QString& dir) {
 
             QString path = iter->next();
 
-            if (filter == Images) {
+            if (filter == Images && !QDir::match(nameFilters, QFileInfo(path).fileName())) {
+                // Explicit name filters are authoritative; everything else must be a readable image
                 QImageReader reader(path);
                 if (!reader.canRead()) {
                     continue;

--- a/services/Colours.qml
+++ b/services/Colours.qml
@@ -104,7 +104,7 @@ Singleton {
     ImageAnalyser {
         id: analyser
 
-        source: Wallpapers.current
+        source: Wallpapers.currentAnalysable
     }
 
     Timer {

--- a/services/Visibilities.qml
+++ b/services/Visibilities.qml
@@ -7,6 +7,7 @@ import qs.services
 Singleton {
     property var screens: new Map()
     property var bars: new Map()
+    property bool sessionLocked: false
 
     function load(screen: ShellScreen, visibilities: DrawerVisibilities): void {
         screens.set(Hypr.monitorFor(screen), visibilities);

--- a/services/Wallpapers.qml
+++ b/services/Wallpapers.qml
@@ -12,17 +12,39 @@ Searcher {
     id: root
 
     readonly property string currentNamePath: `${Paths.state}/wallpaper/path.txt`
+    readonly property string videoFramesPath: `${Paths.cache}/wallpapers/frames`
     readonly property list<string> smartArg: GlobalConfig.services.smartScheme ? [] : ["--no-smart"]
+
+    // Extracts a representative frame from the video "$1" into "$2" unless it already exists.
+    // Tries 1s in first (to skip fade-from-black intros), falls back to the first frame.
+    readonly property string extractFrameScript: `mkdir -p "$(dirname "$2")"
+if ! [ -f "$2" ]; then
+    t="$2.$$.tmp"
+    ffmpeg -y -loglevel error -ss 1 -i "$1" -frames:v 1 -c:v mjpeg -q:v 2 -f image2 "$t" 2> /dev/null
+    [ -s "$t" ] || ffmpeg -y -loglevel error -i "$1" -frames:v 1 -c:v mjpeg -q:v 2 -f image2 "$t" || exit 1
+    [ -s "$t" ] || exit 1
+    mv -f "$t" "$2" || exit 1
+fi`
 
     property bool showPreview: false
     readonly property string current: showPreview ? previewPath : actualCurrent
+    readonly property string currentAnalysable: Images.isValidVideoByName(current) ? (videoFrames[current] ?? "") : current
     property string previewPath
     property string actualCurrent
     property bool previewColourLock
+    property var videoFrames: ({})
+    property var frameQueue: []
 
     function setWallpaper(path: string): void {
         actualCurrent = path;
-        Quickshell.execDetached(["caelestia", "wallpaper", "-f", path, ...smartArg]);
+        if (Images.isValidVideoByName(path)) {
+            // The CLI can't handle videos: extract a frame for it to generate the colour
+            // scheme/thumbnail from, then point the wallpaper state at the actual video.
+            Quickshell.execDetached(["sh", "-c", `${extractFrameScript}
+caelestia wallpaper -f "$2" ${smartArg.join(" ")} && printf %s "$1" > "$3"`, "sh", path, videoFramePath(path), currentNamePath]);
+        } else {
+            Quickshell.execDetached(["caelestia", "wallpaper", "-f", path, ...smartArg]);
+        }
     }
 
     function preview(path: string): void {
@@ -39,12 +61,57 @@ Searcher {
             Colours.showPreview = false;
     }
 
+    function videoFramePath(path: string): string {
+        return `${videoFramesPath}/${Qt.md5(path)}.jpg`;
+    }
+
+    function ensureVideoFrame(path: string): void {
+        if (!Images.isValidVideoByName(path) || videoFrames[path] !== undefined || frameProc.activePath === path || frameQueue.includes(path))
+            return;
+        frameQueue.push(path);
+        processFrameQueue();
+    }
+
+    function processFrameQueue(): void {
+        if (frameProc.running || frameQueue.length === 0)
+            return;
+        frameProc.activePath = frameQueue.shift();
+        frameProc.running = true;
+    }
+
+    function thumbnailFor(path: string): string {
+        if (!Images.isValidVideoByName(path))
+            return path;
+        return videoFrames[path] ?? "";
+    }
+
+    function animationsActiveOn(screen: ShellScreen): bool {
+        if (GameMode.enabled || Visibilities.sessionLocked)
+            return false;
+
+        const monitor = Hypr.monitorFor(screen);
+        if (!monitor)
+            return true;
+        if (monitor.lastIpcObject.dpmsStatus === false)
+            return false;
+
+        // Mirrors the fullscreen detection in modules/drawers/ContentWindow.qml
+        const specialName = monitor.lastIpcObject.specialWorkspace?.name;
+        if (specialName) {
+            const specialWs = Hypr.workspaces.values.find(ws => ws.name === specialName);
+            return !(specialWs?.toplevels.values.some(t => t.lastIpcObject.fullscreen > 1) ?? false);
+        }
+        return !(monitor.activeWorkspace?.toplevels.values.some(t => t.lastIpcObject.fullscreen > 1) ?? false);
+    }
+
     list: wallpapers.entries
     key: "relativePath"
     useFuzzy: GlobalConfig.launcher.useFuzzy.wallpapers
     extraOpts: useFuzzy ? ({}) : ({
             forward: false
         })
+
+    onCurrentChanged: ensureVideoFrame(current)
 
     IpcHandler {
         function get(): string {
@@ -67,7 +134,13 @@ Searcher {
         watchChanges: true
         onFileChanged: reload()
         onLoaded: {
-            root.actualCurrent = text().trim();
+            const path = text().trim();
+
+            // Intermediate write by the CLI while setting a video wallpaper (see setWallpaper)
+            if (Images.isValidVideoByName(root.actualCurrent) && path === root.videoFramePath(root.actualCurrent))
+                return;
+
+            root.actualCurrent = path;
             root.previewColourLock = false;
         }
     }
@@ -78,17 +151,38 @@ Searcher {
         recursive: true
         path: Paths.wallsdir
         filter: FileSystemModel.Images
+        nameFilters: Images.validVideoExtensions.map(e => `*.${e}`)
     }
 
     Process {
         id: getPreviewColoursProc
 
-        command: ["caelestia", "wallpaper", "-p", root.previewPath, ...root.smartArg]
+        command: {
+            if (Images.isValidVideoByName(root.previewPath))
+                return ["sh", "-c", `${root.extractFrameScript}
+exec caelestia wallpaper -p "$2" ${root.smartArg.join(" ")}`, "sh", root.previewPath, root.videoFramePath(root.previewPath)];
+            return ["caelestia", "wallpaper", "-p", root.previewPath, ...root.smartArg];
+        }
         stdout: StdioCollector {
             onStreamFinished: {
                 Colours.load(text, true);
                 Colours.showPreview = true;
             }
+        }
+    }
+
+    Process {
+        id: frameProc
+
+        property string activePath
+
+        command: ["sh", "-c", root.extractFrameScript, "sh", activePath, root.videoFramePath(activePath)]
+        onExited: code => { // qmllint disable signal-handler-parameters
+            const updated = Object.assign({}, root.videoFrames);
+            updated[activePath] = code === 0 ? root.videoFramePath(activePath) : "";
+            root.videoFrames = updated;
+            activePath = "";
+            root.processFrameQueue();
         }
     }
 }

--- a/utils/Images.qml
+++ b/utils/Images.qml
@@ -5,8 +5,18 @@ import Quickshell
 Singleton {
     readonly property list<string> validImageTypes: ["jpeg", "png", "webp", "tiff", "svg"]
     readonly property list<string> validImageExtensions: ["jpg", "jpeg", "png", "webp", "tif", "tiff", "svg"]
+    readonly property list<string> validVideoExtensions: ["mp4", "webm", "mkv", "mov", "avi", "m4v"]
+    readonly property list<string> validWallpaperExtensions: validImageExtensions.concat(["gif"], validVideoExtensions)
 
     function isValidImageByName(name: string): bool {
         return validImageExtensions.some(t => name.endsWith(`.${t}`));
+    }
+
+    function isValidVideoByName(name: string): bool {
+        return validVideoExtensions.some(t => name.toLowerCase().endsWith(`.${t}`));
+    }
+
+    function isAnimatedImageByName(name: string): bool {
+        return name.toLowerCase().endsWith(".gif");
     }
 }


### PR DESCRIPTION
Adds support for videos and animated GIFs as wallpapers, alongside the existing static images. They appear in the wallpaper picker and launcher, cross-fade in the same way images do, and drive the Material colour scheme.

### Usage

Drop a video (`.mp4`, `.webm`, `.mkv`, `.mov`, `.avi`, `.m4v`) or a `.gif` into your wallpapers directory, or pick one from the wallpaper picker / launcher (`>wallpaper`). Nothing to configure.

Two **optional** runtime dependencies, only needed for video (gifs need neither):

- `qt6-multimedia` — plays the video. If missing, the wallpaper falls back to a static extracted frame instead of failing.
- `ffmpeg` — extracts a frame from the video for the colour scheme and picker thumbnails.

### How it works

- `modules/background/Wallpaper.qml` used to hold two `CachingImage` slots that cross-fade. They're now generic slots that load the right renderer per file type: `WallpaperVideo` (`VideoOutput` + `MediaPlayer`), `WallpaperAnimated` (`AnimatedImage` for gifs), or `WallpaperImage` (the existing `CachingImage`, unchanged). The fade/scale transition is identical.
- The `caelestia` CLI generates the colour scheme but can't read videos, so for a video a representative frame is extracted with ffmpeg (1s in, to skip fade-from-black intros, falling back to the first frame), cached under `~/.cache/caelestia/wallpapers/frames/`, and the CLI / colour analysis runs on that frame. Picker and launcher thumbnails reuse it; the launcher shows a movie icon for videos.
- `FileSystemModel`'s `Images` filter dropped any file `QImageReader` couldn't read, which excluded videos. It now treats an explicit `nameFilters` match as authoritative, so the wallpaper scan can include video files (separate commit).

### Performance / GPU

A playing video decodes continuously, so to keep idle cost down:

- Only one video/gif decodes at a time — the hidden cross-fade slot is unloaded once it finishes fading out.
- Playback pauses automatically when nothing can see it: a fullscreen window on that monitor, the monitor's DPMS off (screen asleep), game mode on, or the session locked. It resumes when the wallpaper is visible again.
- Static image wallpapers are unaffected — same code path as before.
- gifs decode on CPU via `AnimatedImage` and pause under the same conditions.

### Breaking changes / side effects

- None for existing image users; static wallpapers behave exactly as before.
- The new deps are optional; without `qt6-multimedia`, videos degrade to a static frame.
- Adds a small frame cache under `~/.cache/caelestia/wallpapers/frames/`.

### Testing

Built the plugin and ran the shell on Hyprland. Verified:

- mp4 and webm videos set as wallpaper (via both the picker and the launcher) play and loop.
- Animated gifs play.
- The Material colour scheme is generated correctly from the auto-extracted video frame.
- Playback pauses on fullscreen, lock, DPMS-off and game mode, and falls back to a static frame when QtMultimedia isn't available.

`qmlformat`, `qml-lint-conventions.py`, `clang-format` and `qmllint` all pass.
