### PR TITLE
fix: broken Chrome notifications (icon, raw HTML body, click does nothing)

### DIFF
--- a/modules/notifications/Notification.qml
+++ b/modules/notifications/Notification.qml
@@ -98,9 +98,27 @@ StyledRect {
             if (!GlobalConfig.notifs.actionOnClick || event.button !== Qt.LeftButton)
                 return;
 
+            // "default" is meant for a plain click; most senders (Chrome included) also
+            // send other actions, so this can't just be actions.length === 1 anymore
             const actions = root.modelData.actions;
-            if (actions.length === 1)
+            const defaultAction = actions.find(a => a.identifier === "default");
+            if (defaultAction) {
+                defaultAction.invoke();
+                root.modelData.popup = false;
+                return;
+            }
+
+            if (actions.length === 1) {
                 actions[0].invoke();
+                root.modelData.popup = false;
+                return;
+            }
+
+            const linkMatch = root.modelData.body.match(/<a[^>]*href="([^"]+)"/i);
+            if (linkMatch) {
+                Qt.openUrlExternally(linkMatch[1]);
+                root.modelData.popup = false;
+            }
         }
 
         Item {

--- a/modules/notifications/Notification.qml
+++ b/modules/notifications/Notification.qml
@@ -18,7 +18,21 @@ StyledRect {
     required property NotifData modelData
     readonly property bool hasImage: modelData.image.length > 0
     readonly property bool hasAppIcon: modelData.appIcon.length > 0
-    readonly property int bodyTextFormat: /[<*_`#\[\]]/.test(modelData.body) ? Text.MarkdownText : Text.PlainText
+    // Notification bodies allow a small HTML subset (<a>, <b>, <i>, <u>), not Markdown
+    readonly property bool hasMarkup: /<\/?(a|b|i|u)[ >]/i.test(modelData.body)
+    readonly property int bodyTextFormat: hasMarkup ? Text.RichText : /[<*_`#\[\]]/.test(modelData.body) ? Text.MarkdownText : Text.PlainText
+    // Escapes everything, then re-opens only the tags above, so a body can't sneak in
+    // bigger markup (e.g. <h1>, <table>) that Qt's rich text would happily also render
+    readonly property string richBody: {
+        if (!hasMarkup)
+            return modelData.body;
+        let s = modelData.body.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+        s = s.replace(/&lt;a href="([^"]*)"&gt;/gi, "<a href=\"$1\">");
+        return s.replace(/&lt;(\/?)(b|i|u)&gt;/gi, "<$1$2>");
+    }
+    // Eliding rich text mid-tag breaks the markup, so the one-line preview strips it
+    // entirely (links included, since a truncated URL isn't useful there anyway)
+    readonly property string plainBody: modelData.body.replace(/<a[^>]*>[\s\S]*?<\/a>/gi, "").replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim()
     readonly property int nonAnimHeight: summary.implicitHeight + (root.expanded ? Tokens.spacing.extraSmall * 2 + appName.height + body.height + actions.height + actions.anchors.topMargin : bodyPreview.height) + inner.anchors.margins * 2
     property bool expanded: Config.notifs.openExpanded
 
@@ -391,7 +405,7 @@ StyledRect {
                 anchors.rightMargin: Tokens.spacing.small
 
                 animate: true
-                textFormat: root.bodyTextFormat
+                textFormat: Text.PlainText
                 text: bodyPreviewMetrics.elidedText
                 color: Colours.palette.m3onSurfaceVariant
                 font: Tokens.font.body.small
@@ -408,7 +422,7 @@ StyledRect {
             TextMetrics {
                 id: bodyPreviewMetrics
 
-                text: root.modelData.body
+                text: root.plainBody
                 font: bodyPreview.font
                 elide: Text.ElideRight
                 elideWidth: bodyPreview.width
@@ -424,7 +438,7 @@ StyledRect {
 
                 animate: true
                 textFormat: root.bodyTextFormat
-                text: root.modelData.body
+                text: root.richBody
                 color: Colours.palette.m3onSurfaceVariant
                 font: Tokens.font.body.small
                 wrapMode: Text.WrapAtWordBoundaryOrAnywhere

--- a/services/NotifData.qml
+++ b/services/NotifData.qml
@@ -29,7 +29,9 @@ QtObject {
     property string notificationId
     property string summary
     property string body
-    property string appIcon
+    property string rawAppIcon
+    // Some senders (e.g. Chrome) pass a file path here instead of a themed icon name
+    readonly property string appIcon: (rawAppIcon.startsWith("/") || rawAppIcon.startsWith("file://")) ? (hints?.["desktop-entry"] ?? rawAppIcon) : rawAppIcon
     property string appName
     property string image
     property var hints // Hints are not persisted across restarts
@@ -123,7 +125,7 @@ QtObject {
         }
 
         function onAppIconChanged(): void {
-            notif.appIcon = notif.notification.appIcon;
+            notif.rawAppIcon = notif.notification.appIcon;
         }
 
         function onAppNameChanged(): void {
@@ -223,7 +225,7 @@ QtObject {
         notificationId = notification.id;
         summary = notification.summary;
         body = notification.body;
-        appIcon = notification.appIcon;
+        rawAppIcon = notification.appIcon;
         appName = notification.appName;
         image = notification.image;
         maybeTriggerDummyImageLoader();


### PR DESCRIPTION
Chrome notifications (probably other apps too) show up broken:

- the app icon badge doesn't load
- the body shows a raw `<a href="...">` tag instead of text
- clicking the notification does nothing

Turns out:

- Chrome sends the icon as a temp file path, not a themed icon name — `Quickshell.iconPath()` can't resolve that, so it now falls back to the `desktop-entry` hint instead
- notification bodies can contain a small HTML subset (not Markdown) for things like a site link — now rendered as rich text instead of shown raw, and stripped from the one-line preview so it doesn't break mid-tag
- clicking only worked with exactly one action, but Chrome always sends two (`default` + `settings`) — now looks for the `default` action specifically, which is the one that focuses the tab

<img width="485" height="121" alt="image" src="https://github.com/user-attachments/assets/c51db9de-f6b7-4f2e-b051-177c8dba2d94" />
<img width="516" height="124" alt="image" src="https://github.com/user-attachments/assets/0f2163c4-920e-4e8f-af46-73b88a26ad06" />
