### PR TITLE
nexus: add cursor theme selector to wallpaper & style page

### DIFF
--- a/components/controls/Menu.qml
+++ b/components/controls/Menu.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts
 import Quickshell
 import Caelestia.Config
 import qs.components
+import qs.components.containers
 import qs.components.effects
 import qs.services
 import qs.modules.drawers
@@ -27,15 +28,67 @@ MouseArea {
     property real marginX
     property real marginY
 
+    property real maxHeight: 320
+    property real minHeight: 160
+    property real edgeMargin: Tokens.spacing.small
+
+    property real _attachTopY: 0
+    property real _attachBottomY: 0
+
+    readonly property real spaceAbove: Math.max(0, _attachTopY - edgeMargin)
+    readonly property real spaceBelow: Math.max(0, root.height - _attachBottomY - edgeMargin)
+
+    readonly property bool _preferBottom: attachSideY === Menu.Bottom
+    readonly property bool _flipToBottom: !_preferBottom && spaceAbove < minHeight && spaceBelow > spaceAbove
+    readonly property bool _flipToTop: _preferBottom && spaceBelow < minHeight && spaceAbove > spaceBelow
+    readonly property bool effectiveBottom: _preferBottom ? !_flipToTop : _flipToBottom
+
+    readonly property int effAttachSideY: effectiveBottom ? Menu.Bottom : Menu.Top
+    readonly property int effThisSideY: effectiveBottom ? Menu.Top : Menu.Bottom
+
+    readonly property real availableSpace: effectiveBottom ? spaceBelow : spaceAbove
+
     property list<MenuItem> items
     property MenuItem active: items[0] ?? null
     property bool expanded
 
     signal itemSelected(item: MenuItem)
 
+    function _updateAttachY() {
+        if (!root.attachTo || !root.parent)
+            return;
+        root._attachTopY = root.attachTo.mapToItem(root.parent, 0, 0).y;
+        root._attachBottomY = root.attachTo.mapToItem(root.parent, 0, root.attachTo.height).y;
+    }
+
+    function scrollToActive() {
+        if (!root.active)
+            return;
+
+        const idx = root.items.indexOf(root.active);
+        if (idx < 0)
+            return;
+
+        const delegate = repeater.itemAt(idx);
+        if (!delegate)
+            return;
+
+        const target = delegate.y + delegate.height / 2 - flick.height / 2;
+        const maxContentY = Math.max(0, flick.contentHeight - flick.height);
+        flick.contentY = Math.max(0, Math.min(target, maxContentY));
+    }
+
+    onExpandedChanged: {
+        if (expanded)
+            Qt.callLater(scrollToActive);
+    }
+
+    onParentChanged: _updateAttachY()
+    Component.onCompleted: _updateAttachY()
+
     parent: {
         const win = QsWindow.window;
-        const contentWin = win as ContentWindow; // If inside the drawer content window, put it inside the interaction wrapper so hover works
+        const contentWin = win as ContentWindow;
         return contentWin ? contentWin.interactionWrapper : (win as QsWindow).contentItem;
     }
     anchors.fill: parent
@@ -59,11 +112,29 @@ MouseArea {
         b: root.attachTo
     }
 
+    Connections {
+        function onTransformChanged() {
+            root._updateAttachY();
+        }
+
+        target: watcher
+    }
+
+    Connections {
+        function onHeightChanged() {
+            root._updateAttachY();
+        }
+
+        target: root.attachTo
+    }
+
     Elevation {
         id: menu
 
+        readonly property real _pad: Tokens.padding.extraSmall
+
         x: {
-            watcher.transform; // mapToItem is not reactive so this forces updates
+            watcher.transform;
             const item = root.attachTo;
             let off = root.attachSideX === Menu.Left ? 0 : item.width;
             if (root.thisSideX === Menu.Right)
@@ -71,27 +142,32 @@ MouseArea {
             return item.mapToItem(root.parent, off, 0).x + root.marginX;
         }
         y: {
-            watcher.transform; // mapToItem is not reactive so this forces updates
-            const item = root.attachTo;
-            let off = root.attachSideY === Menu.Top ? 0 : item.height;
-            if (root.thisSideY === Menu.Bottom)
-                off -= height;
-            return item.mapToItem(root.parent, 0, off).y + root.marginY;
+            const attachY = root.effAttachSideY === Menu.Top ? root._attachTopY : root._attachBottomY;
+            return (root.effThisSideY === Menu.Bottom ? attachY - height : attachY) + root.marginY;
         }
 
         radius: Tokens.rounding.large
         level: 2
 
-        implicitWidth: Math.max(200, column.implicitWidth + column.anchors.margins * 2)
-        implicitHeight: column.implicitHeight + column.anchors.margins * 2
+        implicitWidth: Math.max(200, column.implicitWidth + menu._pad * 2 + scrollBar.implicitWidth + Tokens.spacing.extraSmall)
 
         transform: Scale {
             yScale: root.expanded ? 1 : 0.1
-            origin.y: root.thisSideY === Menu.Bottom ? menu.height : 0
+            origin.y: root.effThisSideY === Menu.Bottom ? menu.height : 0
 
             Behavior on yScale {
                 Anim {}
             }
+        }
+
+        Binding {
+            target: menu
+            property: "implicitHeight"
+            value: {
+                const cap = Math.max(root.minHeight, Math.min(root.maxHeight, root.availableSpace));
+                return Math.min(column.implicitHeight + menu._pad * 2, cap);
+            }
+            delayed: true
         }
 
         MouseArea {
@@ -105,91 +181,113 @@ MouseArea {
             radius: parent.radius
             color: Colours.palette.m3surfaceContainerLow
 
-            ColumnLayout {
-                id: column
+            VerticalFadeFlickable {
+                id: flick
 
                 anchors.fill: parent
-                anchors.margins: Tokens.padding.extraSmall
-                spacing: 0
+                anchors.margins: menu._pad
+                anchors.rightMargin: menu._pad + scrollBar.implicitWidth + Tokens.spacing.extraSmall
 
-                Repeater {
-                    id: repeater
+                contentWidth: width
+                contentHeight: column.implicitHeight
+                clip: true
 
-                    model: root.items
+                ColumnLayout {
+                    id: column
 
-                    StyledRect {
-                        id: item
+                    width: flick.width
+                    spacing: 0
 
-                        required property int index
-                        required property MenuItem modelData
-                        readonly property bool active: modelData === root?.active
+                    Repeater {
+                        id: repeater
 
-                        Layout.fillWidth: true
-                        implicitWidth: menuOptionRow.implicitWidth + Tokens.padding.medium * 2
-                        implicitHeight: menuOptionRow.implicitHeight + Tokens.padding.medium * 2
+                        model: root.items
 
-                        radius: active ? Tokens.rounding.medium : Tokens.rounding.extraSmall
-                        topLeftRadius: index === 0 ? Tokens.rounding.medium : radius
-                        topRightRadius: index === 0 ? Tokens.rounding.medium : radius
-                        bottomLeftRadius: index === repeater?.count - 1 ? Tokens.rounding.medium : radius
-                        bottomRightRadius: index === repeater?.count - 1 ? Tokens.rounding.medium : radius
+                        StyledRect {
+                            id: item
 
-                        color: Qt.alpha(Colours.palette.m3tertiaryContainer, active ? 1 : 0)
+                            required property int index
+                            required property MenuItem modelData
+                            readonly property bool active: modelData === root?.active
 
-                        Behavior on radius {
-                            Anim {}
-                        }
+                            Layout.fillWidth: true
+                            implicitWidth: menuOptionRow.implicitWidth + Tokens.padding.medium * 2
+                            implicitHeight: menuOptionRow.implicitHeight + Tokens.padding.medium * 2
 
-                        StateLayer {
-                            topLeftRadius: parent.topLeftRadius
-                            topRightRadius: parent.topRightRadius
-                            bottomLeftRadius: parent.bottomLeftRadius
-                            bottomRightRadius: parent.bottomRightRadius
+                            radius: active ? Tokens.rounding.medium : Tokens.rounding.extraSmall
+                            topLeftRadius: index === 0 ? Tokens.rounding.medium : radius
+                            topRightRadius: index === 0 ? Tokens.rounding.medium : radius
+                            bottomLeftRadius: index === repeater?.count - 1 ? Tokens.rounding.medium : radius
+                            bottomRightRadius: index === repeater?.count - 1 ? Tokens.rounding.medium : radius
 
-                            color: item.active ? Colours.palette.m3onTertiaryContainer : Colours.palette.m3onSurface
-                            disabled: !root.expanded
-                            onClicked: {
-                                root.itemSelected(item.modelData);
-                                root.active = item.modelData;
-                                item.modelData.clicked();
-                                root.expanded = false;
-                            }
-                        }
+                            color: Qt.alpha(Colours.palette.m3tertiaryContainer, active ? 1 : 0)
 
-                        RowLayout {
-                            id: menuOptionRow
-
-                            anchors.fill: parent
-                            anchors.margins: Tokens.padding.medium
-                            spacing: Tokens.spacing.small
-
-                            MaterialIcon {
-                                Layout.alignment: Qt.AlignVCenter
-                                text: item.modelData?.icon ?? ""
-                                color: item.active ? Colours.palette.m3onTertiaryContainer : Colours.palette.m3onSurfaceVariant
+                            Behavior on radius {
+                                Anim {}
                             }
 
-                            StyledText {
-                                Layout.alignment: Qt.AlignVCenter
-                                Layout.fillWidth: true
-                                text: item.modelData?.text ?? ""
+                            StateLayer {
+                                topLeftRadius: parent.topLeftRadius
+                                topRightRadius: parent.topRightRadius
+                                bottomLeftRadius: parent.bottomLeftRadius
+                                bottomRightRadius: parent.bottomRightRadius
+
                                 color: item.active ? Colours.palette.m3onTertiaryContainer : Colours.palette.m3onSurface
+                                disabled: !root.expanded
+                                onClicked: {
+                                    root.itemSelected(item.modelData);
+                                    root.active = item.modelData;
+                                    item.modelData.clicked();
+                                    root.expanded = false;
+                                }
                             }
 
-                            Loader {
-                                asynchronous: true
-                                Layout.alignment: Qt.AlignVCenter
-                                active: item.modelData?.trailingIcon.length > 0
-                                visible: active
+                            RowLayout {
+                                id: menuOptionRow
 
-                                sourceComponent: MaterialIcon {
-                                    text: item.modelData.trailingIcon
+                                anchors.fill: parent
+                                anchors.margins: Tokens.padding.medium
+                                spacing: Tokens.spacing.small
+
+                                MaterialIcon {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    text: item.modelData?.icon ?? ""
                                     color: item.active ? Colours.palette.m3onTertiaryContainer : Colours.palette.m3onSurfaceVariant
+                                }
+
+                                StyledText {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    Layout.fillWidth: true
+                                    text: item.modelData?.text ?? ""
+                                    color: item.active ? Colours.palette.m3onTertiaryContainer : Colours.palette.m3onSurface
+                                }
+
+                                Loader {
+                                    asynchronous: true
+                                    Layout.alignment: Qt.AlignVCenter
+                                    active: item.modelData?.trailingIcon.length > 0
+                                    visible: active
+
+                                    sourceComponent: MaterialIcon {
+                                        text: item.modelData.trailingIcon
+                                        color: item.active ? Colours.palette.m3onTertiaryContainer : Colours.palette.m3onSurfaceVariant
+                                    }
                                 }
                             }
                         }
                     }
                 }
+            }
+
+            StyledScrollBar {
+                id: scrollBar
+
+                anchors.top: parent.top
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                anchors.margins: menu._pad
+
+                flickable: flick
             }
         }
     }

--- a/components/controls/Menu.qml
+++ b/components/controls/Menu.qml
@@ -5,7 +5,6 @@ import QtQuick.Layouts
 import Quickshell
 import Caelestia.Config
 import qs.components
-import qs.components.containers
 import qs.components.effects
 import qs.services
 import qs.modules.drawers
@@ -28,67 +27,15 @@ MouseArea {
     property real marginX
     property real marginY
 
-    property real maxHeight: 320
-    property real minHeight: 160
-    property real edgeMargin: Tokens.spacing.small
-
-    property real _attachTopY: 0
-    property real _attachBottomY: 0
-
-    readonly property real spaceAbove: Math.max(0, _attachTopY - edgeMargin)
-    readonly property real spaceBelow: Math.max(0, root.height - _attachBottomY - edgeMargin)
-
-    readonly property bool _preferBottom: attachSideY === Menu.Bottom
-    readonly property bool _flipToBottom: !_preferBottom && spaceAbove < minHeight && spaceBelow > spaceAbove
-    readonly property bool _flipToTop: _preferBottom && spaceBelow < minHeight && spaceAbove > spaceBelow
-    readonly property bool effectiveBottom: _preferBottom ? !_flipToTop : _flipToBottom
-
-    readonly property int effAttachSideY: effectiveBottom ? Menu.Bottom : Menu.Top
-    readonly property int effThisSideY: effectiveBottom ? Menu.Top : Menu.Bottom
-
-    readonly property real availableSpace: effectiveBottom ? spaceBelow : spaceAbove
-
     property list<MenuItem> items
     property MenuItem active: items[0] ?? null
     property bool expanded
 
     signal itemSelected(item: MenuItem)
 
-    function _updateAttachY() {
-        if (!root.attachTo || !root.parent)
-            return;
-        root._attachTopY = root.attachTo.mapToItem(root.parent, 0, 0).y;
-        root._attachBottomY = root.attachTo.mapToItem(root.parent, 0, root.attachTo.height).y;
-    }
-
-    function scrollToActive() {
-        if (!root.active)
-            return;
-
-        const idx = root.items.indexOf(root.active);
-        if (idx < 0)
-            return;
-
-        const delegate = repeater.itemAt(idx);
-        if (!delegate)
-            return;
-
-        const target = delegate.y + delegate.height / 2 - flick.height / 2;
-        const maxContentY = Math.max(0, flick.contentHeight - flick.height);
-        flick.contentY = Math.max(0, Math.min(target, maxContentY));
-    }
-
-    onExpandedChanged: {
-        if (expanded)
-            Qt.callLater(scrollToActive);
-    }
-
-    onParentChanged: _updateAttachY()
-    Component.onCompleted: _updateAttachY()
-
     parent: {
         const win = QsWindow.window;
-        const contentWin = win as ContentWindow;
+        const contentWin = win as ContentWindow; // If inside the drawer content window, put it inside the interaction wrapper so hover works
         return contentWin ? contentWin.interactionWrapper : (win as QsWindow).contentItem;
     }
     anchors.fill: parent
@@ -112,29 +59,11 @@ MouseArea {
         b: root.attachTo
     }
 
-    Connections {
-        function onTransformChanged() {
-            root._updateAttachY();
-        }
-
-        target: watcher
-    }
-
-    Connections {
-        function onHeightChanged() {
-            root._updateAttachY();
-        }
-
-        target: root.attachTo
-    }
-
     Elevation {
         id: menu
 
-        readonly property real _pad: Tokens.padding.extraSmall
-
         x: {
-            watcher.transform;
+            watcher.transform; // mapToItem is not reactive so this forces updates
             const item = root.attachTo;
             let off = root.attachSideX === Menu.Left ? 0 : item.width;
             if (root.thisSideX === Menu.Right)
@@ -142,32 +71,27 @@ MouseArea {
             return item.mapToItem(root.parent, off, 0).x + root.marginX;
         }
         y: {
-            const attachY = root.effAttachSideY === Menu.Top ? root._attachTopY : root._attachBottomY;
-            return (root.effThisSideY === Menu.Bottom ? attachY - height : attachY) + root.marginY;
+            watcher.transform; // mapToItem is not reactive so this forces updates
+            const item = root.attachTo;
+            let off = root.attachSideY === Menu.Top ? 0 : item.height;
+            if (root.thisSideY === Menu.Bottom)
+                off -= height;
+            return item.mapToItem(root.parent, 0, off).y + root.marginY;
         }
 
         radius: Tokens.rounding.large
         level: 2
 
-        implicitWidth: Math.max(200, column.implicitWidth + menu._pad * 2 + scrollBar.implicitWidth + Tokens.spacing.extraSmall)
+        implicitWidth: Math.max(200, column.implicitWidth + column.anchors.margins * 2)
+        implicitHeight: column.implicitHeight + column.anchors.margins * 2
 
         transform: Scale {
             yScale: root.expanded ? 1 : 0.1
-            origin.y: root.effThisSideY === Menu.Bottom ? menu.height : 0
+            origin.y: root.thisSideY === Menu.Bottom ? menu.height : 0
 
             Behavior on yScale {
                 Anim {}
             }
-        }
-
-        Binding {
-            target: menu
-            property: "implicitHeight"
-            value: {
-                const cap = Math.max(root.minHeight, Math.min(root.maxHeight, root.availableSpace));
-                return Math.min(column.implicitHeight + menu._pad * 2, cap);
-            }
-            delayed: true
         }
 
         MouseArea {
@@ -181,113 +105,91 @@ MouseArea {
             radius: parent.radius
             color: Colours.palette.m3surfaceContainerLow
 
-            VerticalFadeFlickable {
-                id: flick
+            ColumnLayout {
+                id: column
 
                 anchors.fill: parent
-                anchors.margins: menu._pad
-                anchors.rightMargin: menu._pad + scrollBar.implicitWidth + Tokens.spacing.extraSmall
+                anchors.margins: Tokens.padding.extraSmall
+                spacing: 0
 
-                contentWidth: width
-                contentHeight: column.implicitHeight
-                clip: true
+                Repeater {
+                    id: repeater
 
-                ColumnLayout {
-                    id: column
+                    model: root.items
 
-                    width: flick.width
-                    spacing: 0
+                    StyledRect {
+                        id: item
 
-                    Repeater {
-                        id: repeater
+                        required property int index
+                        required property MenuItem modelData
+                        readonly property bool active: modelData === root?.active
 
-                        model: root.items
+                        Layout.fillWidth: true
+                        implicitWidth: menuOptionRow.implicitWidth + Tokens.padding.medium * 2
+                        implicitHeight: menuOptionRow.implicitHeight + Tokens.padding.medium * 2
 
-                        StyledRect {
-                            id: item
+                        radius: active ? Tokens.rounding.medium : Tokens.rounding.extraSmall
+                        topLeftRadius: index === 0 ? Tokens.rounding.medium : radius
+                        topRightRadius: index === 0 ? Tokens.rounding.medium : radius
+                        bottomLeftRadius: index === repeater?.count - 1 ? Tokens.rounding.medium : radius
+                        bottomRightRadius: index === repeater?.count - 1 ? Tokens.rounding.medium : radius
 
-                            required property int index
-                            required property MenuItem modelData
-                            readonly property bool active: modelData === root?.active
+                        color: Qt.alpha(Colours.palette.m3tertiaryContainer, active ? 1 : 0)
 
-                            Layout.fillWidth: true
-                            implicitWidth: menuOptionRow.implicitWidth + Tokens.padding.medium * 2
-                            implicitHeight: menuOptionRow.implicitHeight + Tokens.padding.medium * 2
+                        Behavior on radius {
+                            Anim {}
+                        }
 
-                            radius: active ? Tokens.rounding.medium : Tokens.rounding.extraSmall
-                            topLeftRadius: index === 0 ? Tokens.rounding.medium : radius
-                            topRightRadius: index === 0 ? Tokens.rounding.medium : radius
-                            bottomLeftRadius: index === repeater?.count - 1 ? Tokens.rounding.medium : radius
-                            bottomRightRadius: index === repeater?.count - 1 ? Tokens.rounding.medium : radius
+                        StateLayer {
+                            topLeftRadius: parent.topLeftRadius
+                            topRightRadius: parent.topRightRadius
+                            bottomLeftRadius: parent.bottomLeftRadius
+                            bottomRightRadius: parent.bottomRightRadius
 
-                            color: Qt.alpha(Colours.palette.m3tertiaryContainer, active ? 1 : 0)
+                            color: item.active ? Colours.palette.m3onTertiaryContainer : Colours.palette.m3onSurface
+                            disabled: !root.expanded
+                            onClicked: {
+                                root.itemSelected(item.modelData);
+                                root.active = item.modelData;
+                                item.modelData.clicked();
+                                root.expanded = false;
+                            }
+                        }
 
-                            Behavior on radius {
-                                Anim {}
+                        RowLayout {
+                            id: menuOptionRow
+
+                            anchors.fill: parent
+                            anchors.margins: Tokens.padding.medium
+                            spacing: Tokens.spacing.small
+
+                            MaterialIcon {
+                                Layout.alignment: Qt.AlignVCenter
+                                text: item.modelData?.icon ?? ""
+                                color: item.active ? Colours.palette.m3onTertiaryContainer : Colours.palette.m3onSurfaceVariant
                             }
 
-                            StateLayer {
-                                topLeftRadius: parent.topLeftRadius
-                                topRightRadius: parent.topRightRadius
-                                bottomLeftRadius: parent.bottomLeftRadius
-                                bottomRightRadius: parent.bottomRightRadius
-
+                            StyledText {
+                                Layout.alignment: Qt.AlignVCenter
+                                Layout.fillWidth: true
+                                text: item.modelData?.text ?? ""
                                 color: item.active ? Colours.palette.m3onTertiaryContainer : Colours.palette.m3onSurface
-                                disabled: !root.expanded
-                                onClicked: {
-                                    root.itemSelected(item.modelData);
-                                    root.active = item.modelData;
-                                    item.modelData.clicked();
-                                    root.expanded = false;
-                                }
                             }
 
-                            RowLayout {
-                                id: menuOptionRow
+                            Loader {
+                                asynchronous: true
+                                Layout.alignment: Qt.AlignVCenter
+                                active: item.modelData?.trailingIcon.length > 0
+                                visible: active
 
-                                anchors.fill: parent
-                                anchors.margins: Tokens.padding.medium
-                                spacing: Tokens.spacing.small
-
-                                MaterialIcon {
-                                    Layout.alignment: Qt.AlignVCenter
-                                    text: item.modelData?.icon ?? ""
+                                sourceComponent: MaterialIcon {
+                                    text: item.modelData.trailingIcon
                                     color: item.active ? Colours.palette.m3onTertiaryContainer : Colours.palette.m3onSurfaceVariant
-                                }
-
-                                StyledText {
-                                    Layout.alignment: Qt.AlignVCenter
-                                    Layout.fillWidth: true
-                                    text: item.modelData?.text ?? ""
-                                    color: item.active ? Colours.palette.m3onTertiaryContainer : Colours.palette.m3onSurface
-                                }
-
-                                Loader {
-                                    asynchronous: true
-                                    Layout.alignment: Qt.AlignVCenter
-                                    active: item.modelData?.trailingIcon.length > 0
-                                    visible: active
-
-                                    sourceComponent: MaterialIcon {
-                                        text: item.modelData.trailingIcon
-                                        color: item.active ? Colours.palette.m3onTertiaryContainer : Colours.palette.m3onSurfaceVariant
-                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
-
-            StyledScrollBar {
-                id: scrollBar
-
-                anchors.top: parent.top
-                anchors.right: parent.right
-                anchors.bottom: parent.bottom
-                anchors.margins: menu._pad
-
-                flickable: flick
             }
         }
     }

--- a/modules/nexus/common/BlobPopup.qml
+++ b/modules/nexus/common/BlobPopup.qml
@@ -63,10 +63,8 @@ Item {
 
         anchors.right: parent.right
         anchors.top: parent.top
-
         implicitWidth: parent.width
         implicitHeight: parent.height
-
         group: blobGroup
         radius: Tokens.rounding.large
         deformScale: 0.00001
@@ -119,7 +117,6 @@ Item {
             id: icon
 
             anchors.centerIn: parent
-            text: "view_apps"
             color: Colours.palette.m3onSurfaceVariant
             fontStyle: Tokens.font.icon.medium
         }

--- a/modules/nexus/common/PopupRow.qml
+++ b/modules/nexus/common/PopupRow.qml
@@ -13,8 +13,10 @@ ConnectedRect {
     property alias icon: icon.text
     property alias label: label.text
     property alias status: status.text
+    property string popupIcon: "view_apps"
     property bool keepPopupAsChild
     readonly property alias popup: popup
+
     default required property Item content
 
     Layout.fillWidth: true
@@ -95,7 +97,6 @@ ConnectedRect {
                 hoverEnabled: true
                 enabled: popup.open
                 z: popup.animDriver > 0 ? 1 : 0
-
                 onClicked: popup.open = false
 
                 BlobPopup {
@@ -113,6 +114,7 @@ ConnectedRect {
                     content: root.content
                     pressOverride: stateLayer.pressed
                     hoverOverride: stateLayer.containsMouse
+                    icon: root.popupIcon
                     color: open || hovered || stateLayer.containsMouse ? Colours.palette.m3secondaryContainer : Colours.palette.m3surfaceContainerHighest
                 }
             }

--- a/modules/nexus/pages/WallpaperAndStyle.qml
+++ b/modules/nexus/pages/WallpaperAndStyle.qml
@@ -2,14 +2,14 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Layouts
-import QtQuick.Controls
-import Quickshell
 import Quickshell.Io
+import Caelestia
 import Caelestia.Components
 import Caelestia.Config
 import qs.components
-import qs.components.controls
+import qs.components.containers
 import qs.components.images
+import qs.components.controls
 import qs.services
 import qs.modules.nexus.common
 
@@ -43,21 +43,14 @@ PageBase {
             persistProc.pendingRun = true;
     }
 
-    function applyCursor(name, size, isScroll = false) {
+    function applyCursor(name, size) {
         const safe = sanitizeCursor(name);
         if (safe.length === 0)
             return;
 
         root.currentCursorTheme = safe;
         root.currentCursorSize = size;
-
-        if (isScroll) {
-            applyDebounceTimer.themeName = safe;
-            applyDebounceTimer.size = size;
-            applyDebounceTimer.restart();
-        } else {
-            applyVisual(safe, size);
-        }
+        applyVisual(safe, size);
     }
 
     title: qsTr("Wallpaper & style")
@@ -117,18 +110,6 @@ PageBase {
                     root.cursorLoaded = true;
             }
         },
-        Timer {
-            id: applyDebounceTimer
-
-            property string themeName: ""
-            property int size: 24
-
-            interval: 300
-
-            onTriggered: {
-                root.applyVisual(themeName, size);
-            }
-        },
         Process {
             id: visualProc
 
@@ -169,18 +150,6 @@ PageBase {
                     pendingRun = false;
                     running = true;
                 }
-            }
-        },
-        Variants {
-            id: themeVariants
-
-            model: root.themeNames
-
-            delegate: MenuItem {
-                required property string modelData
-
-                text: modelData
-                icon: modelData === root.currentCursorTheme ? "check" : ""
             }
         }
     ]
@@ -362,92 +331,209 @@ PageBase {
             onToggled: Colours.setMode(checked ? "dark" : "light")
         }
 
-        SelectRow {
-            id: cursorThemeSelect
-
-            Layout.fillWidth: true
-            Layout.topMargin: Tokens.spacing.large - parent.spacing
+        CursorThemeRow {
             first: true
+            icon: "mouse"
+            popupIcon: "palette"
             label: qsTr("Cursor theme")
-            menuItems: themeVariants.instances
-            active: menuItems.find(i => i.text === root.currentCursorTheme) ?? null
-
-            onSelected: item => root.applyCursor(item.text, root.currentCursorSize, false)
+            status: root.cursorLoaded ? root.currentCursorTheme : qsTr("Loading…")
         }
 
-        Item {
-            Layout.fillWidth: true
+        CursorSizeRow {
             Layout.topMargin: Tokens.spacing.extraSmall / 2 - parent.spacing
-            implicitHeight: sliderRowComponent.implicitHeight
+            last: true
+            icon: "mouse"
+            popupIcon: "straighten"
+            label: qsTr("Cursor size")
+            status: root.cursorLoaded ? root.currentCursorSize + " px" : qsTr("Loading…")
+        }
+    }
 
-            SliderRow {
-                id: sliderRowComponent
+    component CursorThemeRow: PopupRow {
+        id: cursorRow
 
-                anchors.fill: parent
-                last: true
-                icon: "mouse"
-                label: qsTr("Size")
-                value: {
-                    if (!root.cursorLoaded)
-                        return 0;
-                    var idx = root.cursorSizes.indexOf(root.currentCursorSize);
-                    if (idx < 0)
-                        return 0;
-                    return idx / (root.cursorSizes.length - 1);
-                }
-                valueLabel: {
-                    if (!root.cursorLoaded)
-                        return qsTr("Loading…");
-                    var idx = Math.round(value * (root.cursorSizes.length - 1));
-                    if (idx >= 0 && idx < root.cursorSizes.length)
-                        return String(root.cursorSizes[idx]) + " px";
-                    return String(root.currentCursorSize) + " px";
-                }
+        readonly property int popupHeight: root.flickable.height - y + root.flickable.contentY - Tokens.padding.large - Tokens.padding.extraExtraLarge
 
-                onMoved: v => {
-                    var idx = Math.round(v * (root.cursorSizes.length - 1));
-                    if (idx >= 0 && idx < root.cursorSizes.length) {
-                        var newSize = root.cursorSizes[idx];
-                        root.applyCursor(root.currentCursorTheme, newSize, true);
-                    }
-                }
+        keepPopupAsChild: {
+            if (root.nState.animatingContainer || root.opacity < 1)
+                return true;
+
+            let p = root.parent;
+            while (p && p.objectName !== "PageContainer")
+                p = p.parent;
+            return p?.opacity < 1;
+        }
+        popup.topMovement: Math.max(Tokens.sizes.nexus.minPopupHeight - popupHeight, Tokens.padding.large)
+
+        content: Loader {
+            id: themeLoader
+
+            active: cursorRow.popup.animDriver > 0
+
+            onLoaded: {
+                Qt.callLater(() => {
+                    const view = item as VerticalFadeListView;
+                    if (view)
+                        view.positionViewAtIndex(root.themeNames.indexOf(root.currentCursorTheme), ListView.Center);
+                });
             }
 
-            MouseArea {
-                anchors.fill: parent
-                propagateComposedEvents: true
+            sourceComponent: VerticalFadeListView {
+                implicitWidth: Tokens.sizes.nexus.popupWidth
+                implicitHeight: CUtils.clamp(cursorRow.popupHeight, Tokens.sizes.nexus.minPopupHeight, Tokens.sizes.nexus.maxPopupHeight)
 
-                onPressed: mouse => {
-                    mouse.accepted = false;
-                }
+                model: root.themeNames
 
-                onPositionChanged: mouse => {
-                    mouse.accepted = false;
-                }
+                delegate: StateLayer {
+                    id: themeItem
 
-                onReleased: mouse => {
-                    mouse.accepted = false;
-                }
+                    required property string modelData
+                    required property int index
 
-                onWheel: wheel => {
-                    wheel.accepted = true;
+                    anchors.fill: undefined
+                    anchors.left: parent?.left
+                    anchors.right: parent?.right
+                    implicitHeight: itemLayout.implicitHeight + itemLayout.anchors.margins * 2
+                    radius: Tokens.rounding.small
 
-                    if (!root.cursorLoaded)
-                        return;
+                    onClicked: {
+                        cursorRow.popup.open = false;
+                        root.applyCursor(modelData, root.currentCursorSize);
+                    }
 
-                    let step = wheel.angleDelta.y > 0 ? 1 : -1;
-                    let currentIndex = root.cursorSizes.indexOf(root.currentCursorSize);
+                    RowLayout {
+                        id: itemLayout
 
-                    if (currentIndex < 0)
-                        currentIndex = 2;
+                        anchors.fill: parent
+                        anchors.margins: Tokens.padding.medium
+                        spacing: Tokens.spacing.medium
 
-                    let newIndex = Math.max(0, Math.min(root.cursorSizes.length - 1, currentIndex + step));
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: themeItem.modelData
+                            font: Tokens.font.body.small
+                            color: themeItem.modelData === root.currentCursorTheme ? Colours.palette.m3primary : Colours.palette.m3onSurface
+                            elide: Text.ElideRight
+                        }
 
-                    if (newIndex !== currentIndex) {
-                        root.applyCursor(root.currentCursorTheme, root.cursorSizes[newIndex], true);
+                        MaterialIcon {
+                            visible: themeItem.modelData === root.currentCursorTheme
+                            text: "check"
+                            color: Colours.palette.m3primary
+                            fontStyle: Tokens.font.icon.small
+                        }
                     }
                 }
             }
         }
+
+        data: [
+            Connections {
+                function onOpenChanged() {
+                    if (cursorRow.popup.open)
+                        Qt.callLater(() => {
+                            const view = themeLoader.item as VerticalFadeListView;
+                            if (view)
+                                view.positionViewAtIndex(root.themeNames.indexOf(root.currentCursorTheme), ListView.Center);
+                        });
+                }
+
+                target: cursorRow.popup
+            }
+        ]
+    }
+
+    component CursorSizeRow: PopupRow {
+        id: cursorSizeRow
+
+        readonly property int popupHeight: root.flickable.height - y + root.flickable.contentY - Tokens.padding.large - Tokens.padding.extraExtraLarge
+
+        keepPopupAsChild: {
+            if (root.nState.animatingContainer || root.opacity < 1)
+                return true;
+
+            let p = root.parent;
+            while (p && p.objectName !== "PageContainer")
+                p = p.parent;
+            return p?.opacity < 1;
+        }
+        popup.topMovement: Math.max(Tokens.sizes.nexus.minPopupHeight - popupHeight, Tokens.padding.large)
+
+        content: Loader {
+            id: sizeLoader
+
+            active: cursorSizeRow.popup.animDriver > 0
+
+            onLoaded: {
+                Qt.callLater(() => {
+                    const view = item as VerticalFadeListView;
+                    if (view)
+                        view.positionViewAtIndex(root.cursorSizes.indexOf(root.currentCursorSize), ListView.Center);
+                });
+            }
+
+            sourceComponent: VerticalFadeListView {
+                implicitWidth: Tokens.sizes.nexus.popupWidth
+                implicitHeight: CUtils.clamp(cursorSizeRow.popupHeight, Tokens.sizes.nexus.minPopupHeight, Tokens.sizes.nexus.maxPopupHeight)
+
+                model: root.cursorSizes
+
+                delegate: StateLayer {
+                    id: sizeItem
+
+                    required property int modelData
+                    required property int index
+
+                    anchors.fill: undefined
+                    anchors.left: parent?.left
+                    anchors.right: parent?.right
+                    implicitHeight: sizeLayout.implicitHeight + sizeLayout.anchors.margins * 2
+                    radius: Tokens.rounding.small
+
+                    onClicked: {
+                        cursorSizeRow.popup.open = false;
+                        root.applyCursor(root.currentCursorTheme, modelData);
+                    }
+
+                    RowLayout {
+                        id: sizeLayout
+
+                        anchors.fill: parent
+                        anchors.margins: Tokens.padding.medium
+                        spacing: Tokens.spacing.medium
+
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: sizeItem.modelData + " px"
+                            font: Tokens.font.body.small
+                            color: sizeItem.modelData === root.currentCursorSize ? Colours.palette.m3primary : Colours.palette.m3onSurface
+                            elide: Text.ElideRight
+                        }
+
+                        MaterialIcon {
+                            visible: sizeItem.modelData === root.currentCursorSize
+                            text: "check"
+                            color: Colours.palette.m3primary
+                            fontStyle: Tokens.font.icon.small
+                        }
+                    }
+                }
+            }
+        }
+
+        data: [
+            Connections {
+                function onOpenChanged() {
+                    if (cursorSizeRow.popup.open)
+                        Qt.callLater(() => {
+                            const view = sizeLoader.item as VerticalFadeListView;
+                            if (view)
+                                view.positionViewAtIndex(root.cursorSizes.indexOf(root.currentCursorSize), ListView.Center);
+                        });
+                }
+
+                target: cursorSizeRow.popup
+            }
+        ]
     }
 }

--- a/modules/nexus/pages/WallpaperAndStyle.qml
+++ b/modules/nexus/pages/WallpaperAndStyle.qml
@@ -2,6 +2,9 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Layouts
+import QtQuick.Controls
+import Quickshell
+import Quickshell.Io
 import Caelestia.Components
 import Caelestia.Config
 import qs.components
@@ -13,7 +16,171 @@ import qs.modules.nexus.common
 PageBase {
     id: root
 
+    property string currentCursorTheme: ""
+    property int currentCursorSize: 24
+    property bool cursorLoaded: false
+    property var themeNames: []
+
+    readonly property var cursorSizes: [16, 20, 24, 28, 32, 40, 48, 64, 96, 128]
+
+    function sanitizeCursor(name) {
+        return name.replace(/[^a-zA-Z0-9_-]/g, "");
+    }
+
+    function applyVisual(theme, size) {
+        visualProc.pendingTheme = theme;
+        visualProc.pendingSize = size;
+        if (!visualProc.running)
+            visualProc.running = true;
+        else
+            visualProc.pendingRun = true;
+
+        persistProc.themeName = theme;
+        persistProc.size = size;
+        if (!persistProc.running)
+            persistProc.running = true;
+        else
+            persistProc.pendingRun = true;
+    }
+
+    function applyCursor(name, size, isScroll = false) {
+        const safe = sanitizeCursor(name);
+        if (safe.length === 0)
+            return;
+
+        root.currentCursorTheme = safe;
+        root.currentCursorSize = size;
+
+        if (isScroll) {
+            applyDebounceTimer.themeName = safe;
+            applyDebounceTimer.size = size;
+            applyDebounceTimer.restart();
+        } else {
+            applyVisual(safe, size);
+        }
+    }
+
     title: qsTr("Wallpaper & style")
+
+    Component.onCompleted: cursorListProc.running = true
+
+    data: [
+        Process {
+            id: cursorListProc
+
+            running: false
+            command: ["bash", "-c", "for d in /usr/share/icons \"$HOME/.local/share/icons\" \"$HOME/.icons\"; do " + "[ -d \"$d\" ] && for t in \"$d\"/*/; do " + "[ -d \"${t}cursors\" ] && basename \"$t\"; done; done | sort -u"]
+
+            stdout: SplitParser {
+                onRead: data => {
+                    const t = data.trim();
+                    if (t.length > 0 && !root.themeNames.includes(t))
+                        root.themeNames = root.themeNames.concat(t);
+                }
+            }
+
+            onRunningChanged: {
+                if (!running)
+                    cursorCurrentProc.running = true;
+            }
+        },
+        Process {
+            id: cursorCurrentProc
+
+            running: false
+            command: ["bash", "-c", "grep '^\\$cursorTheme' \"$HOME/.config/hypr/variables.conf\" 2>/dev/null | sed 's/.*= *//'; " + "grep '^\\$cursorSize' \"$HOME/.config/hypr/variables.conf\" 2>/dev/null | sed 's/.*= *//'"]
+
+            stdout: SplitParser {
+                id: cursorCurrentParser
+
+                property int lineIndex: 0
+
+                onRead: data => {
+                    const t = data.trim();
+                    if (t.length === 0)
+                        return;
+                    if (lineIndex === 0)
+                        root.currentCursorTheme = t;
+                    else {
+                        const n = parseInt(t);
+                        if (!isNaN(n))
+                            root.currentCursorSize = n;
+                    }
+                    lineIndex++;
+                }
+            }
+
+            onRunningChanged: {
+                if (running)
+                    cursorCurrentParser.lineIndex = 0;
+                if (!running)
+                    root.cursorLoaded = true;
+            }
+        },
+        Timer {
+            id: applyDebounceTimer
+
+            property string themeName: ""
+            property int size: 24
+
+            interval: 300
+            onTriggered: {
+                root.applyVisual(themeName, size);
+            }
+        },
+        Process {
+            id: visualProc
+
+            property string pendingTheme: ""
+            property int pendingSize: 24
+            property bool pendingRun: false
+
+            running: false
+            command: ["hyprctl", "setcursor", visualProc.pendingTheme, String(visualProc.pendingSize)]
+
+            onRunningChanged: {
+                if (!running && pendingRun) {
+                    pendingRun = false;
+                    running = true;
+                }
+            }
+        },
+        Process {
+            id: persistProc
+
+            property string themeName: ""
+            property int size: 24
+            property bool pendingRun: false
+
+            running: false
+            command: ["bash", "-c", 'THEME="$1"; SIZE="$2"; ' + 'gsettings set org.gnome.desktop.interface cursor-theme "$THEME"; ' + 'gsettings set org.gnome.desktop.interface cursor-size "$SIZE"; ' + 'CONF="$HOME/.config/hypr/variables.conf"; ' + 'grep -q "^\\$cursorTheme" "$CONF" 2>/dev/null && ' + '  sed -i "s|^\\$cursorTheme = .*|\\$cursorTheme = $THEME|" "$CONF" || ' + '  echo "\\$cursorTheme = $THEME" >> "$CONF"; ' + 'grep -q "^\\$cursorSize" "$CONF" 2>/dev/null && ' + '  sed -i "s|^\\$cursorSize = .*|\\$cursorSize = $SIZE|" "$CONF" || ' + '  echo "\\$cursorSize = $SIZE" >> "$CONF"', "_", persistProc.themeName, String(persistProc.size)]
+
+            stdout: SplitParser {
+                onRead: data => console.log("[cursor] persistProc stdout:", data)
+            }
+            stderr: SplitParser {
+                onRead: data => console.log("[cursor] persistProc stderr:", data)
+            }
+
+            onRunningChanged: {
+                if (!running && pendingRun) {
+                    pendingRun = false;
+                    running = true;
+                }
+            }
+        },
+        Variants {
+            id: themeVariants
+
+            model: root.themeNames
+            delegate: MenuItem {
+                required property string modelData
+
+                text: modelData
+                icon: modelData === root.currentCursorTheme ? "check" : ""
+            }
+        }
+    ]
 
     ColumnLayout {
         anchors.horizontalCenter: parent.horizontalCenter
@@ -24,7 +191,6 @@ PageBase {
         StyledClippingRect {
             id: wallWrapper
 
-            Layout.alignment: Qt.AlignHCenter
             implicitWidth: {
                 const screen = root.nState.screen;
                 return implicitHeight / screen.height * screen.width;
@@ -34,7 +200,7 @@ PageBase {
                 const cWidth = root.cappedWidth;
                 return Math.min(Math.round(cWidth * 0.4), cWidth / screen.width * screen.height);
             }
-
+            Layout.alignment: Qt.AlignHCenter
             color: Colours.tPalette.m3surfaceContainer
             radius: Tokens.rounding.large
 
@@ -82,14 +248,12 @@ PageBase {
                     id: wallIndicatorLoader
 
                     anchors.centerIn: parent
-
                     opacity: 0
                     active: opacity > 0
 
                     sourceComponent: StyledRect {
                         implicitWidth: wallLoadingIndicator.implicitSize + Tokens.padding.largeIncreased * 2
                         implicitHeight: wallLoadingIndicator.implicitSize + Tokens.padding.largeIncreased * 2
-
                         color: Colours.palette.m3primaryContainer
                         radius: Tokens.rounding.full
 
@@ -127,9 +291,7 @@ PageBase {
                     preventInit: wallIndicatorLoader.opacity > 0
                     fadeOutAnim: Anim.DefaultEffects
                     fadeInAnim: Anim.SlowEffects
-
                     onSourceChanged: wallLoadDebounceTimer.restart()
-
                     onStatusChanged: {
                         if (status === Image.Ready) {
                             wallLoadDebounceTimer.stop();
@@ -154,7 +316,7 @@ PageBase {
                 horizontalPadding: Tokens.padding.extraLarge
                 verticalPadding: Tokens.padding.medium
                 disabled: !Config.background.wallpaperEnabled
-                onClicked: root.nState.openSubPage(1) // Wallpaper page
+                onClicked: root.nState.openSubPage(1)
             }
 
             IconTextButton {
@@ -166,7 +328,7 @@ PageBase {
                 type: IconTextButton.Tonal
                 horizontalPadding: Tokens.padding.extraLarge
                 verticalPadding: Tokens.padding.medium
-                onClicked: root.nState.openSubPage(3) // Colours page
+                onClicked: root.nState.openSubPage(3)
             }
         }
 
@@ -179,7 +341,6 @@ PageBase {
 
         ToggleRow {
             Layout.topMargin: Tokens.spacing.extraSmall / 2 - parent.spacing
-
             text: qsTr("Transparency")
             subtext: qsTr("Base %1, layers %2").arg(Colours.transparency.base).arg(Colours.transparency.layers)
             checked: Colours.transparency.enabled
@@ -188,11 +349,94 @@ PageBase {
 
         ToggleRow {
             Layout.topMargin: Tokens.spacing.extraSmall / 2 - parent.spacing
-
             last: true
             text: qsTr("Dark theme")
             checked: !Colours.light
             onToggled: Colours.setMode(checked ? "dark" : "light")
+        }
+
+        SelectRow {
+            id: cursorThemeSelect
+
+            Layout.fillWidth: true
+            Layout.topMargin: Tokens.spacing.large - parent.spacing
+            first: true
+            label: qsTr("Cursor theme")
+            menuItems: themeVariants.instances
+            active: menuItems.find(i => i.text === root.currentCursorTheme) ?? null
+            onSelected: item => root.applyCursor(item.text, root.currentCursorSize, false)
+        }
+
+        Item {
+            Layout.fillWidth: true
+            Layout.topMargin: Tokens.spacing.extraSmall / 2 - parent.spacing
+            implicitHeight: sliderRowComponent.implicitHeight
+
+            SliderRow {
+                id: sliderRowComponent
+
+                anchors.fill: parent
+                last: true
+                icon: "mouse"
+                label: qsTr("Size")
+                value: {
+                    if (!root.cursorLoaded)
+                        return 0;
+                    var idx = root.cursorSizes.indexOf(root.currentCursorSize);
+                    if (idx < 0)
+                        return 0;
+                    return idx / (root.cursorSizes.length - 1);
+                }
+                valueLabel: {
+                    if (!root.cursorLoaded)
+                        return qsTr("Loading…");
+                    var idx = Math.round(value * (root.cursorSizes.length - 1));
+                    if (idx >= 0 && idx < root.cursorSizes.length)
+                        return String(root.cursorSizes[idx]) + " px";
+                    return String(root.currentCursorSize) + " px";
+                }
+                onMoved: v => {
+                    var idx = Math.round(v * (root.cursorSizes.length - 1));
+                    if (idx >= 0 && idx < root.cursorSizes.length) {
+                        var newSize = root.cursorSizes[idx];
+                        root.applyCursor(root.currentCursorTheme, newSize, true);
+                    }
+                }
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                propagateComposedEvents: true
+
+                onPressed: mouse => {
+                    mouse.accepted = false;
+                }
+                onPositionChanged: mouse => {
+                    mouse.accepted = false;
+                }
+                onReleased: mouse => {
+                    mouse.accepted = false;
+                }
+
+                onWheel: wheel => {
+                    wheel.accepted = true;
+
+                    if (!root.cursorLoaded)
+                        return;
+
+                    let step = wheel.angleDelta.y > 0 ? 1 : -1;
+                    let currentIndex = root.cursorSizes.indexOf(root.currentCursorSize);
+
+                    if (currentIndex < 0)
+                        currentIndex = 2;
+
+                    let newIndex = Math.max(0, Math.min(root.cursorSizes.length - 1, currentIndex + step));
+
+                    if (newIndex !== currentIndex) {
+                        root.applyCursor(root.currentCursorTheme, root.cursorSizes[newIndex], true);
+                    }
+                }
+            }
         }
     }
 }

--- a/modules/nexus/pages/WallpaperAndStyle.qml
+++ b/modules/nexus/pages/WallpaperAndStyle.qml
@@ -124,6 +124,7 @@ PageBase {
             property int size: 24
 
             interval: 300
+
             onTriggered: {
                 root.applyVisual(themeName, size);
             }
@@ -158,6 +159,7 @@ PageBase {
             stdout: SplitParser {
                 onRead: data => console.log("[cursor] persistProc stdout:", data)
             }
+
             stderr: SplitParser {
                 onRead: data => console.log("[cursor] persistProc stderr:", data)
             }
@@ -173,6 +175,7 @@ PageBase {
             id: themeVariants
 
             model: root.themeNames
+
             delegate: MenuItem {
                 required property string modelData
 
@@ -200,6 +203,7 @@ PageBase {
                 const cWidth = root.cappedWidth;
                 return Math.min(Math.round(cWidth * 0.4), cWidth / screen.width * screen.height);
             }
+
             Layout.alignment: Qt.AlignHCenter
             color: Colours.tPalette.m3surfaceContainer
             radius: Tokens.rounding.large
@@ -277,6 +281,7 @@ PageBase {
                     id: wallLoadDebounceTimer
 
                     interval: 100
+
                     onTriggered: {
                         if (wallImg.status !== Image.Ready)
                             wallIndicatorLoader.opacity = 1;
@@ -291,7 +296,9 @@ PageBase {
                     preventInit: wallIndicatorLoader.opacity > 0
                     fadeOutAnim: Anim.DefaultEffects
                     fadeInAnim: Anim.SlowEffects
+
                     onSourceChanged: wallLoadDebounceTimer.restart()
+
                     onStatusChanged: {
                         if (status === Image.Ready) {
                             wallLoadDebounceTimer.stop();
@@ -364,6 +371,7 @@ PageBase {
             label: qsTr("Cursor theme")
             menuItems: themeVariants.instances
             active: menuItems.find(i => i.text === root.currentCursorTheme) ?? null
+
             onSelected: item => root.applyCursor(item.text, root.currentCursorSize, false)
         }
 
@@ -395,6 +403,7 @@ PageBase {
                         return String(root.cursorSizes[idx]) + " px";
                     return String(root.currentCursorSize) + " px";
                 }
+
                 onMoved: v => {
                     var idx = Math.round(v * (root.cursorSizes.length - 1));
                     if (idx >= 0 && idx < root.cursorSizes.length) {
@@ -411,9 +420,11 @@ PageBase {
                 onPressed: mouse => {
                     mouse.accepted = false;
                 }
+
                 onPositionChanged: mouse => {
                     mouse.accepted = false;
                 }
+
                 onReleased: mouse => {
                     mouse.accepted = false;
                 }


### PR DESCRIPTION
## What this adds
- A cursor theme selector and size selector directly in the Wallpaper & style page, replacing the previous separate sub-page approach
- Discovers all cursor themes installed in `/usr/share/icons`, `~/.local/share/icons` and `~/.icons`
- Highlights the currently active theme/size with a check mark in the popup list, and scrolls to it automatically on open
- Applies theme and size immediately via `hyprctl setcursor`
- Persists selection to `gsettings` and to `$cursorTheme` / `$cursorSize` in the Hyprland variables config
- `PopupRow` gained a `popupIcon` prop so each row can set a distinct icon for its trigger button, independent of the row's leading icon

## Notes
- Assumes cursor variables are stored as `$cursorTheme` and `$cursorSize` in the Hyprland variables config
- Theme list is populated lazily on page open, not at shell startup

## Demo
https://github.com/user-attachments/assets/51d5f71b-e51c-4520-b62d-396398a34973