### PR TITLE
fix(media): click-to-seek on position slider and volume slider in audio widget  #1493

### DIFF
--- a/components/controls/StyledSlider.qml
+++ b/components/controls/StyledSlider.qml
@@ -177,7 +177,9 @@ Slider {
                 root.interaction(posBinding.value);
         }
         onReleased: e => {
-            root.interaction(posBinding.value);
+            const clickPos = e.x / width;
+            const finalPos = mouse.dragMovement !== 0 ? posBinding.value : CUtils.clamp(clickPos, 0, 1);
+            root.interaction(finalPos);
             widthBehavior.enabled = true;
             dragMovement = 0;
         }


### PR DESCRIPTION
## Problem
Clicking directly on the media position slider had no effect — the playback position did not change. Only dragging worked.

In `StyledSlider.qml`, `onReleased` was using `posBinding.value` which evaluates to `pressStartPos + dragMovement`. Since `dragMovement` is only updated in `onPositionChanged` (which never fires on a click with no movement), it remained `0` on release — causing the interaction to emit the original position instead of the clicked position.

## Fix
In `onReleased`, check whether any drag movement occurred. If not, calculate the position directly from the release event's `x` coordinate instead of relying on `posBinding`.

## Notes
This also resolves the snap-back issue described in #1485 for click interactions, as the correct position is now emitted on the first try.

## Video

https://github.com/user-attachments/assets/747bd431-c9ec-47f3-b99a-0e3710a3a780

fixed( nexus ):#1493