### PR TITLE
feat: responsive 2-column Wi-Fi list on wide panels

### DIFF
--- a/modules/nexus/common/ItemList.qml
+++ b/modules/nexus/common/ItemList.qml
@@ -13,13 +13,21 @@ ConnectedRect {
     property string placeholderIcon
     property string placeholderText
     property int extraHeight
+    // Number of columns. 1 (default) keeps the original single-column ListView
+    // so existing usages are unaffected. >1 switches to a grid.
+    property int columns: 1
+    // Fixed row height used in grid (multi-column) mode.
+    property int gridCellHeight: Math.round(Tokens.font.body.medium.pointSize * 2 + Tokens.font.label.small.pointSize * 2 + Tokens.padding.medium * 2)
 
     property alias model: list.model
     property alias delegate: list.delegate
     readonly property alias list: list
 
+    readonly property int contentCount: root.columns > 1 ? grid.count : list.count
+    readonly property real activeContentHeight: root.columns > 1 ? grid.contentHeight : list.contentHeight
+
     Layout.fillWidth: true
-    implicitHeight: (showList && list.count > 0 ? list.contentHeight : placeholder.implicitHeight + Tokens.padding.extraLarge * 2) + extraHeight
+    implicitHeight: (showList && contentCount > 0 ? activeContentHeight : placeholder.implicitHeight + Tokens.padding.extraLarge * 2) + extraHeight
     color: Colours.tPalette.m3surfaceContainer
     clip: true
 
@@ -32,7 +40,7 @@ ConnectedRect {
 
         anchors.centerIn: parent
         active: opacity > 0
-        opacity: root.showList && list.count > 0 ? 0 : 1
+        opacity: root.showList && root.contentCount > 0 ? 0 : 1
 
         sourceComponent: ColumnLayout {
             spacing: Tokens.spacing.extraSmall
@@ -69,9 +77,10 @@ ConnectedRect {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
 
+        visible: root.columns <= 1
         spacing: 0
         interactive: false
-        opacity: root.showList ? 1 : 0
+        opacity: root.showList && root.columns <= 1 ? 1 : 0
 
         add: Transition {
             Anim {
@@ -111,6 +120,30 @@ ConnectedRect {
                 property: "y"
             }
         }
+
+        Behavior on opacity {
+            Anim {
+                type: Anim.DefaultEffects
+            }
+        }
+    }
+
+    GridView {
+        id: grid
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+
+        visible: root.columns > 1
+        interactive: false
+        opacity: root.showList && root.columns > 1 ? 1 : 0
+
+        cellWidth: width / Math.max(1, root.columns)
+        cellHeight: root.gridCellHeight
+        model: root.columns > 1 ? list.model : null
+        delegate: list.delegate
 
         Behavior on opacity {
             Anim {

--- a/modules/nexus/pages/NetworkPage.qml
+++ b/modules/nexus/pages/NetworkPage.qml
@@ -59,6 +59,10 @@ PageBase {
         ItemList {
             id: networkList
 
+            // Two columns on wide panels, but only when there's more than one
+            // network to show — a lone SSID stays full-width.
+            columns: width > 620 && Nmcli.networks.length > 1 ? 2 : 1 // qmllint disable missing-property
+
             showList: Nmcli.wifiEnabled
             placeholderIcon: Nmcli.wifiEnabled ? "wifi_find" : "signal_wifi_off"
             placeholderText: Nmcli.wifiEnabled ? qsTr("No networks found") : qsTr("Wi-Fi disabled")
@@ -80,11 +84,15 @@ PageBase {
                 required property Nmcli.AccessPoint modelData
                 property bool currentSelected
                 property real textOpacity: disabled ? 0.5 : 1
+                readonly property bool gridMode: networkList.columns > 1
 
                 disabled: currentSelected || Nmcli.connectingSsid() === modelData.ssid
 
-                anchors.left: networkList.list.contentItem.left
-                anchors.right: networkList.list.contentItem.right
+                // Size to the view's cell (grid) or full width (list) instead of
+                // anchoring to the ListView contentItem, which isn't a sibling in
+                // grid mode and triggers an anchor warning.
+                width: gridMode ? (GridView.view?.cellWidth ?? 0) : (ListView.view?.width ?? 0)
+                height: gridMode ? (GridView.view?.cellHeight ?? 0) : implicitHeight
                 implicitHeight: networkLayout.implicitHeight + networkLayout.anchors.margins * 2
                 radius: Tokens.rounding.extraSmall
                 anchors.fill: undefined
@@ -156,6 +164,17 @@ PageBase {
                             font: Tokens.font.label.small
                             elide: Text.ElideRight
                         }
+                    }
+
+                    // Thin vertical separator before the trailing icon, shown
+                    // only for the connected network.
+                    StyledRect {
+                        Layout.alignment: Qt.AlignVCenter
+                        visible: network.modelData.active
+                        implicitWidth: 1
+                        implicitHeight: Math.round(Tokens.font.icon.medium.pointSize * 1.4)
+                        color: Colours.palette.m3outlineVariant
+                        opacity: network.textOpacity * 0.6
                     }
 
                     AnimLoader {


### PR DESCRIPTION
Adds an optional columns property to `ItemList` (default 1 keeps the existing single-column `ListView` unchanged; >1 switches to a `GridView`). The Wi-Fi network list now shows two columns on panels wider than 620px and one column below that, so wide layouts use the horizontal space better.

The delegate sizes itself to the view (grid cell or full row width) instead of anchoring to the list's content item.