### PR TITLE
fix: align rtl active window titles

### DIFF
--- a/modules/bar/components/ActiveWindow.qml
+++ b/modules/bar/components/ActiveWindow.qml
@@ -112,6 +112,7 @@ Item {
         font: metrics.font
         color: root.colour
         opacity: root.current === this ? 1 : 0
+        horizontalAlignment: Text.AlignLeft
 
         transform: [
             Translate {


### PR DESCRIPTION
Fixes #1632.

Pins the rotated active-window title to the left edge of its pre-rotation text
geometry, so RTL titles grow away from the app icon instead of overlapping it.

Testing:

python3 scripts/qml-lint-conventions.py
Reproduced with an Arabic window title before the change, then verified the title
no longer overlaps the icon after the change.
