### PR TITLE
feat:Add item icons (About page)

### DIFF
--- a/modules/nexus/pages/AboutPage.qml
+++ b/modules/nexus/pages/AboutPage.qml
@@ -172,42 +172,6 @@ PageBase {
 
         InfoRow {
             first: true
-            icon: "dashboard"
-            label: qsTr("Shell")
-            value: "caelestia/shell"
-
-            MouseArea {
-                anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
-                onClicked: Qt.openUrlExternally("https://github.com/caelestia-dots/shell")
-            }
-        }
-
-        InfoRow {
-            icon: "web"
-            label: qsTr("CLI")
-            value: "caelestia/cli"
-
-            MouseArea {
-                anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
-                onClicked: Qt.openUrlExternally("https://github.com/caelestia-dots/cli")
-            }
-        }
-
-        InfoRow {
-            icon: "tune"
-            label: qsTr("Dots")
-            value: "caelestia/dots"
-
-            MouseArea {
-                anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
-                onClicked: Qt.openUrlExternally("https://github.com/caelestia-dots/caelestia")
-            }
-        }
-
-        InfoRow {
             icon: "forum"
             label: qsTr("Discord")
             value: "discord.gg/Caelestia"

--- a/modules/nexus/pages/AboutPage.qml
+++ b/modules/nexus/pages/AboutPage.qml
@@ -165,6 +165,73 @@ PageBase {
             value: CUtils.qtVersion || "…"
         }
 
+        // Resources
+        SectionHeader {
+            text: qsTr("Resources")
+        }
+
+        InfoRow {
+            first: true
+            icon: "dashboard"
+            label: qsTr("Shell")
+            value: "caelestia/shell"
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: Qt.openUrlExternally("https://github.com/caelestia-dots/shell")
+            }
+        }
+
+        InfoRow {
+            icon: "web"
+            label: qsTr("CLI")
+            value: "caelestia/cli"
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: Qt.openUrlExternally("https://github.com/caelestia-dots/cli")
+            }
+        }
+
+        InfoRow {
+            icon: "tune"
+            label: qsTr("Dots")
+            value: "caelestia/dots"
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: Qt.openUrlExternally("https://github.com/caelestia-dots/caelestia")
+            }
+        }
+
+        InfoRow {
+            icon: "forum"
+            label: qsTr("Discord")
+            value: "discord.gg/Caelestia"
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: Qt.openUrlExternally("https://discord.gg/HM24fh65E")
+            }
+        }
+
+        InfoRow {
+            last: true
+            icon: "language"
+            label: qsTr("Website")
+            value: "www.caelestiashell.com"
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: Qt.openUrlExternally("https://caelestiashell.com/")
+            }
+        }
+
         // Plugins
         SectionHeader {
             text: qsTr("Plugins")

--- a/modules/nexus/pages/AboutPage.qml
+++ b/modules/nexus/pages/AboutPage.qml
@@ -90,27 +90,32 @@ PageBase {
 
         InfoRow {
             first: true
+            icon: "dns"
             label: qsTr("Hostname")
             value: SysInfo.hostname
         }
 
         InfoRow {
+            icon: "computer"
             label: qsTr("Device")
             value: SysInfo.device
         }
 
         InfoRow {
+            icon: "rocket_launch"
             label: qsTr("Distro")
             value: SysInfo.osPrettyName || SysInfo.osName
         }
 
         InfoRow {
+            icon: "memory"
             label: qsTr("Kernel")
             value: SysInfo.kernel
         }
 
         InfoRow {
             last: true
+            icon: "developer_board"
             label: qsTr("Firmware")
             value: SysInfo.firmware
         }
@@ -124,20 +129,38 @@ PageBase {
             first: true
             label: qsTr("Shell")
             value: CUtils.version || "…"
+
+            leadingComponent: Component {
+                Item {
+                    readonly property real targetSize: 20
+
+                    implicitWidth: targetSize
+                    implicitHeight: targetSize * (90.38 / 128)
+
+                    AnimatedLogo {
+                        anchors.centerIn: parent
+                        skipIntroAnimation: true
+                        scale: parent.targetSize / 128
+                    }
+                }
+            }
         }
 
         InfoRow {
+            icon: "terminal"
             label: qsTr("CLI")
             value: root.cliVersion || "…"
         }
 
         InfoRow {
+            icon: "deployed_code"
             label: qsTr("Quickshell")
             value: root.quickshellVersion || "…"
         }
 
         InfoRow {
             last: true
+            icon: "code"
             label: qsTr("Qt")
             value: CUtils.qtVersion || "…"
         }
@@ -150,6 +173,7 @@ PageBase {
         InfoRow {
             first: true
             last: true
+            icon: "extension"
             label: qsTr("Loaded plugins")
             value: root.pluginCount.toString()
         }


### PR DESCRIPTION
Adds leading icons and links to About page list items.

## Screenshot
<img width="860" height="475" alt="image" src="https://github.com/user-attachments/assets/91e9bb82-80cb-4829-8c1c-89ed9379ebd6" />

