### PR TITLE
Fix format ci

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Check QML format
         shell: fish {0}
         run: |
+          /usr/lib/qt6/bin/qmlformat --version
           for file in (string match -v 'build/*' **.qml)
             /usr/lib/qt6/bin/qmlformat $file | diff -u $file - || exit 1
           end
@@ -34,5 +35,6 @@ jobs:
       - name: Check C++ format
         shell: fish {0}
         run: |
+          clang-format --version
           find plugin extras -name '*.cpp' -o -name '*.hpp' \
             | xargs clang-format --dry-run --Werror

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Lint QML
         shell: fish {0}
         run: |
+          /usr/lib/qt6/bin/qmllint --version
+
           # Generate tooling
           touch .qmlls.ini
           QT_QPA_PLATFORM=offscreen QML2_IMPORT_PATH="$PWD/build/qml:$QML2_IMPORT_PATH" timeout 2 qs -p .

--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -23,7 +23,13 @@ jobs:
         run: |
           cat > /tmp/Dockerfile <<EOF
           FROM archlinux:latest
-          RUN pacman -Syu --needed --noconfirm sudo base-devel cmake ninja fish git clazy qt6-declarative qt6-shadertools python libpipewire aubio libqalculate && \
+          # TEMPORARY (remove once the upstream qmlformat regression is fixed): pin to the
+          # 2026-05-13 Arch archive snapshot to hold qmlformat at qt6-declarative 6.11.0.
+          # qt6-declarative 6.11.1 silently crashes qmlformat (exit 1, empty output) on QML files
+          # that declare a property named 'id'. To unpin: delete the mirrorlist line below and
+          # change 'pacman -Syyuu' back to 'pacman -Syu'.
+          RUN echo 'Server = https://archive.archlinux.org/repos/2026/05/13/\$repo/os/\$arch' > /etc/pacman.d/mirrorlist && \
+              pacman -Syyuu --needed --noconfirm sudo base-devel cmake ninja fish git clazy qt6-declarative qt6-shadertools python libpipewire aubio libqalculate && \
               useradd -m builder && \
               echo 'builder ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
               sudo -u builder git clone https://aur.archlinux.org/yay-bin.git /home/builder/yay-bin && \

