### PR TITLE
fix: update GPU name detection script to ensure valid output

### DIFF
--- a/plugin/src/Caelestia/Services/gpu.cpp
+++ b/plugin/src/Caelestia/Services/gpu.cpp
@@ -18,9 +18,10 @@ constexpr const char* kTypeDetectScript =
     " elif ls /sys/class/drm/card*/device/gpu_busy_percent 2>/dev/null | grep -q .; then echo GENERIC;"
     " else echo NONE; fi";
 
-constexpr const char* kNameDetectScript = "nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null"
-                                          " || glxinfo -B 2>/dev/null | grep 'Device:' | cut -d':' -f2 | cut -d'(' -f1 | grep -E '[^[:space:]]'"
-                                          " || lspci 2>/dev/null | grep -i 'vga\\|3d controller\\|display' | head -1";
+constexpr const char* kNameDetectScript =
+    "nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null"
+    " || glxinfo -B 2>/dev/null | grep 'Device:' | cut -d':' -f2 | cut -d'(' -f1 | grep -E '[^[:space:]]'"
+    " || lspci 2>/dev/null | grep -i 'vga\\|3d controller\\|display' | head -1";
 
 } // namespace
 

--- a/plugin/src/Caelestia/Services/gpu.cpp
+++ b/plugin/src/Caelestia/Services/gpu.cpp
@@ -19,7 +19,7 @@ constexpr const char* kTypeDetectScript =
     " else echo NONE; fi";
 
 constexpr const char* kNameDetectScript = "nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null"
-                                          " || glxinfo -B 2>/dev/null | grep 'Device:' | cut -d':' -f2 | cut -d'(' -f1"
+                                          " || glxinfo -B 2>/dev/null | grep 'Device:' | cut -d':' -f2 | cut -d'(' -f1 | grep ."
                                           " || lspci 2>/dev/null | grep -i 'vga\\|3d controller\\|display' | head -1";
 
 } // namespace

--- a/plugin/src/Caelestia/Services/gpu.cpp
+++ b/plugin/src/Caelestia/Services/gpu.cpp
@@ -19,7 +19,7 @@ constexpr const char* kTypeDetectScript =
     " else echo NONE; fi";
 
 constexpr const char* kNameDetectScript = "nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null"
-                                          " || glxinfo -B 2>/dev/null | grep 'Device:' | cut -d':' -f2 | cut -d'(' -f1 | grep ."
+                                          " || glxinfo -B 2>/dev/null | grep 'Device:' | cut -d':' -f2 | cut -d'(' -f1 | grep -E '[^[:space:]]'"
                                           " || lspci 2>/dev/null | grep -i 'vga\\|3d controller\\|display' | head -1";
 
 } // namespace


### PR DESCRIPTION
Use of `grep -E '[^[:space:]]` to make sure the `glxinfo` part is actually showing something, otherwise fallback to third detection