### PR TITLE
fix: storage total disk size truncates decimal places

### DIFF
--- a/modules/dashboard/Performance.qml
+++ b/modules/dashboard/Performance.qml
@@ -630,7 +630,7 @@ Item {
 
                     const usedFmt = SystemUsage.formatKib(storageGaugeCard.currentDisk.used);
                     const totalFmt = SystemUsage.formatKib(storageGaugeCard.currentDisk.total);
-                    return `${usedFmt.value.toFixed(1)} / ${Math.floor(totalFmt.value)} ${totalFmt.unit}`;
+                    return `${usedFmt.value.toFixed(1)} / ${Number(totalFmt.value.toFixed(1))} ${totalFmt.unit}`;
                 }
                 font.pointSize: Tokens.font.size.smaller
                 color: Colours.palette.m3onSurfaceVariant


### PR DESCRIPTION
Math.floor drops fractional GiB/TiB (e.g. 1.8 TiB shown as 1 TiB).
Fixed by using Number(value.toFixed(1)).
