### PR TITLE
Weather: add maxTempF and minTempF to forecast items

### DIFF
--- a/services/Weather.qml
+++ b/services/Weather.qml
@@ -133,6 +133,8 @@ Singleton {
                     date: json.daily.time[i].replace(/-/g, "/"),
                     maxTempC: json.daily.temperature_2m_max[i],
                     minTempC: json.daily.temperature_2m_min[i],
+                    maxTempF: Math.round(json.daily.temperature_2m_max[i] * 9 / 5 + 32),
+                    minTempF: Math.round(json.daily.temperature_2m_min[i] * 9 / 5 + 32),
                     weatherCode: json.daily.weather_code[i],
                     icon: Icons.getWeatherIcon(json.daily.weather_code[i])
                 });


### PR DESCRIPTION
Fixes undefined°/undefined° in 7-day forecast when Fahrenheit is enabled. Values are rounded to avoid decimal display.