### PR TITLE
feat(settings): add toggle to hide state icons in occupied workspaces

### DIFF
--- a/modules/bar/components/workspaces/Workspace.qml
+++ b/modules/bar/components/workspaces/Workspace.qml
@@ -46,6 +46,8 @@ ColumnLayout {
                 displayName = displayName.toLowerCase();
             }
             const label = Config.bar.workspaces.label || displayName;
+            if (!Config.bar.workspaces.showOccupiedIcon)
+                return label;
             const occupiedLabel = Config.bar.workspaces.occupiedLabel || label;
             const activeLabel = Config.bar.workspaces.activeLabel || (root.isOccupied ? occupiedLabel : label);
             return root.activeWsId === root.ws ? activeLabel : root.isOccupied ? occupiedLabel : label;

--- a/modules/bar/components/workspaces/Workspace.qml
+++ b/modules/bar/components/workspaces/Workspace.qml
@@ -35,6 +35,7 @@ ColumnLayout {
         Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
         Layout.preferredHeight: Tokens.sizes.bar.innerWidth - Tokens.padding.small
 
+        visible: Config.bar.workspaces.showOccupiedIcon || !root.isOccupied
         animate: true
         text: {
             const ws = Hypr.workspaces.values.find(w => w.id === root.ws);
@@ -46,8 +47,6 @@ ColumnLayout {
                 displayName = displayName.toLowerCase();
             }
             const label = Config.bar.workspaces.label || displayName;
-            if (!Config.bar.workspaces.showOccupiedIcon)
-                return label;
             const occupiedLabel = Config.bar.workspaces.occupiedLabel || label;
             const activeLabel = Config.bar.workspaces.activeLabel || (root.isOccupied ? occupiedLabel : label);
             return root.activeWsId === root.ws ? activeLabel : root.isOccupied ? occupiedLabel : label;
@@ -64,7 +63,7 @@ ColumnLayout {
 
         Layout.alignment: Qt.AlignHCenter
         Layout.fillHeight: true
-        Layout.topMargin: -Tokens.sizes.bar.innerWidth / 10
+        Layout.topMargin: Config.bar.workspaces.showOccupiedIcon || !root.isOccupied ? -Tokens.sizes.bar.innerWidth / 10 : Tokens.padding.extraSmall
 
         visible: active
         active: root.hasWindows

--- a/modules/nexus/pages/panels/taskbar/BarWorkspaces.qml
+++ b/modules/nexus/pages/panels/taskbar/BarWorkspaces.qml
@@ -51,8 +51,8 @@ PageBase {
 
         ToggleRow {
             Layout.fillWidth: true
-            text: qsTr("State icons")
-            subtext: qsTr("Show icons for occupied and active workspaces")
+            text: qsTr("State icons in occupied workspaces")
+            subtext: qsTr("Show state icons in workspaces that have open windows")
             checked: Config.bar.workspaces.showOccupiedIcon
             onToggled: GlobalConfig.bar.workspaces.showOccupiedIcon = checked
         }

--- a/modules/nexus/pages/panels/taskbar/BarWorkspaces.qml
+++ b/modules/nexus/pages/panels/taskbar/BarWorkspaces.qml
@@ -51,6 +51,14 @@ PageBase {
 
         ToggleRow {
             Layout.fillWidth: true
+            text: qsTr("State icons")
+            subtext: qsTr("Show icons for occupied and active workspaces")
+            checked: Config.bar.workspaces.showOccupiedIcon
+            onToggled: GlobalConfig.bar.workspaces.showOccupiedIcon = checked
+        }
+
+        ToggleRow {
+            Layout.fillWidth: true
             text: qsTr("Show windows")
             subtext: qsTr("Show icons of open windows on each workspace")
             checked: Config.bar.workspaces.showWindows

--- a/plugin/src/Caelestia/Config/barconfig.hpp
+++ b/plugin/src/Caelestia/Config/barconfig.hpp
@@ -47,6 +47,7 @@ class BarWorkspaces : public ConfigObject {
     CONFIG_PROPERTY(bool, showWindowsOnSpecialWorkspaces, true)
     CONFIG_PROPERTY(int, maxWindowIcons, 5)
     CONFIG_PROPERTY(bool, activeTrail, false)
+    CONFIG_PROPERTY(bool, showOccupiedIcon, true)
     CONFIG_GLOBAL_PROPERTY(bool, perMonitorWorkspaces, true)
     CONFIG_PROPERTY(QString, label, u"  "_s)
     CONFIG_PROPERTY(QString, occupiedLabel, u"󰮯"_s)


### PR DESCRIPTION
## Summary

Adds a new "State icons in occupied workspaces" toggle to the Panel → Taskbar → Workspaces settings page that controls whether the nerd font glyph (the occupied/active workspace label) is shown in workspaces that have open windows.

- When on (default): existing behaviour, the configured `occupiedLabel`/`activeLabel` glyphs appear in occupied and active workspaces
- When off: the glyph is hidden for occupied workspaces, showing only the window category icons; empty workspaces are unaffected and continue to display their label normally

The window icon `topMargin` is also adjusted when the label is hidden, switching from the negative pull-up offset (designed to sit below the glyph) to a positive `extraSmall` spacing that balances the existing bottom padding.