### PR TITLE
services/wallpapers: fix Colours.showPreview not cleared after wallpaper confirmed

### DIFF
--- a/services/Wallpapers.qml
+++ b/services/Wallpapers.qml
@@ -87,10 +87,12 @@ Searcher {
             }
             root.actualCurrent = wall;
             root.previewColourLock = false;
+            Colours.showPreview = false;
         }
         onLoadFailed: {
             root.actualCurrent = root.fallback;
             root.previewColourLock = false;
+            Colours.showPreview = false;
             Quickshell.execDetached(["caelestia", "wallpaper", "-f", root.fallback, ...root.smartArg]);
         }
     }


### PR DESCRIPTION
When selecting a new wallpaper with a dynamic scheme, `previewColourLock` is set to keep `Colours.showPreview = true` while the new scheme colours are being generated. The lock is cleared in the `path.txt` FileView's `onLoaded`, but `Colours.showPreview` was never actually cleared there.

This left `Colours.palette` pointing at the stale preview palette indefinitely. Variant switches would update `current` but have no visible effect on the shell until restart.

Fix: clear `Colours.showPreview` alongside `previewColourLock` once the wallpaper path is confirmed. By that point `scheme.json` has already been written, so the transition from preview to current is seamless.