### PR TITLE
fix: clamp layers property to 0-1 for transparency

### DIFF
--- a/services/Colours.qml
+++ b/services/Colours.qml
@@ -147,7 +147,7 @@ Singleton {
     component Transparency: QtObject {
         readonly property bool enabled: Tokens.transparency.enabled
         readonly property real base: Math.max(0, Math.min(1, Tokens.transparency.base - (root.light ? 0.1 : 0)))
-        readonly property real layers: Tokens.transparency.layers
+        readonly property real layers: Math.max(0, Math.min(1, Tokens.transparency.layers))
 
         onEnabledChanged: {
             if (enabled)


### PR DESCRIPTION
In Colours.qml, the `base` value for transparency is explicitly clamped, but the `layers` value is not and simply passed as the token. It's then used in:
```
alterColour(c, transparency.layers, layer ?? 1)
...
return Qt.rgba(r, g, b, a);
```

Qt documents Qt.rgba(red, green, blue, alpha) as expecting all components, including alpha, in [0, 1] (see [here](https://doc.qt.io/qt-6/qml-qtqml-qt.html#rgba-method) ).

This is a violation of Qt's expectations for component values. When passing a value greater than 1.0 or less than 0.0, this is a bad input that reaches Qt.rgba(..., a) outside of the documented range. Qt might clamp this internally in some paths, but Caelestia is not guaranteeing that, and this should be clamped defensively regardless.

This PR fixes this by simply clamping the token value to be 0-1 for `layers`. 