--- a/modules/bar/popouts/kblayout/KbLayoutModel.qml
+++ b/modules/bar/popouts/kblayout/KbLayoutModel.qml
@@ -10,25 +10,25 @@ import Caelestia.Config
 Item {
     id: model
 
-    property alias visibleModel: _visibleModel
+    property alias visibleModel: visibleModel
     property string activeLabel: ""
     property int activeIndex: -1
     property var _xkbMap: ({})
     property bool _notifiedLimit: false
 
     function start() {
-        _xkbXmlBase.running = true;
-        _getKbLayoutOpt.running = true;
+        xkbXmlBase.running = true;
+        getKbLayoutOpt.running = true;
     }
 
     function refresh() {
         _notifiedLimit = false;
-        _getKbLayoutOpt.running = true;
+        getKbLayoutOpt.running = true;
     }
 
     function switchTo(idx) {
-        _switchProc.command = ["hyprctl", "switchxkblayout", "all", String(idx)];
-        _switchProc.running = true;
+        switchProc.command = ["hyprctl", "switchxkblayout", "all", String(idx)];
+        switchProc.running = true;
     }
 
     function _buildXmlMap(xml) {
@@ -50,19 +50,19 @@ Item {
 
         _xkbMap = map;
 
-        if (_layoutsModel.count > 0) {
+        if (layoutsModel.count > 0) {
             const tmp = [];
-            for (let i = 0; i < _layoutsModel.count; i++) {
-                const it = _layoutsModel.get(i);
+            for (let i = 0; i < layoutsModel.count; i++) {
+                const it = layoutsModel.get(i);
                 tmp.push({
                     layoutIndex: it.layoutIndex,
                     token: it.token,
                     label: _pretty(it.token)
                 });
             }
-            _layoutsModel.clear();
-            tmp.forEach(t => _layoutsModel.append(t));
-            _fetchActiveLayouts.running = true;
+            layoutsModel.clear();
+            tmp.forEach(t => layoutsModel.append(t));
+            fetchActiveLayouts.running = true;
         }
     }
 
@@ -78,7 +78,7 @@ Item {
 
     function _setLayouts(raw) {
         const parts = raw.split(",").map(s => s.trim()).filter(Boolean);
-        _layoutsModel.clear();
+        layoutsModel.clear();
 
         const seen = new Set();
         let idx = 0;
@@ -87,7 +87,7 @@ Item {
             if (seen.has(p))
                 continue;
             seen.add(p);
-            _layoutsModel.append({
+            layoutsModel.append({
                 layoutIndex: idx,
                 token: p,
                 label: _pretty(p)
@@ -97,19 +97,19 @@ Item {
     }
 
     function _rebuildVisible() {
-        _visibleModel.clear();
+        visibleModel.clear();
 
         let arr = [];
-        for (let i = 0; i < _layoutsModel.count; i++)
-            arr.push(_layoutsModel.get(i));
+        for (let i = 0; i < layoutsModel.count; i++)
+            arr.push(layoutsModel.get(i));
 
         arr = arr.filter(i => i.layoutIndex !== activeIndex);
-        arr.forEach(i => _visibleModel.append(i));
+        arr.forEach(i => visibleModel.append(i));
 
         if (!GlobalConfig.utilities.toasts.kbLimit)
             return;
 
-        if (_layoutsModel.count > 4) {
+        if (layoutsModel.count > 4) {
             Toaster.toast(qsTr("Keyboard layout limit"), qsTr("XKB supports only 4 layouts at a time"), "warning");
         }
     }
@@ -124,26 +124,26 @@ Item {
     visible: false
 
     ListModel {
-        id: _visibleModel
+        id: visibleModel
     }
 
     ListModel {
-        id: _layoutsModel
+        id: layoutsModel
     }
 
     Process {
-        id: _xkbXmlBase
+        id: xkbXmlBase
 
         command: ["xmllint", "--xpath", "//layout/configItem[name and description]", "/usr/share/X11/xkb/rules/base.xml"]
         stdout: StdioCollector {
             onStreamFinished: model._buildXmlMap(text)
         }
-        onRunningChanged: if (!running && (typeof _xkbXmlBase.exitCode !== "undefined") && _xkbXmlBase.exitCode !== 0) // qmllint disable missing-property
-            _xkbXmlEvdev.running = true
+        onRunningChanged: if (!running && (typeof xkbXmlBase.exitCode !== "undefined") && xkbXmlBase.exitCode !== 0) // qmllint disable missing-property
+            xkbXmlEvdev.running = true
     }
 
     Process {
-        id: _xkbXmlEvdev
+        id: xkbXmlEvdev
 
         command: ["xmllint", "--xpath", "//layout/configItem[name and description]", "/usr/share/X11/xkb/rules/evdev.xml"]
         stdout: StdioCollector {
@@ -152,7 +152,7 @@ Item {
     }
 
     Process {
-        id: _getKbLayoutOpt
+        id: getKbLayoutOpt
 
         command: ["hyprctl", "-j", "getoption", "input:kb_layout"]
         stdout: StdioCollector {
@@ -162,17 +162,17 @@ Item {
                     const raw = (j?.str || j?.value || "").toString().trim();
                     if (raw.length) {
                         model._setLayouts(raw);
-                        _fetchActiveLayouts.running = true;
+                        fetchActiveLayouts.running = true;
                         return;
                     }
                 } catch (e) {}
-                _fetchLayoutsFromDevices.running = true;
+                fetchLayoutsFromDevices.running = true;
             }
         }
     }
 
     Process {
-        id: _fetchLayoutsFromDevices
+        id: fetchLayoutsFromDevices
 
         command: ["hyprctl", "-j", "devices"]
         stdout: StdioCollector {
@@ -184,13 +184,13 @@ Item {
                     if (raw.length)
                         model._setLayouts(raw);
                 } catch (e) {}
-                _fetchActiveLayouts.running = true;
+                fetchActiveLayouts.running = true;
             }
         }
     }
 
     Process {
-        id: _fetchActiveLayouts
+        id: fetchActiveLayouts
 
         command: ["hyprctl", "-j", "devices"]
         stdout: StdioCollector {
@@ -201,7 +201,7 @@ Item {
                     const idx = kb?.active_layout_index ?? -1;
 
                     model.activeIndex = idx >= 0 ? idx : -1;
-                    model.activeLabel = (idx >= 0 && idx < _layoutsModel.count) ? _layoutsModel.get(idx).label : "";
+                    model.activeLabel = (idx >= 0 && idx < layoutsModel.count) ? layoutsModel.get(idx).label : "";
                 } catch (e) {
                     model.activeIndex = -1;
                     model.activeLabel = "";
@@ -213,9 +213,9 @@ Item {
     }
 
     Process {
-        id: _switchProc
+        id: switchProc
 
         onRunningChanged: if (!running)
-            _fetchActiveLayouts.running = true
+            fetchActiveLayouts.running = true
     }
 }

--- a/plugin/src/Caelestia/Blobs/blobshape.cpp
+++ b/plugin/src/Caelestia/Blobs/blobshape.cpp
@@ -39,8 +39,8 @@ static float cornerFillFactor(float sd, float smoothFactor) {
     // squaring would only crease the interior). C0-continuous across sd = 0 — unlike the
     // old `if (sd >= 0)` branch, which snapped the radius full<->square (factor 1<->0) on
     // sub-pixel motion as a corner crossed the edge, flickering the fill bridge in/out.
-    const float outside = cpuSmoothstep(0.0f, smoothFactor, sd);  // 0 at edge, ->1 far outside
-    const float inside = cpuSmoothstep(0.0f, -smoothFactor, sd);  // 0 at edge, ->1 deep inside
+    const float outside = cpuSmoothstep(0.0f, smoothFactor, sd); // 0 at edge, ->1 far outside
+    const float inside = cpuSmoothstep(0.0f, -smoothFactor, sd); // 0 at edge, ->1 deep inside
     return std::max(outside, inside);
 }
 

--- a/services/NetworkUsage.qml
+++ b/services/NetworkUsage.qml
@@ -20,8 +20,8 @@ Singleton {
     readonly property real uploadTotal: _uploadTotal
 
     // History buffers for sparkline
-    readonly property CircularBuffer downloadBuffer: _downloadBuffer
-    readonly property CircularBuffer uploadBuffer: _uploadBuffer
+    readonly property alias downloadBuffer: downloadHistory
+    readonly property alias uploadBuffer: uploadHistory
     readonly property int historyLength: 30
 
     // Private properties
@@ -137,13 +137,13 @@ Singleton {
     }
 
     CircularBuffer {
-        id: _downloadBuffer
+        id: downloadHistory
 
         capacity: root.historyLength + 1
     }
 
     CircularBuffer {
-        id: _uploadBuffer
+        id: uploadHistory
 
         capacity: root.historyLength + 1
     }
@@ -200,10 +200,10 @@ Singleton {
                 root._uploadSpeed = txDelta / timeDelta;
 
                 if (root._downloadSpeed >= 0 && isFinite(root._downloadSpeed))
-                    _downloadBuffer.push(root._downloadSpeed);
+                    downloadHistory.push(root._downloadSpeed);
 
                 if (root._uploadSpeed >= 0 && isFinite(root._uploadSpeed))
-                    _uploadBuffer.push(root._uploadSpeed);
+                    uploadHistory.push(root._uploadSpeed);
             }
 
             // Calculate totals with overflow handling


### PR DESCRIPTION
Qt 6.11.1 made `qmlformat` crash when a file contained ids starting with underscores, or properties named `id`.