### PR TITLE
feat: add keyboard shortcuts page to settings

### DIFF
--- a/modules/nexus/PageCompRegistry.qml
+++ b/modules/nexus/PageCompRegistry.qml
@@ -156,6 +156,14 @@ QtObject {
                 }
             }
         },
+        Component {
+            // Keyboard shortcuts
+            StackPage {
+                Component {
+                    KeybindsPage {}
+                }
+            }
+        },
 
         // About
         Component {

--- a/modules/nexus/PageRegistry.qml
+++ b/modules/nexus/PageRegistry.qml
@@ -81,6 +81,12 @@ QtObject {
             description: qsTr("UI language, weather location, display units"),
             category: "shell"
         },
+        {
+            label: qsTr("Keyboard shortcuts"),
+            icon: "keyboard",
+            description: qsTr("View your Hyprland keybinds"),
+            category: "shell"
+        },
 
         // About
         {

--- a/modules/nexus/pages/KeybindsPage.qml
+++ b/modules/nexus/pages/KeybindsPage.qml
@@ -1,0 +1,211 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.modules.nexus.common
+
+PageBase {
+    id: root
+
+    property string search: ""
+
+    function matches(bind: var): bool {
+        if (!search)
+            return true;
+        const q = search.toLowerCase();
+        return bind.action.toLowerCase().includes(q) || bind.keys.toLowerCase().includes(q);
+    }
+
+    function filtered(binds: var): var {
+        return binds.filter(b => root.matches(b));
+    }
+
+    title: qsTr("Keyboard shortcuts")
+
+    ColumnLayout {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        width: root.cappedWidth
+        spacing: Tokens.spacing.extraSmall / 2
+
+        StyledRect {
+            Layout.fillWidth: true
+            Layout.bottomMargin: Tokens.spacing.small
+            implicitHeight: searchLayout.implicitHeight + Tokens.padding.medium * 2
+
+            radius: Tokens.rounding.full
+            color: Colours.tPalette.m3surfaceContainerLowest
+            border.color: Colours.palette.m3outlineVariant
+
+            Behavior on border.color {
+                CAnim {}
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.IBeamCursor
+                onClicked: searchField.forceActiveFocus()
+            }
+
+            RowLayout {
+                id: searchLayout
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.margins: Tokens.padding.large
+                spacing: Tokens.spacing.small
+
+                MaterialIcon {
+                    text: "search"
+                    color: Colours.palette.m3onSurfaceVariant
+                    fontStyle: Tokens.font.icon.medium
+                }
+
+                StyledTextField {
+                    id: searchField
+
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+
+                    placeholderText: qsTr("Search shortcuts")
+                    placeholderTextColor: Colours.palette.m3onSurfaceVariant
+                    color: Colours.palette.m3onSurface
+                    font: Tokens.font.body.large
+
+                    onTextChanged: root.search = text
+                }
+
+                IconButton {
+                    visible: searchField.text.length > 0
+                    icon: "close"
+                    font: Tokens.font.icon.small
+                    type: IconButton.Text
+                    isRound: true
+                    onClicked: searchField.clear()
+                }
+            }
+        }
+
+        Repeater {
+            model: Keybinds.groups
+
+            ColumnLayout {
+                id: section
+
+                required property var modelData
+                required property int index
+
+                readonly property var shown: root.filtered(modelData.binds)
+
+                Layout.fillWidth: true
+                spacing: Tokens.spacing.extraSmall / 2
+                visible: shown.length > 0
+
+                SectionHeader {
+                    first: section.index === 0
+                    text: section.modelData.category
+                }
+
+                Repeater {
+                    model: section.shown
+
+                    ConnectedRect {
+                        id: row
+
+                        required property var modelData
+                        required property int index
+
+                        Layout.fillWidth: true
+                        first: index === 0
+                        last: index === section.shown.length - 1
+                        implicitHeight: rowLayout.implicitHeight + rowLayout.anchors.margins * 2
+
+                        RowLayout {
+                            id: rowLayout
+
+                            anchors.fill: parent
+                            anchors.margins: Tokens.padding.medium
+                            anchors.leftMargin: Tokens.padding.largeIncreased
+                            anchors.rightMargin: Tokens.padding.largeIncreased
+                            spacing: Tokens.spacing.medium
+
+                            StyledText {
+                                Layout.fillWidth: true
+                                text: row.modelData.action
+                                font: Tokens.font.body.small
+                                elide: Text.ElideRight
+                            }
+
+                            Row {
+                                Layout.alignment: Qt.AlignVCenter
+                                spacing: Tokens.spacing.small / 2
+
+                                Repeater {
+                                    model: row.modelData.keys.split(" + ")
+
+                                    StyledRect {
+                                        id: chip
+
+                                        required property string modelData
+
+                                        implicitWidth: Math.max(implicitHeight, chipLabel.implicitWidth + Tokens.padding.small * 2)
+                                        implicitHeight: chipLabel.implicitHeight + Tokens.padding.extraSmall * 2
+
+                                        radius: Tokens.rounding.small
+                                        color: Colours.palette.m3surfaceContainerHighest
+                                        border.color: Colours.palette.m3outlineVariant
+
+                                        StyledText {
+                                            id: chipLabel
+
+                                            anchors.centerIn: parent
+                                            text: chip.modelData
+                                            color: Colours.palette.m3onSurface
+                                            font: Tokens.font.label.medium
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.topMargin: Tokens.padding.extraLarge * 2
+            spacing: Tokens.padding.extraSmall
+            visible: Keybinds.ready ? root.search.length > 0 && !Keybinds.groups.some(g => root.filtered(g.binds).length > 0) : true
+
+            MaterialIcon {
+                Layout.alignment: Qt.AlignHCenter
+                text: Keybinds.ready ? "search_off" : "keyboard"
+                color: Colours.palette.m3outlineVariant
+                fontStyle: Tokens.font.icon.extraLarge
+            }
+
+            StyledText {
+                Layout.alignment: Qt.AlignHCenter
+                text: Keybinds.ready ? qsTr("No matching shortcuts") : qsTr("Loading shortcuts…")
+                color: Colours.palette.m3outlineVariant
+                font: Tokens.font.title.small
+            }
+
+            StyledText {
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.WordWrap
+                visible: !Keybinds.ready
+                text: qsTr("Reading your Hyprland keybinds")
+                color: Colours.palette.m3outlineVariant
+                font: Tokens.font.body.small
+            }
+        }
+    }
+}

--- a/modules/nexus/pages/KeybindsPage.qml
+++ b/modules/nexus/pages/KeybindsPage.qml
@@ -13,6 +13,105 @@ PageBase {
 
     property string search: ""
 
+    // Id of the bind currently being re-recorded ("" if none). A string, not the
+    // bind object, since bind objects lose identity crossing the var boundary.
+    property string recordingId: ""
+
+    function isModifier(k: int): bool {
+        return k === Qt.Key_Super_L || k === Qt.Key_Super_R || k === Qt.Key_Meta || k === Qt.Key_Control || k === Qt.Key_Alt || k === Qt.Key_AltGr || k === Qt.Key_Shift || k === Qt.Key_CapsLock || k === Qt.Key_NumLock;
+    }
+
+    // Map a Qt key event to a Hyprland keysym name (null if unmappable).
+    function keyName(event: var): string {
+        const k = event.key;
+        if (k >= Qt.Key_A && k <= Qt.Key_Z)
+            return String.fromCharCode(k);
+        if (k >= Qt.Key_0 && k <= Qt.Key_9)
+            return String.fromCharCode(k);
+        if (k >= Qt.Key_F1 && k <= Qt.Key_F35)
+            return "F" + (k - Qt.Key_F1 + 1);
+        switch (k) {
+        case Qt.Key_Space:
+            return "space";
+        case Qt.Key_Return:
+        case Qt.Key_Enter:
+            return "Return";
+        case Qt.Key_Tab:
+        case Qt.Key_Backtab:
+            return "Tab";
+        case Qt.Key_Escape:
+            return "Escape";
+        case Qt.Key_Backspace:
+            return "BackSpace";
+        case Qt.Key_Delete:
+            return "Delete";
+        case Qt.Key_Insert:
+            return "Insert";
+        case Qt.Key_Home:
+            return "Home";
+        case Qt.Key_End:
+            return "End";
+        case Qt.Key_PageUp:
+            return "Prior";
+        case Qt.Key_PageDown:
+            return "Next";
+        case Qt.Key_Left:
+            return "Left";
+        case Qt.Key_Right:
+            return "Right";
+        case Qt.Key_Up:
+            return "Up";
+        case Qt.Key_Down:
+            return "Down";
+        case Qt.Key_Minus:
+            return "minus";
+        case Qt.Key_Equal:
+            return "equal";
+        case Qt.Key_Comma:
+            return "comma";
+        case Qt.Key_Period:
+            return "period";
+        case Qt.Key_Slash:
+            return "slash";
+        case Qt.Key_Backslash:
+            return "backslash";
+        case Qt.Key_Semicolon:
+            return "semicolon";
+        case Qt.Key_Apostrophe:
+            return "apostrophe";
+        case Qt.Key_BracketLeft:
+            return "bracketleft";
+        case Qt.Key_BracketRight:
+            return "bracketright";
+        case Qt.Key_QuoteLeft:
+            return "grave";
+        case Qt.Key_Print:
+            return "Print";
+        case Qt.Key_Pause:
+            return "Pause";
+        }
+        if (event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 0x20)
+            return event.text.toUpperCase();
+        return null;
+    }
+
+    // Build a Hyprland key combo string (e.g. "SUPER + T") from a key event.
+    function luaFromEvent(event: var): string {
+        const name = root.keyName(event);
+        if (!name)
+            return "";
+        const mods = [];
+        if (event.modifiers & Qt.MetaModifier)
+            mods.push("SUPER");
+        if (event.modifiers & Qt.ControlModifier)
+            mods.push("CTRL");
+        if (event.modifiers & Qt.AltModifier)
+            mods.push("ALT");
+        if (event.modifiers & Qt.ShiftModifier)
+            mods.push("SHIFT");
+        return [...mods, name].join(" + ");
+    }
+
     function matches(bind: var): bool {
         if (!search)
             return true;
@@ -128,6 +227,9 @@ PageBase {
                         RowLayout {
                             id: rowLayout
 
+                            readonly property bool recording: root.recordingId !== "" && root.recordingId === row.modelData.id
+                            readonly property bool editable: !!row.modelData.edit
+
                             anchors.fill: parent
                             anchors.margins: Tokens.padding.medium
                             anchors.leftMargin: Tokens.padding.largeIncreased
@@ -141,7 +243,16 @@ PageBase {
                                 elide: Text.ElideRight
                             }
 
+                            StyledText {
+                                visible: rowLayout.recording
+                                Layout.alignment: Qt.AlignVCenter
+                                text: qsTr("Press keys…")
+                                color: Colours.palette.m3primary
+                                font: Tokens.font.label.medium
+                            }
+
                             Row {
+                                visible: !rowLayout.recording
                                 Layout.alignment: Qt.AlignVCenter
                                 spacing: Tokens.spacing.small / 2
 
@@ -169,6 +280,51 @@ PageBase {
                                             font: Tokens.font.label.medium
                                         }
                                     }
+                                }
+                            }
+
+                            IconButton {
+                                visible: rowLayout.editable
+                                Layout.alignment: Qt.AlignVCenter
+                                icon: rowLayout.recording ? "close" : "edit"
+                                font: Tokens.font.icon.small
+                                type: IconButton.Text
+                                isRound: true
+                                onClicked: root.recordingId = rowLayout.recording ? "" : row.modelData.id
+                            }
+
+                            Item {
+                                id: capture
+
+                                implicitWidth: 0
+                                implicitHeight: 0
+
+                                // Grab keyboard focus whenever this row enters
+                                // recording, regardless of how it was triggered.
+                                onRecordingChanged: if (recording)
+                                    forceActiveFocus()
+                                property bool recording: rowLayout.recording
+
+                                Keys.onShortcutOverride: event => event.accepted = rowLayout.recording
+                                Keys.onPressed: event => {
+                                    if (!rowLayout.recording)
+                                        return;
+                                    event.accepted = true;
+                                    if (event.key === Qt.Key_Escape) {
+                                        root.recordingId = "";
+                                        return;
+                                    }
+                                    if (root.isModifier(event.key))
+                                        return;
+                                    const combo = root.luaFromEvent(event);
+                                    if (!combo)
+                                        return;
+                                    Keybinds.setBind(row.modelData.edit, combo);
+                                    root.recordingId = "";
+                                }
+                                onActiveFocusChanged: {
+                                    if (!activeFocus && rowLayout.recording)
+                                        root.recordingId = "";
                                 }
                             }
                         }

--- a/services/Keybinds.qml
+++ b/services/Keybinds.qml
@@ -171,6 +171,7 @@ Singleton {
         };
 
         let curComment = "General";
+        const literalCounts = {};
         const lines = kbText.split("\n");
         let li = 0;
         while (li < lines.length) {
@@ -225,13 +226,37 @@ Singleton {
             if (args.length < 2)
                 continue;
 
-            const keys = resolveExpr(args[0].trim());
+            const keyExpr = args[0].trim();
+            const keys = resolveExpr(keyExpr);
             if (keys === null)
                 continue;
 
+            // Track where this bind's keys come from so it can be rewritten.
+            // Only single-variable and single double-quoted literal binds are
+            // editable; concatenations (e.g. the workspace loop) are not.
+            let edit = null;
+            const vm = keyExpr.match(/^vars\.(\w+)$/);
+            const dq = keyExpr.match(/^"([^"]*)"$/);
+            if (vm) {
+                edit = {
+                    kind: "var",
+                    name: vm[1]
+                };
+            } else if (dq) {
+                const raw = dq[1];
+                const idx = literalCounts[raw] ?? 0;
+                literalCounts[raw] = idx + 1;
+                edit = {
+                    kind: "literal",
+                    raw,
+                    index: idx
+                };
+            }
+
             groupOf(curComment).binds.push({
                 keys: normalizeKeys(keys),
-                action: deriveAction(args[1].trim(), curComment)
+                action: deriveAction(args[1].trim(), curComment),
+                edit
             });
         }
 
@@ -255,7 +280,17 @@ Singleton {
             }
         }
 
-        return groups.filter(g => g.binds.length > 0);
+        const result = groups.filter(g => g.binds.length > 0);
+
+        // Stable per-bind id. Bind objects round-trip through this singleton's
+        // `var` property as fresh wrappers, so object identity can't be relied
+        // on downstream — consumers match on this string instead.
+        let idc = 0;
+        for (const g of result)
+            for (const b of g.binds)
+                b.id = "b" + idc++;
+
+        return result;
     }
 
     function normalizeKeys(keys) {
@@ -331,7 +366,56 @@ Singleton {
         return [...mods.map(m => modName[m]), ...restPretty].join(" + ");
     }
 
+    // Rewrite the value of a bind, given its `edit` descriptor (see _parse) and
+    // a new key combo string in Hyprland syntax (e.g. "SUPER + T"). Variable
+    // binds are rewritten in variables.lua, inline literals in keybinds.lua.
+    function setBind(edit: var, value: string): void {
+        if (!edit || !value)
+            return;
+        if (edit.kind === "var") {
+            const next = _replaceVar(_varsText, edit.name, value);
+            if (next === _varsText)
+                return;
+            _varsText = next;
+            varsFile.setText(next);
+        } else if (edit.kind === "literal") {
+            const next = _replaceLiteral(_kbText, edit.raw, edit.index, value);
+            if (next === _kbText)
+                return;
+            _kbText = next;
+            kbFile.setText(next);
+        } else {
+            return;
+        }
+        _rebuild();
+        reloadProc.running = true;
+    }
+
+    function _replaceVar(text, name, value) {
+        const re = new RegExp("(^\\s*" + name + "\\s*=\\s*)\"[^\"]*\"", "m");
+        return text.replace(re, `$1"${value}"`);
+    }
+
+    function _replaceLiteral(text, raw, index, value) {
+        const needle = `"${raw}"`;
+        let pos = -1;
+        for (let count = 0; count <= index; count++) {
+            pos = text.indexOf(needle, pos + 1);
+            if (pos === -1)
+                return text;
+        }
+        return text.slice(0, pos) + `"${value}"` + text.slice(pos + needle.length);
+    }
+
+    Process {
+        id: reloadProc
+
+        command: ["hyprctl", "reload"]
+    }
+
     FileView {
+        id: varsFile
+
         path: `${root.hyprDir}/variables.lua`
         watchChanges: true
         printErrors: false
@@ -343,6 +427,8 @@ Singleton {
     }
 
     FileView {
+        id: kbFile
+
         path: `${root.hyprDir}/hyprland/keybinds.lua`
         watchChanges: true
         printErrors: false

--- a/services/Keybinds.qml
+++ b/services/Keybinds.qml
@@ -1,0 +1,355 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+Singleton {
+    id: root
+
+    readonly property string hyprDir: Quickshell.env("CAELESTIA_HYPR_CONFIG_DIR") || `${Quickshell.env("XDG_CONFIG_HOME") || `${Quickshell.env("HOME")}/.config`}/hypr`
+
+    property var groups: []
+    property bool ready: false
+
+    property string _varsText: ""
+    property string _kbText: ""
+
+    function _rebuild(): void {
+        if (!_varsText || !_kbText)
+            return;
+        groups = _parse(_varsText, _kbText);
+        ready = true;
+    }
+
+    function _parse(varsText, kbText) {
+        const vars = {};
+        for (const line of varsText.split("\n")) {
+            const m = line.match(/^\s*([A-Za-z_]\w*)\s*=\s*"([^"]*)"/);
+            if (m)
+                vars[m[1]] = m[2];
+        }
+
+        const resolveVar = name => {
+            const v = vars[name.replace(/^vars\./, "")];
+            return v === undefined ? null : v;
+        };
+
+        function prettify(token) {
+            const t = token.replace(/^caelestia:/, "");
+            const spaced = t.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ");
+            return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+        }
+
+        function resolveExpr(expr) {
+            expr = expr.trim();
+            const parts = expr.split(/\s*\.\.\s*/);
+            const out = parts.map(p => {
+                p = p.trim();
+                const str = p.match(/^"([^"]*)"$/) || p.match(/^\[\[([\s\S]*?)\]\]$/);
+                if (str)
+                    return str[1];
+                const v = resolveVar(p);
+                if (v !== null)
+                    return v;
+                return null;
+            });
+            if (out.some(x => x === null))
+                return null;
+            return out.join("");
+        }
+
+        function tableField(tbl, key) {
+            const m = tbl.match(new RegExp(key + "\\s*=\\s*\"([^\"]*)\""));
+            return m ? m[1] : null;
+        }
+
+        function deriveAction(dispatch, comment) {
+            const d = dispatch.trim();
+            let m;
+
+            if ((m = d.match(/hl\.dsp\.global\(\s*"([^"]+)"/)))
+                return prettify(m[1]);
+
+            if ((m = d.match(/hl\.dsp\.exec_cmd\(([\s\S]*)\)\s*$/))) {
+                const cmd = resolveExpr(m[1]);
+                return cmd ? cmd.split("\n")[0] : (comment || "Run command");
+            }
+
+            if ((m = d.match(/hl\.dsp\.focus\(\{([\s\S]*)\}/))) {
+                const ws = tableField(m[1], "workspace");
+                if (ws !== null)
+                    return "Focus workspace " + ws;
+                const dir = tableField(m[1], "direction");
+                if (dir !== null)
+                    return "Focus window " + dir;
+                return "Focus";
+            }
+
+            if ((m = d.match(/hl\.dsp\.window\.move\(\{([\s\S]*)\}/))) {
+                const ws = tableField(m[1], "workspace");
+                if (ws !== null)
+                    return "Move window to workspace " + ws;
+                const dir = tableField(m[1], "direction");
+                if (dir !== null)
+                    return "Move window " + dir;
+                if (/out_of_group/.test(m[1]))
+                    return "Move window out of group";
+                return "Move window";
+            }
+
+            if ((m = d.match(/hl\.dsp\.window\.(\w+)/))) {
+                const map = {
+                    resize: "Resize window",
+                    close: "Close window",
+                    float: "Toggle floating",
+                    fullscreen: /maximized/.test(d) ? "Maximise window" : "Fullscreen window",
+                    pin: "Pin window",
+                    center: "Centre window",
+                    drag: "Drag window",
+                    cycle_next: /next\s*=\s*false/.test(d) ? "Cycle group previous" : "Cycle group next"
+                };
+                return map[m[1]] || prettify(m[1]);
+            }
+
+            if ((m = d.match(/hl\.dsp\.group\.(\w+)/))) {
+                const map = {
+                    next: "Next in group",
+                    prev: "Previous in group",
+                    toggle: "Toggle group",
+                    lock_active: "Lock group"
+                };
+                return map[m[1]] || prettify(m[1]);
+            }
+
+            return comment || "Custom action";
+        }
+
+        function splitArgs(s) {
+            const args = [];
+            let depth = 0, buf = "", inStr = null;
+            for (let i = 0; i < s.length; i++) {
+                const c = s[i];
+                if (inStr) {
+                    buf += c;
+                    if (c === inStr)
+                        inStr = null;
+                    continue;
+                }
+                if (c === '"' || c === "'") {
+                    inStr = c;
+                    buf += c;
+                    continue;
+                }
+                if (c === "(" || c === "{" || c === "[")
+                    depth++;
+                else if (c === ")" || c === "}" || c === "]")
+                    depth--;
+                if (c === "," && depth === 0) {
+                    args.push(buf);
+                    buf = "";
+                    continue;
+                }
+                buf += c;
+            }
+            if (buf.trim())
+                args.push(buf);
+            return args;
+        }
+
+        const groups = [];
+        const groupOf = name => {
+            let g = groups.find(g => g.category === name);
+            if (!g) {
+                g = {
+                    category: name,
+                    binds: []
+                };
+                groups.push(g);
+            }
+            return g;
+        };
+
+        let curComment = "General";
+        const lines = kbText.split("\n");
+        let li = 0;
+        while (li < lines.length) {
+            const raw = lines[li];
+            const trimmed = raw.trim();
+
+            const cm = trimmed.match(/^--\s*(.*)$/);
+            if (cm && cm[1] && !/maps to key/.test(cm[1])) {
+                curComment = cm[1].trim();
+                li++;
+                continue;
+            }
+
+            const bidx = raw.indexOf("hl.bind(");
+            if (bidx === -1) {
+                li++;
+                continue;
+            }
+
+            let acc = "";
+            let depth = 0;
+            let started = false;
+            let j = li;
+            const startCol = bidx + "hl.bind".length;
+            let done = false;
+            for (; j < lines.length && !done; j++) {
+                const l = lines[j];
+                const from = j === li ? startCol : 0;
+                for (let k = from; k < l.length; k++) {
+                    const c = l[k];
+                    if (c === "(") {
+                        depth++;
+                        started = true;
+                        if (depth === 1)
+                            continue;
+                    } else if (c === ")") {
+                        depth--;
+                        if (depth === 0) {
+                            done = true;
+                            break;
+                        }
+                    }
+                    if (started)
+                        acc += c;
+                }
+                if (started && !done)
+                    acc += "\n";
+            }
+            li = j;
+
+            const args = splitArgs(acc);
+            if (args.length < 2)
+                continue;
+
+            const keys = resolveExpr(args[0].trim());
+            if (keys === null)
+                continue;
+
+            groupOf(curComment).binds.push({
+                keys: normalizeKeys(keys),
+                action: deriveAction(args[1].trim(), curComment)
+            });
+        }
+
+        const loop = kbText.match(/for\s+i\s*=\s*1,\s*10\s+do([\s\S]*?)end/);
+        if (loop) {
+            const body = loop[1];
+            const bindRe = /hl\.bind\(\s*([A-Za-z_.]+)\s*\.\.\s*"\s*\+\s*"\s*\.\.\s*key\s*,\s*fn\.wsaction\(\s*"(\w+)"\s*,\s*"(\w*)"/g;
+            let lm;
+            const wsGroup = groupOf("Workspaces");
+            while ((lm = bindRe.exec(body))) {
+                const base = resolveVar(lm[1]);
+                if (base === null)
+                    continue;
+                const move = lm[2] === "move";
+                const grp = lm[3] === "group";
+                const action = (move ? "Move window to " : "Focus ") + (grp ? "workspace group " : "workspace ") + "1–10";
+                wsGroup.binds.unshift({
+                    keys: normalizeKeys(base) + " + 1…0",
+                    action
+                });
+            }
+        }
+
+        return groups.filter(g => g.binds.length > 0);
+    }
+
+    function normalizeKeys(keys) {
+        const order = ["SUPER", "CTRL", "ALT", "SHIFT"];
+        const modName = {
+            SUPER: "Super",
+            CTRL: "Ctrl",
+            ALT: "Alt",
+            SHIFT: "Shift"
+        };
+        const special = {
+            SUPER_L: "Super",
+            SUPER_R: "Super",
+            LEFT: "←",
+            RIGHT: "→",
+            UP: "↑",
+            DOWN: "↓",
+            "MOUSE_DOWN": "Scroll ↓",
+            "MOUSE_UP": "Scroll ↑",
+            "MOUSE:272": "LMB",
+            "MOUSE:273": "RMB",
+            PAGE_UP: "Page Up",
+            PAGE_DOWN: "Page Down",
+            BACKSLASH: "\\",
+            MINUS: "−",
+            EQUAL: "=",
+            COMMA: ",",
+            PERIOD: ".",
+            SPACE: "Space",
+            ESCAPE: "Esc",
+            DELETE: "Del",
+            TAB: "Tab",
+            PRINT: "Print",
+            XF86MONBRIGHTNESSUP: "Brightness +",
+            XF86MONBRIGHTNESSDOWN: "Brightness −",
+            XF86AUDIOPLAY: "Play",
+            XF86AUDIOPAUSE: "Pause",
+            XF86AUDIONEXT: "Next",
+            XF86AUDIOPREV: "Prev",
+            XF86AUDIOSTOP: "Stop",
+            XF86AUDIORAISEVOLUME: "Vol +",
+            XF86AUDIOLOWERVOLUME: "Vol −",
+            XF86AUDIOMUTE: "Mute",
+            XF86AUDIOMICMUTE: "Mic mute"
+        };
+
+        const tokens = keys.split("+").map(t => t.trim()).filter(Boolean);
+        const mods = [];
+        const rest = [];
+        for (const t of tokens) {
+            const up = t.toUpperCase();
+            if (order.includes(up)) {
+                if (!mods.includes(up))
+                    mods.push(up);
+            } else {
+                rest.push(t);
+            }
+        }
+        mods.sort((a, b) => order.indexOf(a) - order.indexOf(b));
+
+        const pretty = k => {
+            const up = k.toUpperCase();
+            if (special[up])
+                return special[up];
+            if (/^F\d{1,2}$/i.test(k))
+                return k.toUpperCase();
+            if (k.length === 1)
+                return k.toUpperCase();
+            return k.replace(/^XF86/, "").replace(/([a-z])([A-Z])/g, "$1 $2").replace(/_+/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+        };
+
+        const restPretty = rest.filter(k => !(mods.includes("SUPER") && /^SUPER_[LR]$/i.test(k))).map(pretty);
+        return [...mods.map(m => modName[m]), ...restPretty].join(" + ");
+    }
+
+    FileView {
+        path: `${root.hyprDir}/variables.lua`
+        watchChanges: true
+        printErrors: false
+        onFileChanged: reload()
+        onLoaded: {
+            root._varsText = text();
+            root._rebuild();
+        }
+    }
+
+    FileView {
+        path: `${root.hyprDir}/hyprland/keybinds.lua`
+        watchChanges: true
+        printErrors: false
+        onFileChanged: reload()
+        onLoaded: {
+            root._kbText = text();
+            root._rebuild();
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a **Keyboard shortcuts** page to Nexus (under the *Shell* category, after
*Language & region*). It lists the current Hyprland keybinds grouped by the
sections in the config, with a search box and per-chord keycap chips. The page
is built from the existing `PageBase` / `SectionHeader` / `ConnectedRect`
primitives and `Tokens` / `Colours`, so it follows the current theme and styling.

<img width="1999" height="1090" alt="2" src="https://github.com/user-attachments/assets/7601f71c-fea9-404e-bcab-e479621ab4fa" />



## How it works

A new `Keybinds` service (`services/Keybinds.qml`) reads two files from the hypr
config dir:

- `variables.lua` — resolves the `kb*` / app string variables
- `hyprland/keybinds.lua` — the actual `hl.bind(...)` calls

It resolves each bind's key chord (literal or `vars.*`), derives a readable
action label from the dispatcher (`hl.dsp.global`, `exec_cmd`, `window.*`,
`group.*`, `focus`, …), and groups rows by the section comments. The workspace
`for` loop is collapsed into four summary rows (e.g. `Super + 1…0 → Focus
workspace 1–10`). Modifier order and mouse/arrow/`XF86` keys are normalised for
display. It reloads reactively via `FileView.watchChanges`.

The base dir defaults to `$XDG_CONFIG_HOME/hypr` and can be overridden with
`$CAELESTIA_HYPR_CONFIG_DIR`.

I went with parsing the Lua config rather than `hyprctl binds -j` because the
Lua binds all dispatch through `__lua` with empty descriptions, so `hyprctl`
gives no usable action labels.

## Usage

Open settings (`caelestia shell nexus open`) → **Shell** → **Keyboard shortcuts**.
Type to filter by action or key.

## Side effects / breaking changes

None. Two new files, plus one entry each in `PageRegistry.qml` and
`PageCompRegistry.qml` (kept index-aligned). If the two Lua files aren't present
the page shows a loading/empty state and nothing else is affected.

## Testing

Tested live on Hyprland with the Lua config: the page loads, lists all binds
grouped correctly, search filters, and chips stay right-aligned. `qmllint` is
clean on all four files.

## Notes

The parser targets the default dots' Lua keybind config. It's resilient to
reordering/edits within that format, but a very different config layout may not
be fully parsed.
