### PR TITLE
fix(nexus): open nexus window on focused monitor and fix portrait sizing

### DIFF
--- a/modules/nexus/Nexus.qml
+++ b/modules/nexus/Nexus.qml
@@ -20,8 +20,8 @@ Item {
 
     signal close
 
-    implicitWidth: implicitHeight * Tokens.sizes.nexus.ratio
-    implicitHeight: nState.screen.height * Tokens.sizes.nexus.heightMult
+    implicitHeight: Math.min(nState.screen.width, nState.screen.height) * Tokens.sizes.nexus.heightMult
+    implicitWidth: Math.min(implicitHeight * Tokens.sizes.nexus.ratio, nState.screen.width * 0.90)
 
     Behavior on blobColour {
         CAnim {}

--- a/modules/nexus/WindowFactory.qml
+++ b/modules/nexus/WindowFactory.qml
@@ -2,6 +2,7 @@ pragma Singleton
 
 import QtQuick
 import Quickshell
+import Quickshell.Hyprland
 import Caelestia.Config
 import qs.components
 import qs.services
@@ -10,8 +11,15 @@ import qs.modules.nexus
 Singleton {
     id: root
 
+    function activeScreen(): ShellScreen {
+        return Quickshell.screens.find(s => s.name === Hyprland.focusedMonitor?.name) ?? Quickshell.screens[0];
+    }
+
     function create(parent: Item, props: var): void {
-        nexusComp.createObject(parent ?? dummy, props);
+        const merged = Object.assign({
+            screen: activeScreen()
+        }, props ?? {});
+        nexusComp.createObject(parent ?? dummy, merged);
     }
 
     QtObject {


### PR DESCRIPTION
fixes #1640 

WindowFactory.qml
- create() now resolves the focused monitor via Hyprland.focusedMonitor as default screen

Nexus.qml
- Fix implicitHeight using screen.height on portrait monitors, which incorrectly used the long side as base → now uses Math.min(screen.width, screen.height)
Clamp implicitWidth to 90% of screen width to prevent the window from exceeding monitor bounds on portrait displays

Videos for both landscape and portrait monitor are attached:

https://github.com/user-attachments/assets/5c2104ef-feda-4c11-940f-96e75beaac99


https://github.com/user-attachments/assets/1bb9e945-0079-4c48-8ad8-0ab39a074ca4

