### PR TITLE
lock/weather: fix missing colon in 24h hourly time

### DIFF
--- a/modules/lock/weather/Forecast.qml
+++ b/modules/lock/weather/Forecast.qml
@@ -95,7 +95,7 @@ StyledRect {
                 StyledText {
                     Layout.topMargin: Tokens.spacing.extraSmall
                     Layout.alignment: Qt.AlignHCenter
-                    text: hour.index === 0 ? qsTr("Now") : Qt.formatDateTime(new Date(hour.cond.timestamp.replace("T", " ")), GlobalConfig.services.useTwelveHourClock ? "ha" : "hh00")
+                    text: hour.index === 0 ? qsTr("Now") : Qt.formatDateTime(new Date(hour.cond.timestamp.replace("T", " ")), GlobalConfig.services.useTwelveHourClock ? "ha" : "hh:00")
                     color: Colours.palette.m3onSurfaceVariant
                     font: Tokens.font.body.medium
                 }


### PR DESCRIPTION
The hourly forecast time labels used the format string "hh00" which produced times like "0400" instead of "04:00".

Changed to "hh:00" to display the colon correctly in 24h mode. 12h mode ("ha") is unaffected.

Before > after

<img width="978" height="472" alt="image" src="https://github.com/user-attachments/assets/696fd358-70c4-4b98-a0a9-db7af05fd961" />
<img width="865" height="676" alt="image" src="https://github.com/user-attachments/assets/64c57b08-04a8-4ff8-a0e3-fad675d9c2d9" />

