### PR TITLE
windowinfo: format pid as integer string

### DIFF
--- a/modules/windowinfo/Details.qml
+++ b/modules/windowinfo/Details.qml
@@ -86,7 +86,7 @@ ColumnLayout {
 
     Detail {
         icon: "account_tree"
-        text: qsTr("Process id: %1").arg(root.client?.lastIpcObject.pid ?? -1)
+        text: qsTr("Process id: %1").arg(String(root.client?.lastIpcObject.pid ?? -1))
         color: Colours.palette.m3primary
     }
 


### PR DESCRIPTION
Fixes #1482.

  Formats the window info PID as a string before passing it to `arg(...)`, so larger PIDs
  display as decimal text instead of scientific notation.

  Testing:
  - `python3 scripts/qml-lint-conventions.py`
  - Verified numeric Qt substitution can produce scientific notation while string
  substitution keeps decimal PID text.