### PR TITLE
fix: vpn disconnection toast

### DIFF
--- a/services/VPN.qml
+++ b/services/VPN.qml
@@ -289,9 +289,7 @@ Singleton {
             Toaster.toast(qsTr("VPN connected"), qsTr("Connected to %1").arg(displayName), "vpn_key");
             break;
         case "disconnected":
-            if (status.connected) {
-                Toaster.toast(qsTr("VPN disconnected"), qsTr("Disconnected from %1").arg(displayName), "vpn_key_off");
-            }
+            Toaster.toast(qsTr("VPN disconnected"), qsTr("Disconnected from %1").arg(displayName), "vpn_key_off");
             break;
         case "needs-auth":
             const authMsg = statusObj.reason || "Authentication required";


### PR DESCRIPTION
There was an if statement in the disconnection block only allowing it through if it was connected. Probably a typo