### PR TITLE
feat: manage-router row with ISP and maskable public IP

### DIFF
--- a/modules/nexus/pages/NetworkPage.qml
+++ b/modules/nexus/pages/NetworkPage.qml
@@ -336,12 +336,24 @@ PageBase {
                     visible: root.cappedWidth > 620 && (Nmcli.isp.length > 0 || Nmcli.publicIp.length > 0)
                     spacing: 0
 
-                    StyledText {
+                    RowLayout {
                         Layout.alignment: Qt.AlignRight
-                        text: Nmcli.isp.length > 0 ? qsTr("ISP: %1").arg(Nmcli.isp) : qsTr("Public IP")
-                        font: Tokens.font.body.medium
-                        horizontalAlignment: Text.AlignRight
-                        elide: Text.ElideRight
+                        spacing: Tokens.spacing.extraSmall
+
+                        MaterialIcon {
+                            Layout.alignment: Qt.AlignVCenter
+                            visible: Nmcli.isp.length > 0
+                            text: "language"
+                            fontStyle: Tokens.font.icon.small
+                        }
+
+                        StyledText {
+                            Layout.alignment: Qt.AlignVCenter
+                            text: Nmcli.isp.length > 0 ? Nmcli.isp : qsTr("Public IP")
+                            font: Tokens.font.body.medium
+                            horizontalAlignment: Text.AlignRight
+                            elide: Text.ElideRight
+                        }
                     }
 
                     // Public IP row: a label and the value itself, which is

--- a/modules/nexus/pages/NetworkPage.qml
+++ b/modules/nexus/pages/NetworkPage.qml
@@ -13,15 +13,44 @@ import qs.modules.nexus.common
 PageBase {
     id: root
 
+    // Public IP is hidden by default; tapping the blurred value reveals it.
+    property bool showPublicIp: false
+
     signal networkSelected(ap: Nmcli.AccessPoint)
 
     title: qsTr("Network")
+
+    // Public IP / ISP lookup once on creation (onVisibleChanged alone misses the
+    // initial load, since no change event fires).
+    Component.onCompleted: Nmcli.getPublicIpInfo()
+
+    onVisibleChanged: if (visible) {
+        Nmcli.getPublicIpInfo();
+    }
 
     ColumnLayout {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top
         width: root.cappedWidth
         spacing: Tokens.spacing.extraSmall / 2
+
+        // The public IP / ISP changes when the VPN tunnel goes up or down, so
+        // re-resolve it whenever the connection state flips (after a short delay
+        // so the new route has settled).
+        Connections {
+            function onConnectedChanged() {
+                ispRefreshTimer.restart();
+            }
+
+            target: VPN
+        }
+
+        Timer {
+            id: ispRefreshTimer
+
+            interval: 1500
+            onTriggered: Nmcli.getPublicIpInfo()
+        }
 
         Timer {
             running: root.visible && Nmcli.wifiEnabled
@@ -227,6 +256,161 @@ PageBase {
                     text: qsTr("Add network")
                     font: Tokens.font.body.small
                     elide: Text.ElideRight
+                }
+            }
+        }
+
+        // ---- Router ----------------------------------------------------------
+        // Standalone entry that opens the active connection's router admin page
+        // (gateway IP) in a browser. Uses whichever connection is active.
+        ConnectedRect {
+            id: routerRow
+
+            readonly property string gateway: {
+                const eth = Nmcli.activeEthernet ? (Nmcli.ethernetDeviceDetails?.gateway ?? "") : "";
+                if (eth.length > 0)
+                    return eth;
+                return Nmcli.wirelessDeviceDetails?.gateway ?? "";
+            }
+
+            Layout.fillWidth: true
+            Layout.topMargin: Tokens.spacing.large
+            first: true
+            last: true
+            visible: gateway.length > 0
+            implicitHeight: routerLayout.implicitHeight + Tokens.padding.medium * 2
+
+            StateLayer {
+                onClicked: if (routerRow.gateway.length > 0)
+                    Qt.openUrlExternally("http://" + routerRow.gateway)
+            }
+
+            RowLayout {
+                id: routerLayout
+
+                anchors.fill: parent
+                anchors.margins: Tokens.padding.medium
+                anchors.leftMargin: Tokens.padding.largeIncreased
+                anchors.rightMargin: Tokens.padding.largeIncreased
+                spacing: Tokens.spacing.medium
+
+                StyledRect {
+                    implicitWidth: implicitHeight
+                    implicitHeight: routerIcon.implicitHeight + Tokens.padding.small * 2
+                    radius: Tokens.rounding.full
+                    color: Colours.palette.m3surfaceContainerHighest
+
+                    MaterialIcon {
+                        id: routerIcon
+
+                        anchors.centerIn: parent
+                        text: "router"
+                        color: Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.medium
+                    }
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 0
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        text: qsTr("Manage router")
+                        font: Tokens.font.body.medium
+                        elide: Text.ElideRight
+                    }
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        text: qsTr("Open %1 in your browser").arg(routerRow.gateway)
+                        color: Colours.palette.m3onSurfaceVariant
+                        font: Tokens.font.label.small
+                        elide: Text.ElideRight
+                    }
+                }
+
+                // ISP + public IP — shown on wide panels only, right-aligned.
+                ColumnLayout {
+                    Layout.alignment: Qt.AlignVCenter
+                    visible: root.cappedWidth > 620 && (Nmcli.isp.length > 0 || Nmcli.publicIp.length > 0)
+                    spacing: 0
+
+                    StyledText {
+                        Layout.alignment: Qt.AlignRight
+                        text: Nmcli.isp.length > 0 ? qsTr("ISP: %1").arg(Nmcli.isp) : qsTr("Public IP")
+                        font: Tokens.font.body.medium
+                        horizontalAlignment: Text.AlignRight
+                        elide: Text.ElideRight
+                    }
+
+                    // Public IP row: a label and the value itself, which is
+                    // blurred by default (shoulder-surfing privacy) and toggles
+                    // between hidden and revealed when tapped.
+                    RowLayout {
+                        Layout.alignment: Qt.AlignRight
+                        visible: Nmcli.publicIp.length > 0
+                        spacing: Tokens.spacing.extraSmall
+
+                        StyledText {
+                            Layout.alignment: Qt.AlignVCenter
+                            text: qsTr("Public IP:")
+                            color: Colours.palette.m3outline
+                            font: Tokens.font.label.small
+                            horizontalAlignment: Text.AlignRight
+                        }
+
+                        // The value doubles as the toggle: tap to reveal/hide.
+                        Item {
+                            Layout.alignment: Qt.AlignVCenter
+                            implicitWidth: root.showPublicIp ? ipValue.implicitWidth : blurRow.implicitWidth
+                            implicitHeight: Math.max(ipValue.implicitHeight, blurRow.implicitHeight)
+
+                            StyledText {
+                                id: ipValue
+
+                                anchors.right: parent.right
+                                anchors.verticalCenter: parent.verticalCenter
+                                visible: root.showPublicIp
+                                text: Nmcli.publicIp
+                                color: Colours.palette.m3outline
+                                font: Tokens.font.label.small
+                                horizontalAlignment: Text.AlignRight
+                                elide: Text.ElideRight
+                            }
+
+                            Row {
+                                id: blurRow
+
+                                anchors.right: parent.right
+                                anchors.verticalCenter: parent.verticalCenter
+                                visible: !root.showPublicIp
+                                spacing: 0
+
+                                Repeater {
+                                    model: 4
+
+                                    MaterialIcon {
+                                        text: "blur_on"
+                                        color: Colours.palette.m3outline
+                                        fontStyle: Tokens.font.icon.small
+                                    }
+                                }
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: root.showPublicIp = !root.showPublicIp
+                            }
+                        }
+                    }
+                }
+
+                MaterialIcon {
+                    text: "open_in_new"
+                    color: Colours.palette.m3onSurfaceVariant
+                    fontStyle: Tokens.font.icon.small
                 }
             }
         }

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -27,6 +27,9 @@ Singleton {
     property var pendingConnection: null
     property var wirelessDeviceDetails: null
     property var ethernetDeviceDetails: null
+    // Public IP and ISP from an external lookup (for the router row).
+    property string publicIp: ""
+    property string isp: ""
     property list<var> ethernetDevices: []
     readonly property var activeEthernet: ethernetDevices.find(d => d.connected) ?? null
     property list<var> activeProcesses: []
@@ -952,6 +955,13 @@ Singleton {
         });
     }
 
