### PR TITLE
fix: launcher interrupt ordering race with Hyprland catchall

### DIFF
--- a/modules/Shortcuts.qml
+++ b/modules/Shortcuts.qml
@@ -9,7 +9,7 @@ import qs.modules.nexus
 Scope {
     id: root
 
-    property bool launcherInterrupted
+    property int launcherInterruptCount
     readonly property bool hasFullscreen: Hypr.focusedWorkspace?.toplevels.values.some(t => t.lastIpcObject.fullscreen > 1) ?? false
 
     // qmllint disable unresolved-type
@@ -64,13 +64,15 @@ Scope {
         // qmllint enable unresolved-type
         name: "launcher"
         description: "Toggle launcher"
-        onPressed: root.launcherInterrupted = false
+        onPressed: root.launcherInterruptCount = 0
         onReleased: {
-            if (!root.launcherInterrupted && !root.hasFullscreen) {
+            // Only toggle if no more than one interrupt fired (Super_L itself via catchall).
+            // Two or more interrupts means another key was pressed while holding Super.
+            if (root.launcherInterruptCount <= 1 && !root.hasFullscreen) {
                 const visibilities = Visibilities.getForActive();
                 visibilities.launcher = !visibilities.launcher;
             }
-            root.launcherInterrupted = false;
+            root.launcherInterruptCount = 0;
         }
     }
 
@@ -79,7 +81,7 @@ Scope {
         // qmllint enable unresolved-type
         name: "launcherInterrupt"
         description: "Interrupt launcher keybind"
-        onPressed: root.launcherInterrupted = true
+        onPressed: root.launcherInterruptCount++
     }
 
     // qmllint disable unresolved-type


### PR DESCRIPTION
## Problem

The Super-key launcher toggle uses a boolean `launcherInterrupted` flag:

```
launcher.onPressed           → interrupted = false
launcherInterrupt.onPressed  → interrupted = true   (catchall captures Super_L itself!)
launcher.onReleased          → check interrupted → DON'T toggle ❌
```

Both `launcher` and `launcherInterrupt` fire on the same Super_L key press — the catchall (`bindin = Super, catchall, global, caelestia:launcherInterrupt`) captures Super_L itself. The final `interrupted` value depends on **Hyprland's internal event dispatch order**, which changed between 0.55.2 and 0.55.3.

This causes the launcher to never open when tapping Super alone.

## Fix

Replace the boolean flag with an integer counter:

| Event | Old (fragile) | New (order-independent) |
|---|---|---|
| `launcher.onPressed` | `interrupted = false` | `interruptCount = 0` |
| `launcherInterrupt.onPressed` | `interrupted = true` | `interruptCount++` |
| `launcher.onReleased` | `if !interrupted` | `if interruptCount <= 1` |

- **Tap Super alone**: 1 interrupt (Super_L via catchall) → count=1 ≤ 1 → **launcher opens** ✅
- **Super+another_key**: 2+ interrupts (Super_L + other key) → count≥2 > 1 → **suppressed** ✅

This is **order-independent** — it works regardless of whether Hyprland dispatches the specific binding before or after the catchall.

## Related

- https://github.com/caelestia-dots/shell/issues/562 — similar interrupt race symptoms
- Triggered by Hyprland 0.55.3 (used to work on 0.55.2 due to different dispatch order)
- Affects caelestia-shell ≥ 2.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)