### PR TITLE
fix: key ZFS filesystems by pool in storage service

### DIFF
--- a/plugin/src/Caelestia/Services/storage.cpp
+++ b/plugin/src/Caelestia/Services/storage.cpp
@@ -215,6 +215,7 @@ void Storage::tick() {
         quint64 usedBytes = 0;
         bool hasRoot = false;
         QByteArray device;
+        QByteArray fsType;
     };
 
     QHash<QByteArray, DeviceEntry> byDevice;
@@ -236,6 +237,7 @@ void Storage::tick() {
 
         DeviceEntry& e = byDevice[device];
         e.device = device;
+        e.fsType = v.fileSystemType();
         e.totalBytes = totalBytes;
         e.usedBytes = usedBytes;
         e.hasRoot = e.hasRoot || isRoot;
@@ -245,6 +247,22 @@ void Storage::tick() {
         const DeviceEntry& e = it.value();
         const QStringList disks = resolveToPhysicalDisks(QString::fromLocal8Bit(e.device));
         if (disks.isEmpty()) {
+            // ZFS has no /dev block device to resolve — its "device" is a
+            // "pool/dataset" name (e.g. rpool/root), so resolveToPhysicalDisks
+            // returns nothing and the whole pool would be dropped. Fall back to
+            // keying by the pool name. Datasets in a pool share the pool's free
+            // space, so keep a single representative entry per pool (preferring
+            // the root dataset, else the largest) rather than summing them.
+            if (e.fsType == "zfs") {
+                const qsizetype slash = e.device.indexOf('/');
+                const QString pool = QString::fromLocal8Bit(slash > 0 ? e.device.left(slash) : e.device);
+                Accum& a = byDisk[pool];
+                if (!a.hasRoot && (e.hasRoot || e.totalBytes > a.totalBytes)) {
+                    a.usedBytes = e.usedBytes;
+                    a.totalBytes = e.totalBytes;
+                    a.hasRoot = e.hasRoot;
+                }
+            }
             continue;
         }
         for (const QString& d : disks) {


### PR DESCRIPTION
## Problem

On a ZFS-on-root system, the dashboard's Storage card shows the tiny `/boot` partition instead of the ZFS pool.

`Storage::tick()` resolves each mount's device to a physical disk via `/sys/dev/block`, but `resolveToPhysicalDisks` early-returns on any device string that doesn't start with `/`:

```cpp
if (devicePath.isEmpty() || !devicePath.startsWith(QLatin1Char('/'))) {
    return {};
}
```

ZFS reports its device as a `pool/dataset` name (e.g. `rpool/root`), which has no leading `/`, so it returns empty and the mount is dropped at the `if (disks.isEmpty()) continue;` check. The whole ZFS root disappears, leaving only vfat `/boot`, which then becomes the "primary" disk.

## Fix

When block-device resolution fails for a **ZFS** filesystem, fall back to keying the disk by the pool name (the part before the first `/`). Datasets in a pool share the pool's free space, so keeping one representative entry per pool (preferring the root dataset, else the largest) rather than summing them avoids double-counting the shared free space.

Non-ZFS filesystems are unaffected — the fallback is gated on `fsType == "zfs"`, so anything else that fails resolution still `continue`s as before.

## Testing

Ran the resolver against a live ZFS-on-root machine (`rpool/root` at `/`, vfat `/boot`):

```
before → 1 disk:
  [PRIMARY] nvme0n1   used=0.1 GiB    total=1.0 GiB     root=0   ← /boot

after  → 2 disks:
  [PRIMARY] rpool     used=117.6 GiB  total=457.2 GiB   root=1   ← ZFS pool
            nvme0n1   used=0.1 GiB    total=1.0 GiB     root=0   ← /boot
```

The pool now appears, is keyed by name, sorts first via `hasRoot`, and the numbers match `zpool list` / `df`.