+    // Looks up the public IP and ISP via ip-api.com (free, no token). Results
+    // populate publicIp / isp; failures (offline, blocked) leave them empty.
+    function getPublicIpInfo(): void {
+        publicIpProc.command = ["sh", "-c", "curl -s --max-time 5 http://ip-api.com/json/?fields=query,isp 2>/dev/null"];
+        publicIpProc.running = true;
+    }
+
     function getEthernetDeviceDetails(interfaceName: string, callback: var): void {
         if (!interfaceName || interfaceName.length === 0) {
             const activeInterface = root.ethernetInterfaces.find(iface => {
@@ -1254,6 +1264,23 @@ Singleton {
                 immediateCheckTimer.checkCount = 0;
             }
         }
+    }
+
+    Process {
+        id: publicIpProc
+
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    const data = JSON.parse(text.trim());
+                    root.publicIp = data.query || "";
+                    root.isp = data.isp || "";
+                } catch (e) {
+                    // Lookup failed (offline, blocked) — leave values empty.
+                }
+            }
+        }
+        stderr: StdioCollector {}
     }
 
     Process {


### PR DESCRIPTION
Adds a router row that opens the active connection gateway in a browser and displays ISP and public IP (via ip-api). The IP is masked by default with a toggle to reveal it, and updates when the VPN connection state changes.