### PR TITLE
fix(services): trigger weather reload on service completion

### DIFF
--- a/services/Weather.qml
+++ b/services/Weather.qml
@@ -228,4 +228,6 @@ Singleton {
     ElapsedTimer {
         id: timer
     }
+
+    Component.onCompleted: reload()
 }


### PR DESCRIPTION
Call reload() in Component.onCompleted of Weather.qml so that weather data starts fetching proactively on shell startup, rather than waiting for lazy-loaded UI components (such as SmallWeather.qml or WeatherTab.qml) to instantiate and trigger the reload.