### PR TITLE
fix(config): preserve unknown config keys on save

### DIFF
--- a/plugin/src/Caelestia/Config/rootconfig.cpp
+++ b/plugin/src/Caelestia/Config/rootconfig.cpp
@@ -54,6 +54,40 @@ QStringList RootConfig::collectUnknownKeys(const ConfigObject* obj, const QJsonO
     return unknown;
 }
 
+void RootConfig::mergeUnknownKeys(const ConfigObject* obj, const QJsonObject& source, QJsonObject& target) {
+    const auto* meta = obj->metaObject();
+
+    QSet<QString> known;
+    for (int i = ConfigObject::basePropertyOffset(); i < meta->propertyCount(); ++i)
+        known.insert(QString::fromUtf8(meta->property(i).name()));
+
+    for (auto it = source.begin(); it != source.end(); ++it) {
+        if (!known.contains(it.key())) {
+            if (!target.contains(it.key()))
+                target.insert(it.key(), it.value());
+            continue;
+        }
+
+        if (!it.value().isObject())
+            continue;
+
+        int idx = meta->indexOfProperty(it.key().toUtf8().constData());
+        if (idx < 0)
+            continue;
+
+        auto prop = meta->property(idx);
+        auto* subObj = prop.read(obj).value<ConfigObject*>();
+        if (!subObj)
+            continue;
+
+        auto childTarget = target.value(it.key()).toObject();
+        mergeUnknownKeys(subObj, it.value().toObject(), childTarget);
+
+        if (!childTarget.isEmpty())
+            target.insert(it.key(), childTarget);
+    }
+}
+
 void RootConfig::setupFileBackend(const QString& path, const QString& screen) {
     m_filePath = path;
     m_screen = screen;
@@ -81,6 +115,7 @@ void RootConfig::setupFileBackend(const QString& path, const QString& screen) {
         }
 
         auto json = toJsonObject();
+        mergeUnknownKeys(this, m_lastLoadedJson, json);
         file.write(QJsonDocument(json).toJson(QJsonDocument::Indented));
         file.close();
 
@@ -239,6 +274,7 @@ std::optional<QString> RootConfig::reloadFromFile() {
     clearLoadedKeys();
 
     auto jsonObj = doc.object();
+    m_lastLoadedJson = jsonObj;
     loadFromJson(jsonObj);
 
     m_loading = false;

--- a/plugin/src/Caelestia/Config/rootconfig.hpp
+++ b/plugin/src/Caelestia/Config/rootconfig.hpp
@@ -35,6 +35,7 @@ signals:
 
 private:
     static QStringList collectUnknownKeys(const ConfigObject* obj, const QJsonObject& json);
+    static void mergeUnknownKeys(const ConfigObject* obj, const QJsonObject& source, QJsonObject& target);
     void emitLoadSignals(const std::optional<QString>& result, bool emitLoaded = true);
     void updateWatch();
     void onWatcherEvent();
@@ -58,6 +59,7 @@ private:
     QTimer* m_reloadDebounce = nullptr;
     int m_parseRetries = 0;
     QStringList m_lastUnknownKeys;
+    QJsonObject m_lastLoadedJson;
 };
 
 } // namespace caelestia::config


### PR DESCRIPTION
## Summary

Preserve unknown keys from the loaded `shell.json` when saving config, then merge unknown keys back into the serialized output. This prevents the shell from removing unknown keys in the config, which can be an issue when keys for features that are in development are present, or for configurations designed for forks that are loaded during a build of the upstream shell. Known Qt-meta properties are still authoritative, so normal edits and resets continue to work as expected.

## Testing

- Tested behavior with versus without the patch. Upstream removes unknown keys from the config, while the version present in this PR preserves them.
- Key sorting and loading of known properties continues to work the same as previously.
- Clang formatting passes without errors.