### PR TITLE
Add WPA-Enterprise (802.1X) support, network disconnect/forget, and quick-popout redesign

### DIFF
--- a/modules/bar/popouts/Content.qml
+++ b/modules/bar/popouts/Content.qml
@@ -31,8 +31,6 @@ Item {
         }
 
         Popout {
-            id: networkPopout
-
             name: "network"
             sourceComponent: Network {
                 popouts: root.popouts
@@ -49,37 +47,18 @@ Item {
         }
 
         Popout {
-            id: passwordPopout
-
             name: "wirelesspassword"
             sourceComponent: WirelessPassword {
                 popouts: root.popouts
-                network: (networkPopout.item as Network)?.passwordNetwork ?? null
+                network: root.popouts.pendingNetwork
             }
         }
 
         Popout {
-            id: enterprisePopout
-
             name: "enterprisepassword"
             sourceComponent: EnterprisePassword {
                 popouts: root.popouts
-                network: (networkPopout.item as Network)?.enterpriseNetwork ?? null
-            }
-
-            Connections {
-                function onCurrentNameChanged() {
-                    if (root.popouts.currentName === "enterprisepassword") {
-                        if ((networkPopout.item as Network)?.enterpriseNetwork && enterprisePopout.item)
-                            (enterprisePopout.item as EnterprisePassword).network = (networkPopout.item as Network).enterpriseNetwork;
-                        Qt.callLater(() => {
-                            if (enterprisePopout.item && (networkPopout.item as Network)?.enterpriseNetwork)
-                                (enterprisePopout.item as EnterprisePassword).network = (networkPopout.item as Network).enterpriseNetwork;
-                        }, 100);
-                    }
-                }
-
-                target: root.popouts
+                network: root.popouts.pendingNetwork
             }
         }
 

--- a/modules/bar/popouts/Content.qml
+++ b/modules/bar/popouts/Content.qml
@@ -53,47 +53,8 @@ Item {
 
             name: "wirelesspassword"
             sourceComponent: WirelessPassword {
-                id: passwordComponent
-
                 popouts: root.popouts
                 network: (networkPopout.item as Network)?.passwordNetwork ?? null
-            }
-
-            Connections {
-                function onCurrentNameChanged() {
-                    // Update network immediately when password popout becomes active
-                    if (root.popouts.currentName === "wirelesspassword") {
-                        // Set network immediately if available
-                        if ((networkPopout.item as Network)?.passwordNetwork) {
-                            if (passwordPopout.item) {
-                                (passwordPopout.item as WirelessPassword).network = (networkPopout.item as Network).passwordNetwork;
-                            }
-                        }
-                        // Also try after a short delay in case networkPopout.item wasn't ready
-                        Qt.callLater(() => {
-                            if (passwordPopout.item && (networkPopout.item as Network)?.passwordNetwork) {
-                                (passwordPopout.item as WirelessPassword).network = (networkPopout.item as Network).passwordNetwork;
-                            }
-                        }, 100);
-                    }
-                }
-
-                target: root.popouts
-            }
-
-            Connections {
-                function onItemChanged() {
-                    // When network popout loads, update password popout if it's active
-                    if (root.popouts.currentName === "wirelesspassword" && passwordPopout.item) {
-                        Qt.callLater(() => {
-                            if ((networkPopout.item as Network)?.passwordNetwork) {
-                                (passwordPopout.item as WirelessPassword).network = (networkPopout.item as Network).passwordNetwork;
-                            }
-                        });
-                    }
-                }
-
-                target: networkPopout
             }
         }
 

--- a/modules/bar/popouts/Content.qml
+++ b/modules/bar/popouts/Content.qml
@@ -98,6 +98,31 @@ Item {
         }
 
         Popout {
+            id: enterprisePopout
+
+            name: "enterprisepassword"
+            sourceComponent: EnterprisePassword {
+                popouts: root.popouts
+                network: (networkPopout.item as Network)?.enterpriseNetwork ?? null
+            }
+
+            Connections {
+                function onCurrentNameChanged() {
+                    if (root.popouts.currentName === "enterprisepassword") {
+                        if ((networkPopout.item as Network)?.enterpriseNetwork && enterprisePopout.item)
+                            (enterprisePopout.item as EnterprisePassword).network = (networkPopout.item as Network).enterpriseNetwork;
+                        Qt.callLater(() => {
+                            if (enterprisePopout.item && (networkPopout.item as Network)?.enterpriseNetwork)
+                                (enterprisePopout.item as EnterprisePassword).network = (networkPopout.item as Network).enterpriseNetwork;
+                        }, 100);
+                    }
+                }
+
+                target: root.popouts
+            }
+        }
+
+        Popout {
             name: "bluetooth"
             sourceComponent: Bluetooth {
                 popouts: root.popouts

--- a/modules/bar/popouts/EnterprisePassword.qml
+++ b/modules/bar/popouts/EnterprisePassword.qml
@@ -67,8 +67,6 @@ ColumnLayout {
             } else {
                 hasError = true;
                 passwordField.buffer = "";
-                if (root.network && root.network.ssid && !Nmcli.hasSavedProfile(root.network.ssid))
-                    Nmcli.forgetNetwork(root.network.ssid);
             }
         });
     }

--- a/modules/bar/popouts/EnterprisePassword.qml
+++ b/modules/bar/popouts/EnterprisePassword.qml
@@ -1,0 +1,395 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.utils
+
+ColumnLayout {
+    id: root
+
+    required property PopoutState popouts
+    property var network: null
+    property bool isClosing: false
+
+    property bool connecting: false
+    property bool hasError: false
+
+    readonly property bool shouldBeVisible: root.popouts.currentName === "enterprisepassword"
+
+    function closeDialog(): void {
+        if (isClosing)
+            return;
+
+        isClosing = true;
+        connecting = false;
+        hasError = false;
+        identityField.buffer = "";
+        passwordField.buffer = "";
+
+        if (root.popouts.currentName === "enterprisepassword")
+            root.popouts.currentName = "network";
+    }
+
+    function attemptConnect(): void {
+        if (!root.network || connecting)
+            return;
+
+        if (identityField.buffer.trim().length === 0) {
+            identityField.errorState = true;
+            identityField.forceActiveFocus();
+            return;
+        }
+
+        hasError = false;
+        connecting = true;
+
+        const params = {
+            identity: identityField.buffer.trim(),
+            password: passwordField.buffer,
+            eapMethod: "peap",
+            phase2Method: "mschapv2",
+            anonymousIdentity: "",
+            domainSuffixMatch: "",
+            caCertPath: "",
+            verifyCert: false
+        };
+
+        NetworkConnection.connectWithEnterpriseCredentials(root.network, params, result => {
+            connecting = false;
+
+            if (result && result.success) {
+                root.closeDialog();
+            } else {
+                hasError = true;
+                passwordField.buffer = "";
+                if (root.network && root.network.ssid && !Nmcli.hasSavedProfile(root.network.ssid))
+                    Nmcli.forgetNetwork(root.network.ssid);
+            }
+        });
+    }
+
+    spacing: Tokens.spacing.medium
+    implicitWidth: 400
+    implicitHeight: card.implicitHeight
+    visible: shouldBeVisible || isClosing
+    enabled: shouldBeVisible && !isClosing
+    focus: enabled
+
+    Component.onCompleted: {
+        if (shouldBeVisible)
+            focusTimer.start();
+    }
+
+    onShouldBeVisibleChanged: {
+        if (shouldBeVisible)
+            focusTimer.start();
+        else {
+            identityField.errorState = false;
+            hasError = false;
+        }
+    }
+
+    Keys.onEscapePressed: closeDialog()
+
+    Timer {
+        id: focusTimer
+
+        interval: 150
+        onTriggered: {
+            root.forceActiveFocus();
+            identityField.forceActiveFocus();
+        }
+    }
+
+    StyledRect {
+        id: card
+
+        Layout.fillWidth: true
+        Layout.preferredWidth: 400
+        implicitHeight: content.implicitHeight + Tokens.padding.extraLargeIncreased
+        radius: Tokens.rounding.large
+        color: Colours.tPalette.m3surfaceContainer
+        visible: root.shouldBeVisible || root.isClosing
+        opacity: root.shouldBeVisible && !root.isClosing ? 1 : 0
+        scale: root.shouldBeVisible && !root.isClosing ? 1 : 0.7
+
+        Behavior on opacity {
+            Anim {
+                type: Anim.DefaultEffects
+            }
+        }
+
+        Behavior on scale {
+            Anim {}
+        }
+
+        ParallelAnimation {
+            running: root.isClosing
+            onFinished: {
+                if (root.isClosing)
+                    root.isClosing = false;
+            }
+
+            Anim {
+                type: Anim.DefaultEffects
+                target: card
+                property: "opacity"
+                to: 0
+            }
+            Anim {
+                target: card
+                property: "scale"
+                to: 0.7
+            }
+        }
+
+        ColumnLayout {
+            id: content
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: Tokens.padding.large
+
+            spacing: Tokens.spacing.medium
+
+            MaterialIcon {
+                Layout.alignment: Qt.AlignHCenter
+                text: "lock"
+                fontStyle: Tokens.font.icon.builders.extraLarge.scale(2).build()
+            }
+
+            StyledText {
+                Layout.alignment: Qt.AlignHCenter
+                text: qsTr("Enter credentials")
+                font: Tokens.font.body.builders.large.weight(Font.Medium).build()
+            }
+
+            StyledText {
+                Layout.alignment: Qt.AlignHCenter
+                text: root.network?.ssid ? qsTr("Network: %1").arg(root.network.ssid) : qsTr("Network: Unknown")
+                color: Colours.palette.m3outline
+                font: Tokens.font.body.small
+            }
+
+            StyledText {
+                Layout.alignment: Qt.AlignHCenter
+                Layout.topMargin: Tokens.spacing.small
+                visible: root.connecting || root.hasError
+                text: root.hasError ? qsTr("Connection failed. Please check your credentials and try again.") : qsTr("Connecting...")
+                color: root.hasError ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
+                font: Tokens.font.body.small
+                wrapMode: Text.WordWrap
+                Layout.maximumWidth: content.width
+            }
+
+            CredField {
+                id: identityField
+
+                Layout.topMargin: Tokens.spacing.largeIncreased
+                Layout.fillWidth: true
+                label: qsTr("Identity")
+                onAccepted: passwordField.forceActiveFocus()
+                onAdvance: passwordField.forceActiveFocus()
+            }
+
+            CredField {
+                id: passwordField
+
+                Layout.topMargin: Tokens.spacing.small
+                Layout.fillWidth: true
+                masked: true
+                label: qsTr("Password")
+                onAccepted: root.attemptConnect()
+                onAdvance: identityField.forceActiveFocus()
+            }
+
+            RowLayout {
+                Layout.topMargin: Tokens.spacing.medium
+                Layout.fillWidth: true
+                spacing: Tokens.spacing.medium
+
+                TextButton {
+                    Layout.fillWidth: true
+                    Layout.minimumHeight: Tokens.font.body.medium.pointSize + Tokens.padding.medium * 2
+                    inactiveColour: Colours.palette.m3secondaryContainer
+                    inactiveOnColour: Colours.palette.m3onSecondaryContainer
+                    text: qsTr("Cancel")
+                    onClicked: root.closeDialog()
+                }
+
+                TextButton {
+                    Layout.fillWidth: true
+                    Layout.minimumHeight: Tokens.font.body.medium.pointSize + Tokens.padding.medium * 2
+                    inactiveColour: Colours.palette.m3primary
+                    inactiveOnColour: Colours.palette.m3onPrimary
+                    enabled: !root.connecting
+                    text: qsTr("Connect")
+                    onClicked: root.attemptConnect()
+                }
+            }
+        }
+    }
+
+    component CredField: FocusScope {
+        id: cf
+
+        property bool masked: false
+        property string label: ""
+        property string buffer: ""
+        property bool errorState: false
+
+        signal accepted
+        signal advance
+
+        activeFocusOnTab: true
+        implicitHeight: Math.max(48, chRow.height + Tokens.padding.medium * 2)
+        clip: true
+
+        Keys.onPressed: event => {
+            if (!activeFocus)
+                forceActiveFocus();
+
+            if (event.key === Qt.Key_Escape) {
+                event.accepted = false;
+                return;
+            }
+
+            if (cf.errorState && event.text && event.text.length > 0)
+                cf.errorState = false;
+
+            if (event.key === Qt.Key_Enter || event.key === Qt.Key_Return) {
+                cf.accepted();
+                event.accepted = true;
+            } else if (event.key === Qt.Key_Tab) {
+                cf.advance();
+                event.accepted = true;
+            } else if (event.key === Qt.Key_Backspace) {
+                cf.buffer = event.modifiers & Qt.ControlModifier ? "" : cf.buffer.slice(0, -1);
+                event.accepted = true;
+            } else if (event.text && event.text.length > 0) {
+                cf.buffer += event.text;
+                event.accepted = true;
+            }
+        }
+
+        StyledRect {
+            anchors.fill: parent
+            radius: Tokens.rounding.large
+            color: cf.activeFocus ? Qt.lighter(Colours.tPalette.m3surfaceContainer, 1.05) : Colours.tPalette.m3surfaceContainer
+            border.width: cf.activeFocus || cf.errorState ? 4 : 1
+            border.color: cf.errorState ? Colours.palette.m3error : (cf.activeFocus ? Colours.palette.m3primary : Colours.palette.m3outline)
+
+            Behavior on border.color {
+                CAnim {}
+            }
+
+            Behavior on border.width {
+                CAnim {}
+            }
+
+            Behavior on color {
+                CAnim {}
+            }
+        }
+
+        StateLayer {
+            hoverEnabled: false
+            cursorShape: Qt.IBeamCursor
+            radius: Tokens.rounding.large
+            onClicked: cf.forceActiveFocus()
+        }
+
+        StyledText {
+            anchors.centerIn: parent
+            text: cf.label
+            color: Colours.palette.m3outline
+            font: Tokens.font.mono.medium
+            opacity: cf.buffer ? 0 : 1
+
+            Behavior on opacity {
+                Anim {
+                    type: Anim.DefaultEffects
+                }
+            }
+        }
+
+        Row {
+            id: chRow
+
+            readonly property real pad: Tokens.padding.large
+
+            height: Tokens.font.body.medium.pointSize
+            y: (cf.height - height) / 2
+            x: {
+                const avail = cf.width - pad * 2;
+                if (implicitWidth <= avail)
+                    return (cf.width - implicitWidth) / 2;
+                return cf.width - pad - implicitWidth;
+            }
+            spacing: Tokens.spacing.extraSmall
+
+            Behavior on x {
+                Anim {}
+            }
+
+            Repeater {
+                model: ScriptModel {
+                    values: cf.buffer.split("")
+                }
+
+                Item {
+                    id: chip
+
+                    required property var modelData
+
+                    implicitWidth: cf.masked ? chRow.height : ltr.implicitWidth
+                    implicitHeight: chRow.height
+
+                    opacity: 0
+                    scale: 0
+                    Component.onCompleted: {
+                        opacity = 1;
+                        scale = 1;
+                    }
+
+                    Behavior on opacity {
+                        Anim {
+                            type: Anim.DefaultEffects
+                        }
+                    }
+
+                    Behavior on scale {
+                        Anim {
+                            type: Anim.FastSpatial
+                        }
+                    }
+
+                    StyledRect {
+                        visible: cf.masked
+                        anchors.centerIn: parent
+                        implicitWidth: chRow.height
+                        implicitHeight: chRow.height
+                        color: Colours.palette.m3onSurface
+                        radius: Tokens.rounding.medium / 2
+                    }
+
+                    StyledText {
+                        id: ltr
+
+                        visible: !cf.masked
+                        anchors.centerIn: parent
+                        text: chip.modelData
+                        color: Colours.palette.m3onSurface
+                        font: Tokens.font.mono.medium
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/bar/popouts/Network.qml
+++ b/modules/bar/popouts/Network.qml
@@ -18,7 +18,7 @@ ColumnLayout {
     property string view: "wireless" // "wireless" or "ethernet"
     property var passwordNetwork: null
     property bool showPasswordDialog: false
-    property string enterpriseNoticeSsid: ""
+    property var enterpriseNetwork: null
 
     spacing: Tokens.spacing.small
     width: Tokens.sizes.bar.networkWidth
@@ -170,8 +170,8 @@ ColumnLayout {
                                     if (networkItem.modelData.active) {
                                         Nmcli.disconnectFromNetwork();
                                     } else if (networkItem.modelData.isEnterprise && !Nmcli.hasSavedProfile(networkItem.modelData.ssid)) {
-                                        root.enterpriseNoticeSsid = networkItem.modelData.ssid;
-                                        enterpriseNoticeTimer.restart();
+                                        root.enterpriseNetwork = networkItem.modelData;
+                                        root.popouts.currentName = "enterprisepassword";
                                     } else {
                                         root.connectingToSsid = networkItem.modelData.ssid;
                                         NetworkConnection.handleConnect(networkItem.modelData, null, network => {
@@ -257,47 +257,6 @@ ColumnLayout {
         }
     }
 
-    StyledRect {
-        id: enterpriseNotice
-
-        visible: root.view === "wireless" && root.enterpriseNoticeSsid.length > 0
-        Layout.preferredHeight: visible ? implicitHeight : 0
-        Layout.topMargin: visible ? Tokens.spacing.small : 0
-        Layout.fillWidth: true
-        implicitHeight: enterpriseNoticeLayout.implicitHeight + Tokens.padding.medium
-
-        radius: Tokens.rounding.large
-        color: Colours.palette.m3secondaryContainer
-
-        Timer {
-            id: enterpriseNoticeTimer
-
-            interval: 4000
-            onTriggered: root.enterpriseNoticeSsid = ""
-        }
-
-        RowLayout {
-            id: enterpriseNoticeLayout
-
-            anchors.centerIn: parent
-            width: parent.width - Tokens.padding.large * 2
-            spacing: Tokens.spacing.small
-
-            MaterialIcon {
-                text: "school"
-                color: Colours.palette.m3onSecondaryContainer
-                fontStyle: Tokens.font.icon.medium
-            }
-
-            StyledText {
-                Layout.fillWidth: true
-                text: qsTr("“%1” needs institutional credentials — configure it in Settings → Network.").arg(root.enterpriseNoticeSsid)
-                color: Colours.palette.m3onSecondaryContainer
-                font: Tokens.font.body.small
-                wrapMode: Text.WordWrap
-            }
-        }
-    }
 
     // Ethernet section
     StyledText {

--- a/modules/bar/popouts/Network.qml
+++ b/modules/bar/popouts/Network.qml
@@ -257,7 +257,6 @@ ColumnLayout {
         }
     }
 
-
     // Ethernet section
     StyledText {
         visible: root.view === "ethernet"

--- a/modules/bar/popouts/Network.qml
+++ b/modules/bar/popouts/Network.qml
@@ -60,7 +60,7 @@ ColumnLayout {
             }
         }
 
-        RowLayout {
+        StyledRect {
             id: networkItem
 
             required property Nmcli.AccessPoint modelData
@@ -71,7 +71,9 @@ ColumnLayout {
             Layout.preferredHeight: visible ? implicitHeight : 0
             Layout.fillWidth: true
             Layout.rightMargin: Tokens.padding.extraSmall
-            spacing: Tokens.spacing.small
+            implicitHeight: rowLayout.implicitHeight + Tokens.padding.extraSmall
+            radius: Tokens.rounding.medium
+            color: modelData.active ? Qt.alpha(Colours.palette.m3primary, 0.12) : "transparent"
 
             opacity: 0
             scale: 0.7
@@ -91,121 +93,162 @@ ColumnLayout {
                 Anim {}
             }
 
-            MaterialIcon {
-                text: Icons.getNetworkIcon(networkItem.modelData.strength)
-                color: networkItem.modelData.active ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+            Behavior on color {
+                CAnim {}
             }
 
-            MaterialIcon {
-                readonly property bool saved: Nmcli.hasSavedProfile(networkItem.modelData.ssid)
+            RowLayout {
+                id: rowLayout
 
-                visible: networkItem.modelData.isSecure
-                text: saved ? "wifi_lock" : "lock"
-                fill: saved ? 1 : 0
-                color: saved ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
-                fontStyle: Tokens.font.icon.small
-            }
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.leftMargin: Tokens.spacing.small
+                anchors.rightMargin: Tokens.spacing.small
+                spacing: Tokens.spacing.small
 
-            StyledText {
-                Layout.leftMargin: Tokens.spacing.extraSmall
-                Layout.rightMargin: Tokens.spacing.extraSmall
-                Layout.fillWidth: true
-                text: networkItem.modelData.ssid
-                elide: Text.ElideRight
-                font: Tokens.font.body.builders.medium.weight(networkItem.modelData.active ? Font.Medium : Font.Normal).build()
-                color: networkItem.modelData.active ? Colours.palette.m3primary : Colours.palette.m3onSurface
-            }
-
-            StyledRect {
-                implicitWidth: implicitHeight
-                implicitHeight: wirelessConnectIcon.implicitHeight + Tokens.padding.extraSmall
-
-                radius: Tokens.rounding.full
-                color: Qt.alpha(Colours.palette.m3primary, networkItem.modelData.active ? 1 : 0)
-
-                CircularIndicator {
-                    anchors.fill: parent
-                    running: networkItem.loading
-                }
-
-                StateLayer {
-                    color: networkItem.modelData.active ? Colours.palette.m3onPrimary : Colours.palette.m3onSurface
-                    disabled: networkItem.loading || !Nmcli.wifiEnabled
-
-                    onClicked: {
-                        if (networkItem.modelData.active) {
-                            Nmcli.disconnectFromNetwork();
-                        } else if (networkItem.modelData.isEnterprise && !Nmcli.hasSavedProfile(networkItem.modelData.ssid)) {
-                            root.enterpriseNoticeSsid = networkItem.modelData.ssid;
-                            enterpriseNoticeTimer.restart();
-                        } else {
-                            root.connectingToSsid = networkItem.modelData.ssid;
-                            NetworkConnection.handleConnect(networkItem.modelData, null, network => {
-                                // Password is required - show password dialog
-                                root.passwordNetwork = network;
-                                root.showPasswordDialog = true;
-                                root.popouts.currentName = "wirelesspassword";
-                            });
-
-                            // Clear connecting state if connection succeeds immediately (saved profile)
-                            // This is handled by the onActiveChanged connection below
-                        }
-                    }
+                MaterialIcon {
+                    text: Icons.getNetworkIcon(networkItem.modelData.strength)
+                    color: networkItem.modelData.active ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
                 }
 
                 MaterialIcon {
-                    id: wirelessConnectIcon
+                    readonly property bool saved: Nmcli.hasSavedProfile(networkItem.modelData.ssid)
+
+                    visible: networkItem.modelData.isSecure
+                    text: saved ? "wifi_lock" : "lock"
+                    fill: saved ? 1 : 0
+                    color: saved ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                    fontStyle: Tokens.font.icon.small
+                }
+
+                StyledText {
+                    Layout.leftMargin: Tokens.spacing.extraSmall
+                    Layout.rightMargin: Tokens.spacing.extraSmall
+                    Layout.fillWidth: true
+                    text: networkItem.modelData.ssid
+                    elide: Text.ElideRight
+                    font: Tokens.font.body.builders.medium.weight(networkItem.modelData.active ? Font.Medium : Font.Normal).build()
+                    color: networkItem.modelData.active ? Colours.palette.m3primary : Colours.palette.m3onSurface
+                }
+
+                StyledRect {
+                    id: actionPill
 
                     readonly property bool saved: Nmcli.hasSavedProfile(networkItem.modelData.ssid)
 
-                    anchors.centerIn: parent
-                    animate: true
-                    text: networkItem.modelData.active ? "link_off" : "link"
-                    fill: !networkItem.modelData.active && saved ? 1 : 0
-                    color: networkItem.modelData.active ? Colours.palette.m3onPrimary : (saved ? Colours.palette.m3primary : Colours.palette.m3onSurface)
-
-                    opacity: networkItem.loading ? 0 : 1
-
-                    Behavior on opacity {
-                        Anim {
-                            type: Anim.DefaultEffects
-                        }
-                    }
-                }
-            }
-
-            Loader {
-                active: Nmcli.hasSavedProfile(networkItem.modelData.ssid)
-                asynchronous: true
-                sourceComponent: StyledRect {
-                    implicitWidth: implicitHeight
-                    implicitHeight: wirelessConnectIcon.parent.implicitHeight
-
+                    implicitWidth: pillRow.implicitWidth
+                    implicitHeight: pillRow.implicitHeight
                     radius: Tokens.rounding.full
-                    color: "transparent"
+                    color: networkItem.modelData.active ? Colours.palette.m3primary : actionPill.saved ? Colours.palette.m3surfaceContainerHigh : "transparent"
 
-                    StateLayer {
-                        id: forgetState
-
-                        radius: Tokens.rounding.full
-                        disabled: networkItem.loading
-                        onClicked: Nmcli.forgetNetwork(networkItem.modelData.ssid)
+                    Behavior on color {
+                        CAnim {}
                     }
 
-                    MaterialIcon {
-                        anchors.centerIn: parent
-                        text: "delete"
-                        fontStyle: Tokens.font.icon.small
-                        color: forgetState.containsMouse ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
-                        opacity: forgetState.containsMouse ? 1 : 0.6
+                    Row {
+                        id: pillRow
 
-                        Behavior on color {
-                            CAnim {}
+                        Item {
+                            id: connectSegment
+
+                            width: wirelessConnectIcon.implicitHeight + Tokens.padding.extraSmall
+                            height: width
+
+                            CircularIndicator {
+                                anchors.fill: parent
+                                running: networkItem.loading
+                            }
+
+                            StateLayer {
+                                anchors.fill: parent
+                                radius: Tokens.rounding.full
+                                color: networkItem.modelData.active ? Colours.palette.m3onPrimary : Colours.palette.m3onSurface
+                                disabled: networkItem.loading || !Nmcli.wifiEnabled
+
+                                onClicked: {
+                                    if (networkItem.modelData.active) {
+                                        Nmcli.disconnectFromNetwork();
+                                    } else if (networkItem.modelData.isEnterprise && !Nmcli.hasSavedProfile(networkItem.modelData.ssid)) {
+                                        root.enterpriseNoticeSsid = networkItem.modelData.ssid;
+                                        enterpriseNoticeTimer.restart();
+                                    } else {
+                                        root.connectingToSsid = networkItem.modelData.ssid;
+                                        NetworkConnection.handleConnect(networkItem.modelData, null, network => {
+                                            // Password is required - show password dialog
+                                            root.passwordNetwork = network;
+                                            root.showPasswordDialog = true;
+                                            root.popouts.currentName = "wirelesspassword";
+                                        });
+
+                                        // Clear connecting state if connection succeeds immediately (saved profile)
+                                        // This is handled by the onActiveChanged connection below
+                                    }
+                                }
+                            }
+
+                            MaterialIcon {
+                                id: wirelessConnectIcon
+
+                                anchors.centerIn: parent
+                                animate: true
+                                text: networkItem.modelData.active ? "link_off" : "link"
+                                fill: !networkItem.modelData.active && actionPill.saved ? 1 : 0
+                                color: networkItem.modelData.active ? Colours.palette.m3onPrimary : (actionPill.saved ? Colours.palette.m3primary : Colours.palette.m3onSurface)
+
+                                opacity: networkItem.loading ? 0 : 1
+
+                                Behavior on opacity {
+                                    Anim {
+                                        type: Anim.DefaultEffects
+                                    }
+                                }
+                            }
                         }
 
-                        Behavior on opacity {
-                            Anim {
-                                type: Anim.DefaultEffects
+                        Item {
+                            visible: actionPill.saved
+                            width: visible ? 1 : 0
+                            height: connectSegment.height
+
+                            Rectangle {
+                                anchors.centerIn: parent
+                                width: 1
+                                height: parent.height * 0.5
+                                color: Qt.alpha(networkItem.modelData.active ? Colours.palette.m3onPrimary : Colours.palette.m3onSurfaceVariant, 0.3)
+                            }
+                        }
+
+                        Item {
+                            visible: actionPill.saved
+                            width: visible ? connectSegment.width : 0
+                            height: connectSegment.height
+
+                            StateLayer {
+                                id: forgetState
+
+                                anchors.fill: parent
+                                radius: Tokens.rounding.full
+                                disabled: networkItem.loading
+                                onClicked: Nmcli.forgetNetwork(networkItem.modelData.ssid)
+                            }
+
+                            MaterialIcon {
+                                anchors.centerIn: parent
+                                text: "delete"
+                                fontStyle: Tokens.font.icon.small
+                                color: forgetState.containsMouse ? Colours.palette.m3error : (networkItem.modelData.active ? Colours.palette.m3onPrimary : Colours.palette.m3onSurfaceVariant)
+                                opacity: forgetState.containsMouse ? 1 : 0.7
+
+                                Behavior on color {
+                                    CAnim {}
+                                }
+
+                                Behavior on opacity {
+                                    Anim {
+                                        type: Anim.DefaultEffects
+                                    }
+                                }
                             }
                         }
                     }
@@ -253,60 +296,6 @@ ColumnLayout {
                 font: Tokens.font.body.small
                 wrapMode: Text.WordWrap
             }
-        }
-    }
-
-    StyledRect {
-        visible: root.view === "wireless"
-        Layout.preferredHeight: visible ? implicitHeight : 0
-        Layout.topMargin: visible ? Tokens.spacing.small : 0
-        Layout.fillWidth: true
-        implicitHeight: rescanBtn.implicitHeight + Tokens.padding.small
-
-        radius: Tokens.rounding.full
-        color: Colours.palette.m3primaryContainer
-
-        StateLayer {
-            color: Colours.palette.m3onPrimaryContainer
-            disabled: Nmcli.scanning || !Nmcli.wifiEnabled
-            onClicked: Nmcli.rescanWifi()
-        }
-
-        RowLayout {
-            id: rescanBtn
-
-            anchors.centerIn: parent
-            spacing: Tokens.spacing.small
-            opacity: Nmcli.scanning ? 0 : 1
-
-            MaterialIcon {
-                id: scanIcon
-
-                Layout.topMargin: Math.round(fontInfo.pointSize * 0.0575)
-                animate: true
-                text: "wifi_find"
-                color: Colours.palette.m3onPrimaryContainer
-            }
-
-            StyledText {
-                Layout.topMargin: -Math.round(scanIcon.fontInfo.pointSize * 0.0575)
-                text: qsTr("Rescan networks")
-                color: Colours.palette.m3onPrimaryContainer
-            }
-
-            Behavior on opacity {
-                Anim {
-                    type: Anim.DefaultEffects
-                }
-            }
-        }
-
-        CircularIndicator {
-            anchors.centerIn: parent
-            strokeWidth: Tokens.padding.extraSmall / 2
-            bgColour: "transparent"
-            implicitSize: parent.implicitHeight - Tokens.padding.large
-            running: Nmcli.scanning
         }
     }
 
@@ -430,16 +419,105 @@ ColumnLayout {
         }
     }
 
-    IconTextButton {
+    StyledRect {
         Layout.fillWidth: true
         Layout.topMargin: Tokens.spacing.medium
-        inactiveColour: Colours.palette.m3primaryContainer
-        inactiveOnColour: Colours.palette.m3onPrimaryContainer
-        verticalPadding: Tokens.padding.extraSmall
-        text: qsTr("Open settings")
-        icon: "settings"
+        implicitHeight: footerRow.implicitHeight + Tokens.padding.small
 
-        onClicked: root.popouts.detachRequested("network")
+        radius: Tokens.rounding.full
+        color: Colours.palette.m3primaryContainer
+
+        RowLayout {
+            id: footerRow
+
+            anchors.fill: parent
+            spacing: 0
+
+            Item {
+                visible: root.view === "wireless"
+                Layout.fillWidth: true
+                Layout.preferredHeight: rescanRow.implicitHeight + Tokens.padding.small
+
+                StateLayer {
+                    anchors.fill: parent
+                    color: Colours.palette.m3onPrimaryContainer
+                    disabled: Nmcli.scanning || !Nmcli.wifiEnabled
+                    onClicked: Nmcli.rescanWifi()
+                }
+
+                RowLayout {
+                    id: rescanRow
+
+                    anchors.centerIn: parent
+                    spacing: Tokens.spacing.small
+                    opacity: Nmcli.scanning ? 0 : 1
+
+                    MaterialIcon {
+                        id: scanIcon
+
+                        animate: true
+                        text: "wifi_find"
+                        color: Colours.palette.m3onPrimaryContainer
+                    }
+
+                    StyledText {
+                        text: qsTr("Rescan")
+                        color: Colours.palette.m3onPrimaryContainer
+                    }
+
+                    Behavior on opacity {
+                        Anim {
+                            type: Anim.DefaultEffects
+                        }
+                    }
+                }
+
+                CircularIndicator {
+                    anchors.centerIn: parent
+                    strokeWidth: Tokens.padding.extraSmall / 2
+                    bgColour: "transparent"
+                    implicitSize: rescanRow.implicitHeight
+                    running: Nmcli.scanning
+                }
+            }
+
+            Rectangle {
+                visible: root.view === "wireless"
+                Layout.preferredWidth: 1
+                Layout.fillHeight: true
+                Layout.topMargin: Tokens.padding.small
+                Layout.bottomMargin: Tokens.padding.small
+                color: Qt.alpha(Colours.palette.m3onPrimaryContainer, 0.3)
+            }
+
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: settingsRow.implicitHeight + Tokens.padding.small
+
+                StateLayer {
+                    anchors.fill: parent
+                    color: Colours.palette.m3onPrimaryContainer
+                    onClicked: root.popouts.detachRequested("network")
+                }
+
+                RowLayout {
+                    id: settingsRow
+
+                    anchors.centerIn: parent
+                    spacing: Tokens.spacing.small
+
+                    MaterialIcon {
+                        text: "settings"
+                        color: Colours.palette.m3onPrimaryContainer
+                    }
+
+                    StyledText {
+                        text: qsTr("Settings")
+                        color: Colours.palette.m3onPrimaryContainer
+                    }
+                }
+            }
+        }
     }
 
     Connections {

--- a/modules/bar/popouts/Network.qml
+++ b/modules/bar/popouts/Network.qml
@@ -16,9 +16,6 @@ ColumnLayout {
 
     property string connectingToSsid: ""
     property string view: "wireless" // "wireless" or "ethernet"
-    property var passwordNetwork: null
-    property bool showPasswordDialog: false
-    property var enterpriseNetwork: null
 
     spacing: Tokens.spacing.small
     width: Tokens.sizes.bar.networkWidth
@@ -170,19 +167,14 @@ ColumnLayout {
                                     if (networkItem.modelData.active) {
                                         Nmcli.disconnectFromNetwork();
                                     } else if (networkItem.modelData.isEnterprise && !Nmcli.hasSavedProfile(networkItem.modelData.ssid)) {
-                                        root.enterpriseNetwork = networkItem.modelData;
+                                        root.popouts.pendingNetwork = networkItem.modelData;
                                         root.popouts.currentName = "enterprisepassword";
                                     } else {
                                         root.connectingToSsid = networkItem.modelData.ssid;
                                         NetworkConnection.handleConnect(networkItem.modelData, null, network => {
-                                            // Password is required - show password dialog
-                                            root.passwordNetwork = network;
-                                            root.showPasswordDialog = true;
+                                            root.popouts.pendingNetwork = network;
                                             root.popouts.currentName = "wirelesspassword";
                                         });
-
-                                        // Clear connecting state if connection succeeds immediately (saved profile)
-                                        // This is handled by the onActiveChanged connection below
                                     }
                                 }
                             }
@@ -482,14 +474,6 @@ ColumnLayout {
         function onActiveChanged(): void {
             if (Nmcli.active && root.connectingToSsid === Nmcli.active.ssid) {
                 root.connectingToSsid = "";
-                // Close password dialog if we successfully connected
-                if (root.showPasswordDialog && root.passwordNetwork && Nmcli.active.ssid === root.passwordNetwork.ssid) {
-                    root.showPasswordDialog = false;
-                    root.passwordNetwork = null;
-                    if (root.popouts.currentName === "wirelesspassword") {
-                        root.popouts.currentName = "network";
-                    }
-                }
             }
         }
 
@@ -499,18 +483,6 @@ ColumnLayout {
         }
 
         target: Nmcli
-    }
-
-    Connections {
-        function onCurrentNameChanged(): void {
-            // Clear password network when leaving password dialog
-            if (root.popouts.currentName !== "wirelesspassword" && root.showPasswordDialog) {
-                root.showPasswordDialog = false;
-                root.passwordNetwork = null;
-            }
-        }
-
-        target: root.popouts
     }
 
     component Toggle: RowLayout {

--- a/modules/bar/popouts/Network.qml
+++ b/modules/bar/popouts/Network.qml
@@ -18,6 +18,7 @@ ColumnLayout {
     property string view: "wireless" // "wireless" or "ethernet"
     property var passwordNetwork: null
     property bool showPasswordDialog: false
+    property string enterpriseNoticeSsid: ""
 
     spacing: Tokens.spacing.small
     width: Tokens.sizes.bar.networkWidth
@@ -53,11 +54,10 @@ ColumnLayout {
     Repeater {
         visible: root.view === "wireless"
         model: ScriptModel {
-            values: [...Nmcli.networks].sort((a, b) => {
-                if (a.active !== b.active)
-                    return b.active - a.active;
-                return b.strength - a.strength;
-            }).slice(0, 8)
+            values: {
+                const rank = n => n.active ? 0 : Nmcli.hasSavedProfile(n.ssid) ? 1 : 2;
+                return [...Nmcli.networks].sort((a, b) => rank(a) - rank(b) || b.strength - a.strength).slice(0, 8);
+            }
         }
 
         RowLayout {
@@ -97,8 +97,12 @@ ColumnLayout {
             }
 
             MaterialIcon {
+                readonly property bool saved: Nmcli.hasSavedProfile(networkItem.modelData.ssid)
+
                 visible: networkItem.modelData.isSecure
-                text: "lock"
+                text: saved ? "wifi_lock" : "lock"
+                fill: saved ? 1 : 0
+                color: saved ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
                 fontStyle: Tokens.font.icon.small
             }
 
@@ -131,6 +135,9 @@ ColumnLayout {
                     onClicked: {
                         if (networkItem.modelData.active) {
                             Nmcli.disconnectFromNetwork();
+                        } else if (networkItem.modelData.isEnterprise && !Nmcli.hasSavedProfile(networkItem.modelData.ssid)) {
+                            root.enterpriseNoticeSsid = networkItem.modelData.ssid;
+                            enterpriseNoticeTimer.restart();
                         } else {
                             root.connectingToSsid = networkItem.modelData.ssid;
                             NetworkConnection.handleConnect(networkItem.modelData, null, network => {
@@ -149,10 +156,13 @@ ColumnLayout {
                 MaterialIcon {
                     id: wirelessConnectIcon
 
+                    readonly property bool saved: Nmcli.hasSavedProfile(networkItem.modelData.ssid)
+
                     anchors.centerIn: parent
                     animate: true
                     text: networkItem.modelData.active ? "link_off" : "link"
-                    color: networkItem.modelData.active ? Colours.palette.m3onPrimary : Colours.palette.m3onSurface
+                    fill: !networkItem.modelData.active && saved ? 1 : 0
+                    color: networkItem.modelData.active ? Colours.palette.m3onPrimary : (saved ? Colours.palette.m3primary : Colours.palette.m3onSurface)
 
                     opacity: networkItem.loading ? 0 : 1
 
@@ -162,6 +172,86 @@ ColumnLayout {
                         }
                     }
                 }
+            }
+
+            Loader {
+                active: Nmcli.hasSavedProfile(networkItem.modelData.ssid)
+                asynchronous: true
+                sourceComponent: StyledRect {
+                    implicitWidth: implicitHeight
+                    implicitHeight: wirelessConnectIcon.parent.implicitHeight
+
+                    radius: Tokens.rounding.full
+                    color: "transparent"
+
+                    StateLayer {
+                        id: forgetState
+
+                        radius: Tokens.rounding.full
+                        disabled: networkItem.loading
+                        onClicked: Nmcli.forgetNetwork(networkItem.modelData.ssid)
+                    }
+
+                    MaterialIcon {
+                        anchors.centerIn: parent
+                        text: "delete"
+                        fontStyle: Tokens.font.icon.small
+                        color: forgetState.containsMouse ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
+                        opacity: forgetState.containsMouse ? 1 : 0.6
+
+                        Behavior on color {
+                            CAnim {}
+                        }
+
+                        Behavior on opacity {
+                            Anim {
+                                type: Anim.DefaultEffects
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    StyledRect {
+        id: enterpriseNotice
+
+        visible: root.view === "wireless" && root.enterpriseNoticeSsid.length > 0
+        Layout.preferredHeight: visible ? implicitHeight : 0
+        Layout.topMargin: visible ? Tokens.spacing.small : 0
+        Layout.fillWidth: true
+        implicitHeight: enterpriseNoticeLayout.implicitHeight + Tokens.padding.medium
+
+        radius: Tokens.rounding.large
+        color: Colours.palette.m3secondaryContainer
+
+        Timer {
+            id: enterpriseNoticeTimer
+
+            interval: 4000
+            onTriggered: root.enterpriseNoticeSsid = ""
+        }
+
+        RowLayout {
+            id: enterpriseNoticeLayout
+
+            anchors.centerIn: parent
+            width: parent.width - Tokens.padding.large * 2
+            spacing: Tokens.spacing.small
+
+            MaterialIcon {
+                text: "school"
+                color: Colours.palette.m3onSecondaryContainer
+                fontStyle: Tokens.font.icon.medium
+            }
+
+            StyledText {
+                Layout.fillWidth: true
+                text: qsTr("“%1” needs institutional credentials — configure it in Settings → Network.").arg(root.enterpriseNoticeSsid)
+                color: Colours.palette.m3onSecondaryContainer
+                font: Tokens.font.body.small
+                wrapMode: Text.WordWrap
             }
         }
     }
@@ -338,6 +428,18 @@ ColumnLayout {
                 }
             }
         }
+    }
+
+    IconTextButton {
+        Layout.fillWidth: true
+        Layout.topMargin: Tokens.spacing.medium
+        inactiveColour: Colours.palette.m3primaryContainer
+        inactiveOnColour: Colours.palette.m3onPrimaryContainer
+        verticalPadding: Tokens.padding.extraSmall
+        text: qsTr("Open settings")
+        icon: "settings"
+
+        onClicked: root.popouts.detachRequested("network")
     }
 
     Connections {

--- a/modules/bar/popouts/PopoutState.qml
+++ b/modules/bar/popouts/PopoutState.qml
@@ -3,6 +3,10 @@ import QtQuick
 QtObject {
     property string currentName
     property bool hasCurrent
+    // The access point a credentials popout was opened for. It has to live here
+    // rather than on the network popout, whose Loader unloads as soon as the
+    // dialog becomes the current popout.
+    property var pendingNetwork: null
 
     signal detachRequested(mode: string)
 }

--- a/modules/bar/popouts/WirelessPassword.qml
+++ b/modules/bar/popouts/WirelessPassword.qml
@@ -69,6 +69,8 @@ ColumnLayout {
     }
 
     StyledRect {
+        id: card
+
         Layout.fillWidth: true
         Layout.preferredWidth: 400
         implicitHeight: content.implicitHeight + Tokens.padding.extraLargeIncreased
@@ -99,12 +101,12 @@ ColumnLayout {
 
             Anim {
                 type: Anim.DefaultEffects
-                target: parent
+                target: card
                 property: "opacity"
                 to: 0
             }
             Anim {
-                target: parent
+                target: card
                 property: "scale"
                 to: 0.7
             }
@@ -197,7 +199,7 @@ ColumnLayout {
 
                     if (event.key === Qt.Key_Escape) {
                         event.accepted = false;
-                        closeDialog();
+                        root.closeDialog();
                     }
 
                     // Clear error when user starts typing

--- a/modules/bar/popouts/WirelessPassword.qml
+++ b/modules/bar/popouts/WirelessPassword.qml
@@ -18,39 +18,6 @@ ColumnLayout {
 
     readonly property bool shouldBeVisible: root.popouts.currentName === "wirelesspassword"
 
-    function checkConnectionStatus(): void {
-        if (!root.shouldBeVisible || !connectButton.connecting) {
-            return;
-        }
-
-        // Check if we're connected to the target network (case-insensitive SSID comparison)
-        const isConnected = root.network && Nmcli.active && Nmcli.active.ssid && Nmcli.active.ssid.toLowerCase().trim() === root.network.ssid.toLowerCase().trim();
-
-        if (isConnected) {
-            // Successfully connected - give it a moment for network list to update
-            // Use Timer for actual delay
-            connectionSuccessTimer.start();
-            return;
-        }
-
-        // Check for connection failures - if pending connection was cleared but we're not connected
-        if (Nmcli.pendingConnection === null && connectButton.connecting) {
-            // Wait a bit more before giving up (allow time for connection to establish)
-            if (connectionMonitor.repeatCount > 10) {
-                connectionMonitor.stop();
-                connectButton.connecting = false;
-                connectButton.hasError = true;
-                connectButton.enabled = true;
-                connectButton.text = qsTr("Connect");
-                passwordContainer.passwordBuffer = "";
-                // Delete the failed connection
-                if (root.network && root.network.ssid) {
-                    Nmcli.forgetNetwork(root.network.ssid);
-                }
-            }
-        }
-    }
-
     function closeDialog(): void {
         if (isClosing) {
             return;
@@ -61,7 +28,6 @@ ColumnLayout {
         connectButton.connecting = false;
         connectButton.hasError = false;
         connectButton.text = qsTr("Connect");
-        connectionMonitor.stop();
 
         // Return to network popout
         if (root.popouts.currentName === "wirelesspassword") {
@@ -91,29 +57,6 @@ ColumnLayout {
     }
 
     Keys.onEscapePressed: closeDialog()
-
-    Connections {
-        function onCurrentNameChanged() {
-            if (root.popouts.currentName === "wirelesspassword") {
-                // Update network when popout becomes active
-                Qt.callLater(() => {
-                    // Try to get network from parent Content's networkPopout
-                    const content = root.parent?.parent?.parent;
-                    if (content) {
-                        const networkPopout = content.children.find(c => c.name === "network");
-                        if (networkPopout && networkPopout.item) {
-                            root.network = networkPopout.item.passwordNetwork;
-                        }
-                    }
-                    // Force focus to password container when popout becomes active
-                    // Use Timer for actual delay to ensure dialog is fully rendered
-                    focusTimer.start();
-                });
-            }
-        }
-
-        target: root.popouts
-    }
 
     Timer {
         id: focusTimer
@@ -204,35 +147,6 @@ ColumnLayout {
                 }
                 color: Colours.palette.m3outline
                 font: Tokens.font.body.small
-            }
-
-            Timer {
-                property int attempts: 0
-
-                interval: 50
-                running: root.shouldBeVisible && (!root.network || !root.network.ssid)
-                repeat: true
-                onTriggered: {
-                    attempts++;
-                    // Keep trying to get network from Network component
-                    const content = root.parent?.parent?.parent;
-                    if (content) {
-                        const networkPopout = content.children.find(c => c.name === "network");
-                        if (networkPopout && networkPopout.item && networkPopout.item.passwordNetwork) {
-                            root.network = networkPopout.item.passwordNetwork;
-                        }
-                    }
-                    // Stop if we got it or after 20 attempts (1 second)
-                    if ((root.network && root.network.ssid) || attempts >= 20) {
-                        stop();
-                        attempts = 0;
-                    }
-                }
-                onRunningChanged: {
-                    if (!running) {
-                        attempts = 0;
-                    }
-                }
             }
 
             StyledText {
@@ -515,108 +429,23 @@ ColumnLayout {
                         enabled = false;
                         text = qsTr("Connecting...");
 
-                        // Connect to network
+                        // nmcli blocks until activation resolves, so this result is
+                        // final - no polling, and no cleanup to do here: the service
+                        // never leaves a profile behind for a failed attempt.
                         NetworkConnection.connectWithPassword(root.network, password, result => {
-                            if (result && result.success)
-                            // Connection successful, monitor will handle the rest
-                            {} else if (result && result.needsPassword) {
-                                // Shouldn't happen since we provided password
-                                connectionMonitor.stop();
-                                connecting = false;
-                                hasError = true;
-                                enabled = true;
-                                text = qsTr("Connect");
-                                passwordContainer.passwordBuffer = "";
-                                // Delete the failed connection
-                                if (root.network && root.network.ssid) {
-                                    Nmcli.forgetNetwork(root.network.ssid);
-                                }
+                            if (result && result.success) {
+                                root.closeDialog();
                             } else {
-                                // Connection failed immediately - show error
-                                connectionMonitor.stop();
                                 connecting = false;
                                 hasError = true;
                                 enabled = true;
                                 text = qsTr("Connect");
                                 passwordContainer.passwordBuffer = "";
-                                // Delete the failed connection
-                                if (root.network && root.network.ssid) {
-                                    Nmcli.forgetNetwork(root.network.ssid);
-                                }
                             }
                         });
-
-                        // Start monitoring connection
-                        connectionMonitor.start();
                     }
                 }
             }
         }
-    }
-
-    Timer {
-        id: connectionMonitor
-
-        property int repeatCount: 0
-
-        interval: 1000
-        repeat: true
-        triggeredOnStart: false
-
-        onTriggered: {
-            repeatCount++;
-            root.checkConnectionStatus();
-        }
-
-        onRunningChanged: {
-            if (!running) {
-                repeatCount = 0;
-            }
-        }
-    }
-
-    Timer {
-        id: connectionSuccessTimer
-
-        interval: 500
-        onTriggered: {
-            // Double-check connection is still active
-            if (root.shouldBeVisible && Nmcli.active && Nmcli.active.ssid) {
-                const stillConnected = Nmcli.active.ssid.toLowerCase().trim() === root.network.ssid.toLowerCase().trim();
-                if (stillConnected) {
-                    connectionMonitor.stop();
-                    connectButton.connecting = false;
-                    connectButton.text = qsTr("Connect");
-                    // Return to network popout on successful connection
-                    if (root.popouts.currentName === "wirelesspassword") {
-                        root.popouts.currentName = "network";
-                    }
-                    closeDialog();
-                }
-            }
-        }
-    }
-
-    Connections {
-        function onActiveChanged() {
-            if (root.shouldBeVisible) {
-                root.checkConnectionStatus();
-            }
-        }
-
-        function onConnectionFailed(ssid: string) {
-            if (root.shouldBeVisible && root.network && root.network.ssid === ssid && connectButton.connecting) {
-                connectionMonitor.stop();
-                connectButton.connecting = false;
-                connectButton.hasError = true;
-                connectButton.enabled = true;
-                connectButton.text = qsTr("Connect");
-                passwordContainer.passwordBuffer = "";
-                // Delete the failed connection
-                Nmcli.forgetNetwork(ssid);
-            }
-        }
-
-        target: Nmcli
     }
 }

--- a/modules/bar/popouts/Wrapper.qml
+++ b/modules/bar/popouts/Wrapper.qml
@@ -66,11 +66,11 @@ Item {
 
     focus: hasCurrent
     Keys.onEscapePressed: {
-        // Forward escape to password popout if active, otherwise close
-        if (currentName === "wirelesspassword" && content.item) {
-            const passwordPopout = (content.item as Content)?.children.find(c => c.name === "wirelesspassword");
-            if (passwordPopout && passwordPopout.item) {
-                passwordPopout.item.closeDialog();
+        // Forward escape to a credentials popout if active, otherwise close
+        if ((currentName === "wirelesspassword" || currentName === "enterprisepassword") && content.item) {
+            const credsPopout = (content.item as Content)?.children.find(c => c.name === currentName);
+            if (credsPopout && credsPopout.item) {
+                credsPopout.item.closeDialog();
                 return;
             }
         }
@@ -78,8 +78,8 @@ Item {
     }
 
     Keys.onPressed: event => {
-        // Don't intercept keys when password popout is active - let it handle them
-        if (currentName === "wirelesspassword") {
+        // Don't intercept keys when a credentials popout is active - let it handle them
+        if (currentName === "wirelesspassword" || currentName === "enterprisepassword") {
             event.accepted = false;
         }
     }
@@ -97,7 +97,7 @@ Item {
     }
 
     Binding {
-        when: root.isDetached || (root.hasCurrent && root.currentName === "wirelesspassword")
+        when: root.isDetached || (root.hasCurrent && (root.currentName === "wirelesspassword" || root.currentName === "enterprisepassword"))
 
         target: QsWindow.window
         property: "WlrLayershell.keyboardFocus"

--- a/modules/nexus/NexusState.qml
+++ b/modules/nexus/NexusState.qml
@@ -14,6 +14,7 @@ QtObject {
     property BluetoothDevice selectedBtDevice
     property DesktopEntry selectedApp
     property string selectedEthernetInterface
+    property var selectedWifiNetwork
 
     signal close
     signal subPageOpened(idx: int)

--- a/modules/nexus/PageCompRegistry.qml
+++ b/modules/nexus/PageCompRegistry.qml
@@ -52,6 +52,9 @@ QtObject {
                 Component {
                     EnterpriseConnectPage {}
                 }
+                Component {
+                    WifiPasswordPage {}
+                }
             }
         },
         Component {

--- a/modules/nexus/PageCompRegistry.qml
+++ b/modules/nexus/PageCompRegistry.qml
@@ -49,6 +49,9 @@ QtObject {
                 Component {
                     EthernetDetailPage {}
                 }
+                Component {
+                    EnterpriseConnectPage {}
+                }
             }
         },
         Component {

--- a/modules/nexus/pages/NetworkPage.qml
+++ b/modules/nexus/pages/NetworkPage.qml
@@ -131,7 +131,10 @@ PageBase {
                             return;
                         }
 
-                        NetworkConnection.handleConnect(modelData);
+                        NetworkConnection.handleConnect(modelData, null, network => {
+                            root.nState.selectedWifiNetwork = network;
+                            root.nState.openSubPage(3);
+                        });
                         currentSelected = true;
                         root.networkSelected(modelData);
                     }

--- a/modules/nexus/pages/NetworkPage.qml
+++ b/modules/nexus/pages/NetworkPage.qml
@@ -103,7 +103,21 @@ PageBase {
                 anchors.fill: undefined
 
                 onClicked: {
+                    if (modelData.active) {
+                        if (modelData.isEnterprise) {
+                            root.nState.selectedWifiNetwork = modelData;
+                            root.nState.openSubPage(2);
+                        }
+                        return;
+                    }
+
                     if (!modelData.active) {
+                        if (modelData.isEnterprise && !Nmcli.hasSavedProfile(modelData.ssid)) {
+                            root.nState.selectedWifiNetwork = modelData;
+                            root.nState.openSubPage(2);
+                            return;
+                        }
+
                         NetworkConnection.handleConnect(modelData);
                         currentSelected = true;
                         root.networkSelected(modelData);

--- a/modules/nexus/pages/NetworkPage.qml
+++ b/modules/nexus/pages/NetworkPage.qml
@@ -107,6 +107,8 @@ PageBase {
                         if (modelData.isEnterprise) {
                             root.nState.selectedWifiNetwork = modelData;
                             root.nState.openSubPage(2);
+                        } else {
+                            Nmcli.disconnectFromNetwork();
                         }
                         return;
                     }
@@ -192,8 +194,11 @@ PageBase {
                             id: iconComp
 
                             MaterialIcon {
-                                text: network.modelData.active ? "settings" : "lock"
-                                color: network.modelData.active ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                                readonly property bool saved: Nmcli.hasSavedProfile(network.modelData.ssid)
+
+                                text: network.modelData.active ? (network.modelData.isEnterprise ? "settings" : "link_off") : (saved ? "wifi_lock" : (network.modelData.isSecure ? "lock" : "wifi"))
+                                fill: network.modelData.active || saved ? 1 : 0
+                                color: network.modelData.active || saved ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
                                 fontStyle: Tokens.font.icon.medium
                                 opacity: network.textOpacity
                             }
@@ -204,6 +209,40 @@ PageBase {
 
                             LoadingIndicator {
                                 implicitSize: Math.round(Tokens.font.icon.medium.pointSize * 1.3)
+                            }
+                        }
+                    }
+
+                    Loader {
+                        active: Nmcli.hasSavedProfile(network.modelData.ssid)
+                        asynchronous: true
+                        sourceComponent: Item {
+                            implicitWidth: Tokens.font.icon.medium.pointSize + Tokens.padding.small * 2
+                            implicitHeight: implicitWidth
+
+                            StateLayer {
+                                id: forgetState
+
+                                radius: Tokens.rounding.full
+                                onClicked: Nmcli.forgetNetwork(network.modelData.ssid)
+                            }
+
+                            MaterialIcon {
+                                anchors.centerIn: parent
+                                text: "delete"
+                                fontStyle: Tokens.font.icon.small
+                                color: forgetState.containsMouse ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
+                                opacity: (forgetState.containsMouse ? 1 : 0.6) * network.textOpacity
+
+                                Behavior on color {
+                                    CAnim {}
+                                }
+
+                                Behavior on opacity {
+                                    Anim {
+                                        type: Anim.DefaultEffects
+                                    }
+                                }
                             }
                         }
                     }

--- a/modules/nexus/pages/NetworkPage.qml
+++ b/modules/nexus/pages/NetworkPage.qml
@@ -102,6 +102,17 @@ PageBase {
                 radius: Tokens.rounding.extraSmall
                 anchors.fill: undefined
 
+                StyledRect {
+                    z: -1
+                    anchors.fill: parent
+                    radius: network.radius
+                    color: network.modelData.active ? Qt.alpha(Colours.palette.m3primary, 0.12) : "transparent"
+
+                    Behavior on color {
+                        CAnim {}
+                    }
+                }
+
                 onClicked: {
                     if (modelData.active) {
                         if (modelData.isEnterprise) {
@@ -187,60 +198,98 @@ PageBase {
                         }
                     }
 
-                    AnimLoader {
-                        sourceComp: Nmcli.connectingSsid() === network.modelData.ssid ? loadingComp : iconComp
+                    StyledRect {
+                        id: statusPill
 
-                        Component {
-                            id: iconComp
+                        readonly property bool saved: Nmcli.hasSavedProfile(network.modelData.ssid)
 
-                            MaterialIcon {
-                                readonly property bool saved: Nmcli.hasSavedProfile(network.modelData.ssid)
+                        implicitWidth: statusPillRow.implicitWidth
+                        implicitHeight: statusPillRow.implicitHeight
+                        radius: Tokens.rounding.full
+                        color: network.modelData.active ? Qt.alpha(Colours.palette.m3primary, 0.18) : statusPill.saved ? Colours.palette.m3surfaceContainerHigh : "transparent"
 
-                                text: network.modelData.active ? (network.modelData.isEnterprise ? "settings" : "link_off") : (saved ? "wifi_lock" : (network.modelData.isSecure ? "lock" : "wifi"))
-                                fill: network.modelData.active || saved ? 1 : 0
-                                color: network.modelData.active || saved ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
-                                fontStyle: Tokens.font.icon.medium
-                                opacity: network.textOpacity
-                            }
+                        Behavior on color {
+                            CAnim {}
                         }
 
-                        Component {
-                            id: loadingComp
+                        Row {
+                            id: statusPillRow
 
-                            LoadingIndicator {
-                                implicitSize: Math.round(Tokens.font.icon.medium.pointSize * 1.3)
+                            Item {
+                                id: statusSegment
+
+                                width: Tokens.font.icon.medium.pointSize + Tokens.padding.small * 2
+                                height: width
+
+                                AnimLoader {
+                                    anchors.centerIn: parent
+                                    sourceComp: Nmcli.connectingSsid() === network.modelData.ssid ? loadingComp : iconComp
+
+                                    Component {
+                                        id: iconComp
+
+                                        MaterialIcon {
+                                            readonly property bool saved: Nmcli.hasSavedProfile(network.modelData.ssid)
+
+                                            text: network.modelData.active ? (network.modelData.isEnterprise ? "settings" : "link_off") : (saved ? "wifi_lock" : (network.modelData.isSecure ? "lock" : "wifi"))
+                                            fill: network.modelData.active || saved ? 1 : 0
+                                            color: network.modelData.active || saved ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                                            fontStyle: Tokens.font.icon.medium
+                                            opacity: network.textOpacity
+                                        }
+                                    }
+
+                                    Component {
+                                        id: loadingComp
+
+                                        LoadingIndicator {
+                                            implicitSize: Math.round(Tokens.font.icon.medium.pointSize * 1.3)
+                                        }
+                                    }
+                                }
                             }
-                        }
-                    }
 
-                    Loader {
-                        active: Nmcli.hasSavedProfile(network.modelData.ssid)
-                        asynchronous: true
-                        sourceComponent: Item {
-                            implicitWidth: Tokens.font.icon.medium.pointSize + Tokens.padding.small * 2
-                            implicitHeight: implicitWidth
+                            Item {
+                                visible: statusPill.saved
+                                width: visible ? 1 : 0
+                                height: statusSegment.height
 
-                            StateLayer {
-                                id: forgetState
-
-                                radius: Tokens.rounding.full
-                                onClicked: Nmcli.forgetNetwork(network.modelData.ssid)
+                                Rectangle {
+                                    anchors.centerIn: parent
+                                    width: 1
+                                    height: parent.height * 0.5
+                                    color: Qt.alpha(network.modelData.active ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant, 0.3)
+                                }
                             }
 
-                            MaterialIcon {
-                                anchors.centerIn: parent
-                                text: "delete"
-                                fontStyle: Tokens.font.icon.small
-                                color: forgetState.containsMouse ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
-                                opacity: (forgetState.containsMouse ? 1 : 0.6) * network.textOpacity
+                            Item {
+                                visible: statusPill.saved
+                                width: visible ? statusSegment.width : 0
+                                height: statusSegment.height
 
-                                Behavior on color {
-                                    CAnim {}
+                                StateLayer {
+                                    id: forgetState
+
+                                    anchors.fill: parent
+                                    radius: Tokens.rounding.full
+                                    onClicked: Nmcli.forgetNetwork(network.modelData.ssid)
                                 }
 
-                                Behavior on opacity {
-                                    Anim {
-                                        type: Anim.DefaultEffects
+                                MaterialIcon {
+                                    anchors.centerIn: parent
+                                    text: "delete"
+                                    fontStyle: Tokens.font.icon.small
+                                    color: forgetState.containsMouse ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
+                                    opacity: (forgetState.containsMouse ? 1 : 0.6) * network.textOpacity
+
+                                    Behavior on color {
+                                        CAnim {}
+                                    }
+
+                                    Behavior on opacity {
+                                        Anim {
+                                            type: Anim.DefaultEffects
+                                        }
                                     }
                                 }
                             }

--- a/modules/nexus/pages/NetworkPage.qml
+++ b/modules/nexus/pages/NetworkPage.qml
@@ -102,17 +102,6 @@ PageBase {
                 radius: Tokens.rounding.extraSmall
                 anchors.fill: undefined
 
-                StyledRect {
-                    z: -1
-                    anchors.fill: parent
-                    radius: network.radius
-                    color: network.modelData.active ? Qt.alpha(Colours.palette.m3primary, 0.12) : "transparent"
-
-                    Behavior on color {
-                        CAnim {}
-                    }
-                }
-
                 onClicked: {
                     if (modelData.active) {
                         if (modelData.isEnterprise) {
@@ -162,6 +151,17 @@ PageBase {
                     }
 
                     target: root
+                }
+
+                StyledRect {
+                    z: -1
+                    anchors.fill: parent
+                    radius: network.radius
+                    color: network.modelData.active ? Qt.alpha(Colours.palette.m3primary, 0.12) : "transparent"
+
+                    Behavior on color {
+                        CAnim {}
+                    }
                 }
 
                 RowLayout {

--- a/modules/nexus/pages/network/EnterpriseConnectPage.qml
+++ b/modules/nexus/pages/network/EnterpriseConnectPage.qml
@@ -23,26 +23,6 @@ PageBase {
     property bool hasError: false
     property string errorMessage: ""
 
-    title: root.ssid.length > 0 ? root.ssid : qsTr("Enterprise network")
-    isSubPage: true
-
-    Component.onCompleted: {
-        if (root.ssid.length > 0 && Nmcli.hasSavedProfile(root.ssid)) {
-            Nmcli.getEnterpriseConfig(root.ssid, cfg => {
-                if (!cfg)
-                    return;
-                identityField.text = cfg.identity;
-                anonIdentityField.text = cfg.anonymousIdentity;
-                domainSuffixField.text = cfg.domainSuffixMatch;
-                caCertField.text = cfg.caCertPath;
-                root.eapMethod = cfg.eapMethod;
-                root.phase2Method = cfg.phase2Method;
-                eapSelect.active = cfg.eapMethod === "tls" ? tlsItem : (cfg.eapMethod === "ttls" ? ttlsItem : peapItem);
-                phase2Select.active = cfg.phase2Method === "pap" ? papItem : (cfg.phase2Method === "gtc" ? gtcItem : (cfg.phase2Method === "md5" ? md5Item : mschapv2Item));
-            });
-        }
-    }
-
     function attemptConnect(): void {
         if (!root.network || root.connecting) {
             return;
@@ -82,6 +62,26 @@ PageBase {
                 }
             }
         });
+    }
+
+    title: root.ssid.length > 0 ? root.ssid : qsTr("Enterprise network")
+    isSubPage: true
+
+    Component.onCompleted: {
+        if (root.ssid.length > 0 && Nmcli.hasSavedProfile(root.ssid)) {
+            Nmcli.getEnterpriseConfig(root.ssid, cfg => {
+                if (!cfg)
+                    return;
+                identityField.text = cfg.identity;
+                anonIdentityField.text = cfg.anonymousIdentity;
+                domainSuffixField.text = cfg.domainSuffixMatch;
+                caCertField.text = cfg.caCertPath;
+                root.eapMethod = cfg.eapMethod;
+                root.phase2Method = cfg.phase2Method;
+                eapSelect.active = cfg.eapMethod === "tls" ? tlsItem : (cfg.eapMethod === "ttls" ? ttlsItem : peapItem);
+                phase2Select.active = cfg.phase2Method === "pap" ? papItem : (cfg.phase2Method === "gtc" ? gtcItem : (cfg.phase2Method === "md5" ? md5Item : mschapv2Item));
+            });
+        }
     }
 
     ColumnLayout {

--- a/modules/nexus/pages/network/EnterpriseConnectPage.qml
+++ b/modules/nexus/pages/network/EnterpriseConnectPage.qml
@@ -339,6 +339,77 @@ PageBase {
                     }
                 }
             }
+
+            ButtonBase {
+                id: disconnectBtn
+
+                visible: root.network?.active ?? false
+                fillWidth: true
+                shapeMorph: true
+                isRound: true
+                inactiveColour: Colours.palette.m3secondaryContainer
+                inactiveOnColour: Colours.palette.m3onSecondaryContainer
+
+                implicitWidth: disconnectLayout.implicitWidth + Tokens.padding.extraLarge * 2
+                implicitHeight: disconnectLayout.implicitHeight + Tokens.padding.medium * 2
+
+                onClicked: Nmcli.disconnectFromNetwork()
+
+                RowLayout {
+                    id: disconnectLayout
+
+                    anchors.centerIn: parent
+                    spacing: Tokens.spacing.small
+
+                    MaterialIcon {
+                        text: "link_off"
+                        color: disconnectBtn.onColour
+                        fontStyle: Tokens.font.icon.medium
+                    }
+
+                    StyledText {
+                        text: qsTr("Disconnect")
+                        color: disconnectBtn.onColour
+                    }
+                }
+            }
+
+            ButtonBase {
+                id: forgetBtn
+
+                visible: root.ssid.length > 0 && Nmcli.hasSavedProfile(root.ssid)
+                fillWidth: true
+                shapeMorph: true
+                isRound: true
+                inactiveColour: Colours.palette.m3errorContainer
+                inactiveOnColour: Colours.palette.m3onErrorContainer
+
+                implicitWidth: forgetLayout.implicitWidth + Tokens.padding.extraLarge * 2
+                implicitHeight: forgetLayout.implicitHeight + Tokens.padding.medium * 2
+
+                onClicked: {
+                    Nmcli.forgetNetwork(root.ssid);
+                    nState.closeSubPage();
+                }
+
+                RowLayout {
+                    id: forgetLayout
+
+                    anchors.centerIn: parent
+                    spacing: Tokens.spacing.small
+
+                    MaterialIcon {
+                        text: "delete"
+                        color: forgetBtn.onColour
+                        fontStyle: Tokens.font.icon.medium
+                    }
+
+                    StyledText {
+                        text: qsTr("Forget network")
+                        color: forgetBtn.onColour
+                    }
+                }
+            }
         }
     }
 }

--- a/modules/nexus/pages/network/EnterpriseConnectPage.qml
+++ b/modules/nexus/pages/network/EnterpriseConnectPage.qml
@@ -1,0 +1,344 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Caelestia.Components
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.utils
+import qs.modules.nexus.common
+
+PageBase {
+    id: root
+
+    readonly property Nmcli.AccessPoint network: nState.selectedWifiNetwork ?? null
+    readonly property string ssid: root.network?.ssid ?? ""
+
+    property string eapMethod: "peap"
+    property string phase2Method: "mschapv2"
+    property bool showAdvanced: false
+    property bool connecting: false
+    property bool hasError: false
+    property string errorMessage: ""
+
+    title: root.ssid.length > 0 ? root.ssid : qsTr("Enterprise network")
+    isSubPage: true
+
+    Component.onCompleted: {
+        if (root.ssid.length > 0 && Nmcli.hasSavedProfile(root.ssid)) {
+            Nmcli.getEnterpriseConfig(root.ssid, cfg => {
+                if (!cfg)
+                    return;
+                identityField.text = cfg.identity;
+                anonIdentityField.text = cfg.anonymousIdentity;
+                domainSuffixField.text = cfg.domainSuffixMatch;
+                caCertField.text = cfg.caCertPath;
+                root.eapMethod = cfg.eapMethod;
+                root.phase2Method = cfg.phase2Method;
+                eapSelect.active = cfg.eapMethod === "tls" ? tlsItem : (cfg.eapMethod === "ttls" ? ttlsItem : peapItem);
+                phase2Select.active = cfg.phase2Method === "pap" ? papItem : (cfg.phase2Method === "gtc" ? gtcItem : (cfg.phase2Method === "md5" ? md5Item : mschapv2Item));
+            });
+        }
+    }
+
+    function attemptConnect(): void {
+        if (!root.network || root.connecting) {
+            return;
+        }
+        if (identityField.text.trim().length === 0) {
+            identityField.isError = true;
+            return;
+        }
+
+        root.hasError = false;
+        root.connecting = true;
+
+        const wasSaved = Nmcli.hasSavedProfile(root.ssid);
+
+        const params = {
+            identity: identityField.text.trim(),
+            password: passwordField.text,
+            eapMethod: root.eapMethod,
+            phase2Method: root.phase2Method,
+            anonymousIdentity: anonIdentityField.text.trim(),
+            domainSuffixMatch: domainSuffixField.text.trim(),
+            caCertPath: caCertField.text.trim(),
+            verifyCert: verifyCertToggle.checked
+        };
+
+        NetworkConnection.connectWithEnterpriseCredentials(root.network, params, result => {
+            root.connecting = false;
+
+            if (result && result.success) {
+                root.hasError = false;
+                nState.closeSubPage();
+            } else {
+                root.hasError = true;
+                root.errorMessage = qsTr("Connection failed. Check your identity, password and EAP settings.");
+                if (root.ssid.length > 0 && !wasSaved) {
+                    Nmcli.forgetNetwork(root.ssid);
+                }
+            }
+        });
+    }
+
+    ColumnLayout {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        width: root.cappedWidth
+        spacing: Tokens.spacing.extraSmall / 2
+
+        SectionHeader {
+            first: true
+            text: qsTr("Credentials")
+        }
+
+        M3TextField {
+            id: identityField
+
+            Layout.fillWidth: true
+            Layout.topMargin: Tokens.spacing.small
+            label: qsTr("Identity")
+            placeholder: qsTr("matricula@instituicao.edu.br")
+            leadingIcon: "person"
+            supportingText: qsTr("Usually your ID/matrícula followed by @ and your institution's domain")
+            errorText: qsTr("Identity is required")
+            inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
+        }
+
+        M3TextField {
+            id: passwordField
+
+            Layout.fillWidth: true
+            Layout.topMargin: Tokens.spacing.large
+            label: qsTr("Password")
+            leadingIcon: "lock"
+            password: true
+            inputMethodHints: Qt.ImhNoPredictiveText
+            onAccepted: root.attemptConnect()
+        }
+
+        SectionHeader {
+            text: qsTr("Authentication method")
+        }
+
+        SelectRow {
+            id: eapSelect
+
+            Layout.fillWidth: true
+            Layout.topMargin: Tokens.spacing.small
+            first: true
+            last: root.eapMethod === "tls"
+            label: qsTr("EAP method")
+            fallbackText: qsTr("PEAP")
+            fallbackIcon: "security"
+            active: peapItem
+
+            menuItems: [peapItem, ttlsItem, tlsItem]
+
+            onSelected: item => {
+                root.eapMethod = item === tlsItem ? "tls" : (item === ttlsItem ? "ttls" : "peap");
+            }
+
+            MenuItem {
+                id: peapItem
+
+                icon: "security"
+                text: qsTr("PEAP")
+            }
+
+            MenuItem {
+                id: ttlsItem
+
+                icon: "security"
+                text: qsTr("TTLS")
+            }
+
+            MenuItem {
+                id: tlsItem
+
+                icon: "security"
+                text: qsTr("TLS")
+            }
+        }
+
+        SelectRow {
+            id: phase2Select
+
+            Layout.fillWidth: true
+            visible: root.eapMethod !== "tls"
+            last: true
+            label: qsTr("Phase 2 authentication")
+            fallbackText: qsTr("MSCHAPv2")
+            fallbackIcon: "verified_user"
+            active: mschapv2Item
+
+            menuItems: [mschapv2Item, papItem, gtcItem, md5Item]
+
+            onSelected: item => {
+                root.phase2Method = item === papItem ? "pap" : (item === gtcItem ? "gtc" : (item === md5Item ? "md5" : "mschapv2"));
+            }
+
+            MenuItem {
+                id: mschapv2Item
+
+                icon: "verified_user"
+                text: qsTr("MSCHAPv2")
+            }
+
+            MenuItem {
+                id: papItem
+
+                icon: "verified_user"
+                text: qsTr("PAP")
+            }
+
+            MenuItem {
+                id: gtcItem
+
+                icon: "verified_user"
+                text: qsTr("GTC")
+            }
+
+            MenuItem {
+                id: md5Item
+
+                icon: "verified_user"
+                text: qsTr("MD5")
+            }
+        }
+
+        ToggleRow {
+            Layout.topMargin: Tokens.spacing.large
+            first: true
+            last: !root.showAdvanced
+            text: qsTr("Advanced options")
+            font: Tokens.font.body.medium
+            horizontalPadding: Tokens.padding.largeIncreased
+            checked: root.showAdvanced
+            onToggled: root.showAdvanced = checked
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.topMargin: Tokens.spacing.large
+            spacing: Tokens.spacing.large
+            visible: root.showAdvanced
+
+            M3TextField {
+                id: anonIdentityField
+
+                Layout.fillWidth: true
+                label: qsTr("Anonymous identity")
+                placeholder: qsTr("anonymous@instituicao.edu.br")
+                leadingIcon: "visibility_off"
+                supportingText: qsTr("Optional — outer identity sent before the TLS tunnel is established")
+                inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
+            }
+
+            M3TextField {
+                id: domainSuffixField
+
+                Layout.fillWidth: true
+                label: qsTr("Domain suffix match")
+                placeholder: qsTr("instituicao.edu.br")
+                leadingIcon: "domain"
+                supportingText: qsTr("Optional — restricts which server certificate domains are accepted")
+                inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
+            }
+
+            M3TextField {
+                id: caCertField
+
+                Layout.fillWidth: true
+                label: qsTr("CA certificate path")
+                placeholder: qsTr("/etc/ssl/certs/eduroam-ca.pem")
+                leadingIcon: "folder"
+                supportingText: qsTr("Optional — path to a CA certificate to validate the RADIUS server")
+                inputMethodHints: Qt.ImhNoPredictiveText
+            }
+
+            ToggleRow {
+                id: verifyCertToggle
+
+                Layout.fillWidth: true
+                first: true
+                last: true
+                text: qsTr("Verify server certificate")
+                subtext: qsTr("Disable only if you know what you're doing — this weakens security")
+                enabled: caCertField.text.trim().length === 0
+                checked: caCertField.text.trim().length === 0
+            }
+        }
+
+        StyledText {
+            Layout.fillWidth: true
+            Layout.topMargin: Tokens.spacing.medium
+            visible: root.hasError
+            text: root.errorMessage
+            color: Colours.palette.m3error
+            font: Tokens.font.body.small
+            wrapMode: Text.WordWrap
+        }
+
+        ButtonRow {
+            Layout.topMargin: Tokens.spacing.large
+            Layout.alignment: Qt.AlignHCenter
+            Layout.minimumWidth: Math.round(root.cappedWidth * 0.5)
+            spacing: Tokens.spacing.small
+
+            ButtonBase {
+                id: connectBtn
+
+                fillWidth: true
+                shapeMorph: true
+                isRound: true
+                inactiveColour: Colours.palette.m3primary
+                inactiveOnColour: Colours.palette.m3onPrimary
+                stateLayer.disabled: root.connecting
+
+                implicitWidth: connectLayout.implicitWidth + Tokens.padding.extraLarge * 2
+                implicitHeight: connectLayout.implicitHeight + Tokens.padding.medium * 2
+
+                onClicked: root.attemptConnect()
+
+                AnimLoader {
+                    id: connectLayout
+
+                    anchors.centerIn: parent
+                    sourceComp: root.connecting ? loadingComp : textComp
+
+                    Component {
+                        id: textComp
+
+                        RowLayout {
+                            spacing: Tokens.spacing.small
+
+                            MaterialIcon {
+                                text: "wifi_lock"
+                                color: connectBtn.onColour
+                                fontStyle: Tokens.font.icon.medium
+                            }
+
+                            StyledText {
+                                text: root.network?.active ? qsTr("Reconnect") : qsTr("Connect")
+                                color: connectBtn.onColour
+                            }
+                        }
+                    }
+
+                    Component {
+                        id: loadingComp
+
+                        LoadingIndicator {
+                            implicitSize: Math.round(Tokens.font.body.medium.pointSize * 1.4)
+                            color: connectBtn.onColour
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/nexus/pages/network/EnterpriseConnectPage.qml
+++ b/modules/nexus/pages/network/EnterpriseConnectPage.qml
@@ -68,6 +68,9 @@ PageBase {
     isSubPage: true
 
     Component.onCompleted: {
+        eapSelect.active = peapItem;
+        phase2Select.active = mschapv2Item;
+
         if (root.ssid.length > 0 && Nmcli.hasSavedProfile(root.ssid)) {
             Nmcli.getEnterpriseConfig(root.ssid, cfg => {
                 if (!cfg)
@@ -134,7 +137,6 @@ PageBase {
             label: qsTr("EAP method")
             fallbackText: qsTr("PEAP")
             fallbackIcon: "security"
-            active: peapItem
 
             menuItems: [peapItem, ttlsItem, tlsItem]
 
@@ -173,7 +175,6 @@ PageBase {
             label: qsTr("Phase 2 authentication")
             fallbackText: qsTr("MSCHAPv2")
             fallbackIcon: "verified_user"
-            active: mschapv2Item
 
             menuItems: [mschapv2Item, papItem, gtcItem, md5Item]
 
@@ -389,7 +390,7 @@ PageBase {
 
                 onClicked: {
                     Nmcli.forgetNetwork(root.ssid);
-                    nState.closeSubPage();
+                    root.nState.closeSubPage();
                 }
 
                 RowLayout {

--- a/modules/nexus/pages/network/EnterpriseConnectPage.qml
+++ b/modules/nexus/pages/network/EnterpriseConnectPage.qml
@@ -35,8 +35,6 @@ PageBase {
         root.hasError = false;
         root.connecting = true;
 
-        const wasSaved = Nmcli.hasSavedProfile(root.ssid);
-
         const params = {
             identity: identityField.text.trim(),
             password: passwordField.text,
@@ -57,9 +55,6 @@ PageBase {
             } else {
                 root.hasError = true;
                 root.errorMessage = qsTr("Connection failed. Check your identity, password and EAP settings.");
-                if (root.ssid.length > 0 && !wasSaved) {
-                    Nmcli.forgetNetwork(root.ssid);
-                }
             }
         });
     }

--- a/modules/nexus/pages/network/WifiPasswordPage.qml
+++ b/modules/nexus/pages/network/WifiPasswordPage.qml
@@ -19,9 +19,6 @@ PageBase {
     property bool connecting: false
     property bool hasError: false
 
-    title: root.ssid.length > 0 ? root.ssid : qsTr("Enter password")
-    isSubPage: true
-
     function attemptConnect(): void {
         if (!root.network || root.connecting) {
             return;
@@ -41,6 +38,9 @@ PageBase {
             }
         });
     }
+
+    title: root.ssid.length > 0 ? root.ssid : qsTr("Enter password")
+    isSubPage: true
 
     ColumnLayout {
         anchors.horizontalCenter: parent.horizontalCenter

--- a/modules/nexus/pages/network/WifiPasswordPage.qml
+++ b/modules/nexus/pages/network/WifiPasswordPage.qml
@@ -1,0 +1,126 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Caelestia.Components
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.utils
+import qs.modules.nexus.common
+
+PageBase {
+    id: root
+
+    readonly property Nmcli.AccessPoint network: nState.selectedWifiNetwork ?? null
+    readonly property string ssid: root.network?.ssid ?? ""
+
+    property bool connecting: false
+    property bool hasError: false
+
+    title: root.ssid.length > 0 ? root.ssid : qsTr("Enter password")
+    isSubPage: true
+
+    function attemptConnect(): void {
+        if (!root.network || root.connecting) {
+            return;
+        }
+
+        root.hasError = false;
+        root.connecting = true;
+
+        NetworkConnection.connectWithPassword(root.network, passwordField.text, result => {
+            root.connecting = false;
+
+            if (result && result.success) {
+                nState.closeSubPage();
+            } else {
+                root.hasError = true;
+                passwordField.isError = true;
+            }
+        });
+    }
+
+    ColumnLayout {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        width: root.cappedWidth
+        spacing: Tokens.spacing.extraSmall / 2
+
+        SectionHeader {
+            first: true
+            text: qsTr("Password")
+        }
+
+        M3TextField {
+            id: passwordField
+
+            Layout.fillWidth: true
+            Layout.topMargin: Tokens.spacing.small
+            label: qsTr("Password")
+            leadingIcon: "lock"
+            password: true
+            errorText: qsTr("Incorrect password — try again")
+            inputMethodHints: Qt.ImhNoPredictiveText
+            onAccepted: root.attemptConnect()
+        }
+
+        ButtonRow {
+            Layout.topMargin: Tokens.spacing.large
+            Layout.alignment: Qt.AlignHCenter
+            Layout.minimumWidth: Math.round(root.cappedWidth * 0.5)
+
+            ButtonBase {
+                id: connectBtn
+
+                fillWidth: true
+                shapeMorph: true
+                isRound: true
+                inactiveColour: Colours.palette.m3primary
+                inactiveOnColour: Colours.palette.m3onPrimary
+                stateLayer.disabled: root.connecting
+
+                implicitWidth: connectLayout.implicitWidth + Tokens.padding.extraLarge * 2
+                implicitHeight: connectLayout.implicitHeight + Tokens.padding.medium * 2
+
+                onClicked: root.attemptConnect()
+
+                AnimLoader {
+                    id: connectLayout
+
+                    anchors.centerIn: parent
+                    sourceComp: root.connecting ? loadingComp : textComp
+
+                    Component {
+                        id: textComp
+
+                        RowLayout {
+                            spacing: Tokens.spacing.small
+
+                            MaterialIcon {
+                                text: "wifi"
+                                color: connectBtn.onColour
+                                fontStyle: Tokens.font.icon.medium
+                            }
+
+                            StyledText {
+                                text: qsTr("Connect")
+                                color: connectBtn.onColour
+                            }
+                        }
+                    }
+
+                    Component {
+                        id: loadingComp
+
+                        LoadingIndicator {
+                            implicitSize: Math.round(Tokens.font.body.medium.pointSize * 1.4)
+                            color: connectBtn.onColour
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -24,7 +24,6 @@ Singleton {
 
     property var wifiConnectionQueue: []
     property int currentSsidQueryIndex: 0
-    property var pendingConnection: null
     property var wirelessDeviceDetails: null
     property var ethernetDeviceDetails: null
     property string ethernetDataUsage: ""
@@ -37,9 +36,6 @@ Singleton {
     // anything other than that as a usable connection.
     readonly property bool hasAvailableEthernet: ethernetDevices.some(d => d.state !== "unavailable")
     property list<var> activeProcesses: []
-
-    readonly property alias connectionCheckTimer: connectionCheckTimer
-    readonly property alias immediateCheckTimer: immediateCheckTimer
 
     // Constants
     readonly property string deviceTypeWifi: "wifi"
@@ -62,16 +58,66 @@ Singleton {
     readonly property string connectionParamIfname: "ifname"
     readonly property string connectionParamSsid: "ssid"
     readonly property string connectionParamPassword: "password"
-    readonly property string connectionParamBssid: "802-11-wireless.bssid"
+    readonly property string connectionParamAutoconnect: "connection.autoconnect"
+    readonly property string securityWepKey: "802-11-wireless-security.wep-key0"
+    readonly property string keyMgmtSae: "sae"
+    readonly property string keyMgmtNone: "none"
+    // nmcli's `connection up` blocks until activation resolves. Its default
+    // timeout is 90s, and a wrong password burns the whole budget because
+    // NetworkManager keeps retrying the handshake, so keep it short.
+    readonly property string activationTimeout: "20"
 
-    signal connectionFailed(string ssid)
+    // Classifies a failed nmcli result so the UI can show a useful message.
+    // Never used to decide control flow - the exit code alone does that.
+    function failureReason(result: var): string {
+        if (!result || result.success) {
+            return "";
+        }
+        const error = result.error ?? "";
+        if (error.includes("Secrets were required") || error.includes("No secrets provided")) {
+            return "badPassword";
+        }
+        // nmcli exit codes: 3 timeout, 4 activation failed, 10 not found.
+        if (result.exitCode === 3) {
+            return "timeout";
+        }
+        if (result.exitCode === 10) {
+            return "notFound";
+        }
+        return "unknown";
+    }
 
-    function detectPasswordRequired(error: string): bool {
-        if (!error || error.length === 0) {
+    // Picks the nmcli key management mode from the security string reported by
+    // `nmcli -g SECURITY`, e.g. "WPA2", "WPA1 WPA2", "WPA3", "WPA2 802.1X".
+    // Returns "" for open networks.
+    function keyMgmtForSecurity(security: string): string {
+        const s = (security ?? "").toUpperCase();
+        if (s.includes("WPA3") || s.includes("SAE")) {
+            return root.keyMgmtSae;
+        }
+        if (s.includes("WPA")) {
+            return root.keyMgmtWpaPsk;
+        }
+        if (s.includes("WEP")) {
+            return root.keyMgmtNone;
+        }
+        return "";
+    }
+
+    // WPA-PSK passphrases are 8-63 characters, or exactly 64 hex digits for a
+    // raw PMK. Checking here means a typo never costs a connection attempt or
+    // leaves a junk profile behind.
+    function isValidPsk(password: string, keyMgmt: string): bool {
+        if (!password || password.length === 0) {
             return false;
         }
-
-        return (error.includes("Secrets were required") || error.includes("Secrets were required, but not provided") || error.includes("No secrets provided") || error.includes("802-11-wireless-security.psk") || error.includes("password for") || (error.includes("password") && !error.includes("Connection activated") && !error.includes("successfully")) || (error.includes("Secrets") && !error.includes("Connection activated") && !error.includes("successfully")) || (error.includes("802.11") && !error.includes("Connection activated") && !error.includes("successfully"))) && !error.includes("Connection activated") && !error.includes("successfully");
+        if (keyMgmt === root.keyMgmtNone) {
+            return true;
+        }
+        if (/^[0-9a-fA-F]{64}$/.test(password)) {
+            return true;
+        }
+        return password.length >= 8 && password.length <= 63;
     }
 
     function parseNetworkOutput(output: string): list<var> {
@@ -120,14 +166,6 @@ Singleton {
         }
 
         return Array.from(networkMap.values());
-    }
-
-    function isConnectionCommand(command: list<string>): bool {
-        if (!command || command.length === 0) {
-            return false;
-        }
-
-        return command.includes(root.nmcliCommandWifi) || command.includes(root.nmcliCommandConnection);
     }
 
     function parseDeviceStatusOutput(output: string, filterType: string): list<var> {
@@ -281,9 +319,9 @@ Singleton {
                         if (interfaceName && interfaceName.length > 0) {
                             Qt.callLater(() => {
                                 getEthernetDeviceDetails(interfaceName, () => {});
-                            }, 1000);
+                            });
                         }
-                    }, 500);
+                    });
                 }
                 if (callback)
                     callback(result);
@@ -295,8 +333,8 @@ Singleton {
                         getEthernetInterfaces(() => {});
                         Qt.callLater(() => {
                             getEthernetDeviceDetails(interfaceName, () => {});
-                        }, 1000);
-                    }, 500);
+                        });
+                    });
                 }
                 if (callback)
                     callback(result);
@@ -329,7 +367,7 @@ Singleton {
                 root.ethernetDeviceDetails = null;
                 Qt.callLater(() => {
                     getEthernetInterfaces(() => {});
-                }, 500);
+                });
             }
             if (callback)
                 callback(result);
@@ -361,220 +399,155 @@ Singleton {
         });
     }
 
-    function connectToNetworkWithPasswordCheck(ssid: string, isSecure: bool, callback: var, bssid: string): void {
-        if (isSecure) {
-            const hasBssid = bssid !== undefined && bssid !== null && bssid.length > 0;
-            connectWireless(ssid, "", bssid, result => {
-                if (result.success) {
-                    if (callback)
-                        callback({
-                            success: true,
-                            usedSavedPassword: true,
-                            output: result.output,
-                            error: "",
-                            exitCode: 0
-                        });
-                } else if (result.needsPassword) {
-                    if (callback)
-                        callback({
-                            success: false,
-                            needsPassword: true,
-                            output: result.output,
-                            error: result.error,
-                            exitCode: result.exitCode
-                        });
-                } else {
-                    if (callback)
-                        callback(result);
-                }
-            });
-        } else {
-            connectWireless(ssid, "", bssid, callback);
-        }
-    }
-
-    function connectToNetwork(ssid: string, password: string, bssid: string, callback: var): void {
-        connectWireless(ssid, password, bssid, callback);
-    }
-
-    function connectWireless(ssid: string, password: string, bssid: string, callback: var, retryCount: int): void {
-        const hasBssid = bssid !== undefined && bssid !== null && bssid.length > 0;
-        const retries = retryCount !== undefined ? retryCount : 0;
-        const maxRetries = 2;
-
-        if (callback) {
-            root.pendingConnection = {
-                ssid: ssid,
-                bssid: hasBssid ? bssid : "",
-                callback: callback,
-                retryCount: retries
-            };
-            connectionCheckTimer.start();
-            immediateCheckTimer.checkCount = 0;
-            immediateCheckTimer.start();
-        }
-
-        if (password && password.length > 0 && hasBssid) {
-            const bssidUpper = bssid.toUpperCase();
-            createConnectionWithPassword(ssid, bssidUpper, password, callback);
+    // Connects using whatever profile/secrets NetworkManager already has. Only
+    // valid for open networks or ones with a saved profile - a secured network
+    // without one needs connectToNetwork() with a password.
+    function connectToNetwork(ssid: string, password: string, security: string, callback: var): void {
+        if (password && password.length > 0) {
+            createConnectionWithPassword(ssid, password, security, callback);
             return;
         }
 
-        let cmd = [root.nmcliCommandDevice, root.nmcliCommandWifi, "connect", ssid];
-        if (password && password.length > 0) {
-            cmd.push(root.connectionParamPassword, password);
-        }
-        executeCommand(cmd, result => {
-            if (result.needsPassword && callback) {
-                if (callback)
-                    callback(result);
-                return;
-            }
-
-            if (!result.success && root.pendingConnection && retries < maxRetries) {
-                console.warn(lc, "Connection failed, retrying... (attempt " + (retries + 1) + "/" + maxRetries + ")");
-                Qt.callLater(() => {
-                    connectWireless(ssid, password, bssid, callback, retries + 1);
-                }, 1000);
-            } else if (!result.success && root.pendingConnection) {} else if (result.success && callback) {} else if (!result.success && !root.pendingConnection) {
-                if (callback)
-                    callback(result);
-            }
-        });
-    }
-
-    function createConnectionWithPassword(ssid: string, bssidUpper: string, password: string, callback: var): void {
-        checkAndDeleteConnection(ssid, () => {
-            const cmd = [root.nmcliCommandConnection, "add", root.connectionParamType, root.deviceTypeWifi, root.connectionParamConName, ssid, root.connectionParamIfname, "*", root.connectionParamSsid, ssid, root.connectionParamBssid, bssidUpper, root.securityKeyMgmt, root.keyMgmtWpaPsk, root.securityPsk, password];
-
-            executeCommand(cmd, result => {
-                if (result.success) {
-                    loadSavedConnections(() => {});
-                    activateConnection(ssid, callback);
-                } else {
-                    const hasDuplicateWarning = result.error && (result.error.includes("another connection with the name") || result.error.includes("Reference the connection by its uuid"));
-
-                    if (hasDuplicateWarning || (result.exitCode > 0 && result.exitCode < 10)) {
-                        loadSavedConnections(() => {});
-                        activateConnection(ssid, callback);
-                    } else {
-                        console.warn(lc, "Connection profile creation failed, trying fallback...");
-                        let fallbackCmd = [root.nmcliCommandDevice, root.nmcliCommandWifi, "connect", ssid, root.connectionParamPassword, password];
-                        executeCommand(fallbackCmd, fallbackResult => {
-                            if (callback)
-                                callback(fallbackResult);
-                        });
-                    }
-                }
-            });
-        });
-    }
-
-    function checkAndDeleteConnection(ssid: string, callback: var): void {
-        executeCommand([root.nmcliCommandConnection, "show", ssid], result => {
-            if (result.success) {
-                executeCommand([root.nmcliCommandConnection, "delete", ssid], deleteResult => {
-                    Qt.callLater(() => {
-                        if (callback)
-                            callback();
-                    }, 300);
-                });
-            } else {
-                if (callback)
-                    callback();
-            }
-        });
-    }
-
-    function activateConnection(connectionName: string, callback: var): void {
-        executeCommand([root.nmcliCommandConnection, "up", connectionName], result => {
+        executeCommand(["-w", root.activationTimeout, root.nmcliCommandDevice, root.nmcliCommandWifi, "connect", ssid], result => {
             if (callback)
                 callback(result);
         });
     }
 
-    function connectEnterpriseNetwork(ssid: string, bssid: string, params: var, callback: var): void {
-        executeCommand([root.nmcliCommandConnection, "show", ssid], showResult => {
-            const fields = ["802-1x.eap", params.eapMethod || "peap", "802-1x.identity", params.identity || "", "802-1x.anonymous-identity", params.anonymousIdentity || "", "802-1x.phase2-auth", params.phase2Method || "mschapv2", "802-1x.domain-suffix-match", params.domainSuffixMatch || "", "802-1x.system-ca-certs", params.verifyCert ? "yes" : "no", "wifi-sec.key-mgmt", "wpa-eap"];
+    // Writes the password into a profile, then activates it. The profile is
+    // created with autoconnect off and only promoted once activation actually
+    // succeeds, so a wrong password can never leave behind a profile that looks
+    // saved and that NetworkManager keeps retrying forever. An existing profile
+    // is modified rather than recreated, preserving its static IP/DNS settings,
+    // and is never deleted on failure.
+    function createConnectionWithPassword(ssid: string, password: string, security: string, callback: var): void {
+        const keyMgmt = keyMgmtForSecurity(security);
 
-            if (params.password && params.password.length > 0) {
-                fields.push("802-1x.password", params.password);
-            }
-            if (params.caCertPath && params.caCertPath.length > 0) {
-                fields.push("802-1x.ca-cert", params.caCertPath);
-            }
-
-            if (showResult.success) {
-                executeCommand([root.nmcliCommandConnection, "modify", ssid, ...fields], modifyResult => {
-                    if (!modifyResult.success) {
-                        if (callback)
-                            callback(modifyResult);
-                        return;
-                    }
-                    activateConnection(ssid, callback);
+        if (keyMgmt.length > 0 && !isValidPsk(password, keyMgmt)) {
+            if (callback)
+                callback({
+                    success: false,
+                    output: "",
+                    error: "Password must be between 8 and 63 characters",
+                    exitCode: -1,
+                    reason: "badPassword"
                 });
-            } else {
-                const addCmd = [root.nmcliCommandConnection, "add", root.connectionParamType, root.deviceTypeWifi, root.connectionParamConName, ssid, root.connectionParamIfname, "*", root.connectionParamSsid, ssid, ...fields];
-                if (bssid && bssid.length > 0) {
-                    addCmd.push(root.connectionParamBssid, bssid.toUpperCase());
+            return;
+        }
+
+        const finish = result => {
+            if (callback)
+                callback(Object.assign({}, result, {
+                    reason: failureReason(result)
+                }));
+        };
+
+        const secFields = keyMgmt === root.keyMgmtNone ? [root.securityKeyMgmt, root.keyMgmtNone, root.securityWepKey, password] : [root.securityKeyMgmt, keyMgmt, root.securityPsk, password];
+
+        executeCommand([root.nmcliCommandConnection, "show", ssid], existsResult => {
+            const createdNow = !existsResult.success;
+
+            const cmd = createdNow ? [root.nmcliCommandConnection, "add", root.connectionParamType, root.deviceTypeWifi, root.connectionParamConName, ssid, root.connectionParamIfname, "*", root.connectionParamSsid, ssid, root.connectionParamAutoconnect, "no", ...secFields] : [root.nmcliCommandConnection, "modify", ssid, ...secFields];
+
+            executeCommand(cmd, writeResult => {
+                if (!writeResult.success) {
+                    finish(writeResult);
+                    return;
                 }
 
-                executeCommand(addCmd, addResult => {
-                    if (!addResult.success) {
-                        if (callback)
-                            callback(addResult);
-                        return;
+                activateConnection(ssid, upResult => {
+                    if (upResult.success) {
+                        executeCommand([root.nmcliCommandConnection, "modify", ssid, root.connectionParamAutoconnect, "yes"], () => {
+                            loadSavedConnections(() => {});
+                            finish(upResult);
+                        });
+                    } else if (createdNow) {
+                        executeCommand([root.nmcliCommandConnection, "delete", ssid], () => {
+                            loadSavedConnections(() => {});
+                            finish(upResult);
+                        });
+                    } else {
+                        finish(upResult);
                     }
-                    activateConnection(ssid, callback);
                 });
-            }
+            });
         });
     }
 
-    function getEnterpriseConfig(connectionName: string, callback: var): void {
-        executeCommand(["-t", "-f", "802-1x.eap,802-1x.phase2-auth,802-1x.identity,802-1x.anonymous-identity,802-1x.domain-suffix-match,802-1x.ca-cert,802-1x.system-ca-certs", root.nmcliCommandConnection, "show", connectionName], result => {
-            if (!result.success) {
-                if (callback)
-                    callback(null);
-                return;
+    function connectEnterpriseNetwork(ssid: string, params: var, callback: var): void {
+        if (!ssid || ssid.length === 0) {
+            if (callback)
+                callback({
+                    success: false,
+                    output: "",
+                    error: "No SSID specified",
+                    exitCode: -1
+                });
+            return;
+        }
+
+        executeCommand([root.nmcliCommandConnection, "show", ssid], existsResult => {
+            const createdNow = !existsResult.success;
+
+            const eapMethod = (params.eapMethod || "peap").toLowerCase();
+            const fields = ["wifi-sec.key-mgmt", "wpa-eap", "802-1x.eap", eapMethod, "802-1x.identity", params.identity || ""];
+
+            if (eapMethod !== "tls") {
+                fields.push("802-1x.phase2-auth", params.phase2Method ? params.phase2Method.toLowerCase() : "mschapv2");
+            }
+            if (params.password) {
+                fields.push("802-1x.password", params.password);
+            }
+            fields.push("802-1x.anonymous-identity", params.anonymousIdentity || "");
+            fields.push("802-1x.domain-suffix-match", params.domainSuffixMatch || "");
+            if (params.caCertPath) {
+                fields.push("802-1x.ca-cert", params.caCertPath);
+                fields.push("802-1x.system-ca-certs", "no");
+            } else {
+                fields.push("802-1x.ca-cert", "");
+                fields.push("802-1x.system-ca-certs", params.verifyCert ? "yes" : "no");
             }
 
-            const cfg = {
-                eapMethod: "peap",
-                phase2Method: "mschapv2",
-                identity: "",
-                anonymousIdentity: "",
-                domainSuffixMatch: "",
-                caCertPath: ""
+            const finish = result => {
+                if (callback)
+                    callback(Object.assign({}, result, {
+                        reason: failureReason(result)
+                    }));
             };
 
-            const lines = result.output.trim().split("\n");
-            for (const line of lines) {
-                const idx = line.indexOf(":");
-                if (idx < 0)
-                    continue;
-                const key = line.slice(0, idx).trim();
-                const value = line.slice(idx + 1).trim();
+            const cmd = createdNow ? [root.nmcliCommandConnection, "add", root.connectionParamType, root.deviceTypeWifi, root.connectionParamConName, ssid, root.connectionParamIfname, "*", root.connectionParamSsid, ssid, root.connectionParamAutoconnect, "no", ...fields] : [root.nmcliCommandConnection, "modify", ssid, ...fields];
 
-                if (value === "" || value === "--")
-                    continue;
+            executeCommand(cmd, writeResult => {
+                if (!writeResult.success) {
+                    finish(writeResult);
+                    return;
+                }
 
-                if (key === "802-1x.eap")
-                    cfg.eapMethod = value.split(",")[0].trim();
-                else if (key === "802-1x.phase2-auth")
-                    cfg.phase2Method = value;
-                else if (key === "802-1x.identity")
-                    cfg.identity = value;
-                else if (key === "802-1x.anonymous-identity")
-                    cfg.anonymousIdentity = value;
-                else if (key === "802-1x.domain-suffix-match")
-                    cfg.domainSuffixMatch = value;
-                else if (key === "802-1x.ca-cert")
-                    cfg.caCertPath = value;
-            }
+                activateConnection(ssid, upResult => {
+                    if (upResult.success) {
+                        executeCommand([root.nmcliCommandConnection, "modify", ssid, root.connectionParamAutoconnect, "yes"], () => {
+                            loadSavedConnections(() => {});
+                            finish(upResult);
+                        });
+                    } else if (createdNow) {
+                        executeCommand([root.nmcliCommandConnection, "delete", ssid], () => {
+                            loadSavedConnections(() => {});
+                            finish(upResult);
+                        });
+                    } else {
+                        finish(upResult);
+                    }
+                });
+            });
+        });
+    }
 
+    // nmcli blocks until the activation resolves, so the exit code here is the
+    // real answer - no polling or timers needed.
+    function activateConnection(connectionName: string, callback: var): void {
+        executeCommand(["-w", root.activationTimeout, root.nmcliCommandConnection, "up", connectionName], result => {
             if (callback)
-                callback(cfg);
+                callback(result);
         });
     }
 
@@ -668,13 +641,6 @@ Singleton {
         }
         const ssidLower = ssid.toLowerCase().trim();
 
-        if (root.active && root.active.ssid) {
-            const activeSsidLower = root.active.ssid.toLowerCase().trim();
-            if (activeSsidLower === ssidLower) {
-                return true;
-            }
-        }
-
         const hasSsid = root.savedConnectionSsids.some(savedSsid => savedSsid && savedSsid.toLowerCase().trim() === ssidLower);
 
         if (hasSsid) {
@@ -698,13 +664,17 @@ Singleton {
             return;
         }
 
-        const connectionName = root.savedConnections.find(conn => conn && conn.toLowerCase().trim() === ssid.toLowerCase().trim()) || ssid;
+        const ssidLower = ssid.toLowerCase().trim();
+        const connectionName = root.savedConnections.find(conn => conn && conn.toLowerCase().trim() === ssidLower) || ssid;
 
         executeCommand([root.nmcliCommandConnection, "delete", connectionName], result => {
             if (result.success) {
-                Qt.callLater(() => {
-                    loadSavedConnections(() => {});
-                }, 500);
+                // Drop it locally before reloading: NetworkManager takes a moment
+                // to propagate the removal, and reading back too early leaves the
+                // network still showing as saved.
+                root.savedConnections = root.savedConnections.filter(conn => conn !== connectionName);
+                root.savedConnectionSsids = root.savedConnectionSsids.filter(s => s.toLowerCase().trim() !== ssidLower);
+                loadSavedConnections(() => {});
             }
             if (callback)
                 callback(result);
@@ -725,20 +695,16 @@ Singleton {
         }
     }
 
-    function disconnectFromNetwork(): void {
-        if (active && active.ssid) {
-            executeCommand([root.nmcliCommandConnection, "down", active.ssid], result => {
-                if (result.success) {
-                    getNetworks(() => {});
-                }
-            });
-        } else {
-            executeCommand([root.nmcliCommandDevice, "disconnect", root.deviceTypeWifi], result => {
-                if (result.success) {
-                    getNetworks(() => {});
-                }
-            });
-        }
+    function disconnectFromNetwork(callback: var): void {
+        const cmd = active && active.ssid ? [root.nmcliCommandConnection, "down", active.ssid] : [root.nmcliCommandDevice, "disconnect", root.deviceTypeWifi];
+
+        executeCommand(cmd, result => {
+            if (result.success) {
+                getNetworks(() => {});
+            }
+            if (callback)
+                callback(result);
+        });
     }
 
     function getDeviceDetails(interfaceName: string, callback: var): void {
@@ -910,7 +876,6 @@ Singleton {
 
             if (callback)
                 callback(root.networks);
-            checkPendingConnection();
         });
     }
 
@@ -959,69 +924,6 @@ Singleton {
             if (callback)
                 callback(ssids);
         });
-    }
-
-    function handlePasswordRequired(proc: var, error: string, output: string, exitCode: int): bool {
-        if (!proc || !error || error.length === 0) {
-            return false;
-        }
-
-        if (!isConnectionCommand(proc.cmdArgs) || !root.pendingConnection || !root.pendingConnection.callback) {
-            return false;
-        }
-
-        const needsPassword = detectPasswordRequired(error);
-
-        if (needsPassword && !proc.callbackCalled && root.pendingConnection) {
-            connectionCheckTimer.stop();
-            immediateCheckTimer.stop();
-            immediateCheckTimer.checkCount = 0;
-            const pending = root.pendingConnection;
-            root.pendingConnection = null;
-            proc.callbackCalled = true;
-            const result = {
-                success: false,
-                output: output || "",
-                error: error,
-                exitCode: exitCode,
-                needsPassword: true
-            };
-            if (pending.callback) {
-                pending.callback(result);
-            }
-            if (proc.callback && proc.callback !== pending.callback) {
-                proc.callback(result);
-            }
-            return true;
-        }
-
-        return false;
-    }
-
-    function checkPendingConnection(): void {
-        if (root.pendingConnection) {
-            Qt.callLater(() => {
-                const connected = root.active && root.active.ssid === root.pendingConnection.ssid;
-                if (connected) {
-                    connectionCheckTimer.stop();
-                    immediateCheckTimer.stop();
-                    immediateCheckTimer.checkCount = 0;
-                    if (root.pendingConnection.callback) {
-                        root.pendingConnection.callback({
-                            success: true,
-                            output: "Connected",
-                            error: "",
-                            exitCode: 0
-                        });
-                    }
-                    root.pendingConnection = null;
-                } else {
-                    if (!immediateCheckTimer.running) {
-                        immediateCheckTimer.start();
-                    }
-                }
-            });
-        }
     }
 
     function cidrToSubnetMask(cidr: string): string {
@@ -1122,6 +1024,62 @@ Singleton {
             // Distinguish "automatic + custom DNS only" from plain DHCP.
             if (cfg.method === "auto" && cfg.ignoreAutoDns)
                 cfg.method = "auto-dns";
+
+            if (callback)
+                callback(cfg);
+        });
+    }
+
+    function getEnterpriseConfig(connectionName: string, callback: var): void {
+        if (!connectionName || connectionName.length === 0) {
+            if (callback)
+                callback(null);
+            return;
+        }
+
+        executeCommand(["-t", "-f", "802-1x.eap,802-1x.phase2-auth,802-1x.identity,802-1x.anonymous-identity,802-1x.domain-suffix-match,802-1x.ca-cert,802-1x.system-ca-certs", root.nmcliCommandConnection, "show", connectionName], result => {
+            if (!result.success) {
+                if (callback)
+                    callback(null);
+                return;
+            }
+
+            const cfg = {
+                eapMethod: "peap",
+                phase2Method: "mschapv2",
+                identity: "",
+                anonymousIdentity: "",
+                domainSuffixMatch: "",
+                caCertPath: "",
+                verifyCert: true
+            };
+
+            const lines = result.output.trim().split("\n");
+            for (const line of lines) {
+                const idx = line.indexOf(":");
+                if (idx < 0)
+                    continue;
+                const key = line.slice(0, idx).trim();
+                const value = line.slice(idx + 1).trim();
+
+                if (value === "" || value === "--")
+                    continue;
+
+                if (key === "802-1x.eap")
+                    cfg.eapMethod = value.split(",")[0].trim();
+                else if (key === "802-1x.phase2-auth")
+                    cfg.phase2Method = value;
+                else if (key === "802-1x.identity")
+                    cfg.identity = value;
+                else if (key === "802-1x.anonymous-identity")
+                    cfg.anonymousIdentity = value;
+                else if (key === "802-1x.domain-suffix-match")
+                    cfg.domainSuffixMatch = value;
+                else if (key === "802-1x.ca-cert")
+                    cfg.caCertPath = value;
+                else if (key === "802-1x.system-ca-certs")
+                    cfg.verifyCert = value === "yes";
+            }
 
             if (callback)
                 callback(cfg);
@@ -1325,7 +1283,7 @@ Singleton {
                             getEthernetDeviceDetails(activeEthernet.device, () => {});
                         }
                     }
-                }, 500);
+                });
             } else {
                 root.wirelessDeviceDetails = null;
                 root.ethernetDeviceDetails = null;
@@ -1336,7 +1294,7 @@ Singleton {
                 if (root.activeEthernet && root.activeEthernet.connected) {
                     Qt.callLater(() => {
                         getEthernetDeviceDetails(root.activeEthernet.iface, () => {});
-                    }, 500);
+                    });
                 }
             });
         });
@@ -1346,27 +1304,9 @@ Singleton {
         getWifiStatus(() => {});
         getNetworks(() => {});
         loadSavedConnections(() => {});
+        getWirelessInterfaces(() => {});
         getEthernetInterfaces(() => {});
-
-        Qt.callLater(() => {
-            if (root.wirelessInterfaces.length > 0) {
-                const activeWireless = root.wirelessInterfaces.find(iface => {
-                    return isConnectedState(iface.state);
-                });
-                if (activeWireless && activeWireless.device) {
-                    getWirelessDeviceDetails(activeWireless.device, () => {});
-                }
-            }
-
-            if (root.ethernetInterfaces.length > 0) {
-                const activeEthernet = root.ethernetInterfaces.find(iface => {
-                    return isConnectedState(iface.state);
-                });
-                if (activeEthernet && activeEthernet.device) {
-                    getEthernetDeviceDetails(activeEthernet.device, () => {});
-                }
-            }
-        }, 2000);
+        initDetailsTimer.start();
     }
 
     Component {
@@ -1388,145 +1328,18 @@ Singleton {
     }
 
     Timer {
-        id: connectionCheckTimer
+        id: initDetailsTimer
 
-        interval: 4000
+        interval: 2000
         onTriggered: {
-            if (root.pendingConnection) {
-                const connected = root.active && root.active.ssid === root.pendingConnection.ssid;
-
-                if (!connected && root.pendingConnection.callback) {
-                    let foundPasswordError = false;
-                    for (let i = 0; i < root.activeProcesses.length; i++) {
-                        const proc = root.activeProcesses[i];
-                        if (proc && proc.stderr && proc.stderr.text) {
-                            const error = proc.stderr.text.trim();
-                            if (error && error.length > 0) {
-                                if (root.isConnectionCommand(proc.cmdArgs)) {
-                                    const needsPassword = root.detectPasswordRequired(error);
-
-                                    if (needsPassword && !proc.callbackCalled && root.pendingConnection) {
-                                        const pending = root.pendingConnection;
-                                        root.pendingConnection = null;
-                                        immediateCheckTimer.stop();
-                                        immediateCheckTimer.checkCount = 0;
-                                        proc.callbackCalled = true;
-                                        const result = {
-                                            success: false,
-                                            output: (proc.stdout && proc.stdout.text) ? proc.stdout.text : "",
-                                            error: error,
-                                            exitCode: -1,
-                                            needsPassword: true
-                                        };
-                                        if (pending.callback) {
-                                            pending.callback(result);
-                                        }
-                                        if (proc.callback && proc.callback !== pending.callback) {
-                                            proc.callback(result);
-                                        }
-                                        foundPasswordError = true;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    if (!foundPasswordError) {
-                        const pending = root.pendingConnection;
-                        const failedSsid = pending.ssid;
-                        root.pendingConnection = null;
-                        immediateCheckTimer.stop();
-                        immediateCheckTimer.checkCount = 0;
-                        root.connectionFailed(failedSsid);
-                        pending.callback({
-                            success: false,
-                            output: "",
-                            error: "Connection timeout",
-                            exitCode: -1,
-                            needsPassword: false
-                        });
-                    }
-                } else if (connected) {
-                    root.pendingConnection = null;
-                    immediateCheckTimer.stop();
-                    immediateCheckTimer.checkCount = 0;
-                }
+            const activeWireless = root.wirelessInterfaces.find(iface => root.isConnectedState(iface.state));
+            if (activeWireless && activeWireless.device) {
+                root.getWirelessDeviceDetails(activeWireless.device, () => {});
             }
-        }
-    }
 
-    Timer {
-        id: immediateCheckTimer
-
-        property int checkCount: 0
-
-        interval: 500
-        repeat: true
-        triggeredOnStart: false
-
-        onTriggered: {
-            if (root.pendingConnection) {
-                checkCount++;
-                const connected = root.active && root.active.ssid === root.pendingConnection.ssid;
-
-                if (connected) {
-                    connectionCheckTimer.stop();
-                    immediateCheckTimer.stop();
-                    immediateCheckTimer.checkCount = 0;
-                    if (root.pendingConnection.callback) {
-                        root.pendingConnection.callback({
-                            success: true,
-                            output: "Connected",
-                            error: "",
-                            exitCode: 0
-                        });
-                    }
-                    root.pendingConnection = null;
-                } else {
-                    for (let i = 0; i < root.activeProcesses.length; i++) {
-                        const proc = root.activeProcesses[i];
-                        if (proc && proc.stderr && proc.stderr.text) {
-                            const error = proc.stderr.text.trim();
-                            if (error && error.length > 0) {
-                                if (root.isConnectionCommand(proc.cmdArgs)) {
-                                    const needsPassword = root.detectPasswordRequired(error);
-
-                                    if (needsPassword && !proc.callbackCalled && root.pendingConnection && root.pendingConnection.callback) {
-                                        connectionCheckTimer.stop();
-                                        immediateCheckTimer.stop();
-                                        immediateCheckTimer.checkCount = 0;
-                                        const pending = root.pendingConnection;
-                                        root.pendingConnection = null;
-                                        proc.callbackCalled = true;
-                                        const result = {
-                                            success: false,
-                                            output: (proc.stdout && proc.stdout.text) ? proc.stdout.text : "",
-                                            error: error,
-                                            exitCode: -1,
-                                            needsPassword: true
-                                        };
-                                        if (pending.callback) {
-                                            pending.callback(result);
-                                        }
-                                        if (proc.callback && proc.callback !== pending.callback) {
-                                            proc.callback(result);
-                                        }
-                                        return;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    if (checkCount >= 6) {
-                        immediateCheckTimer.stop();
-                        immediateCheckTimer.checkCount = 0;
-                    }
-                }
-            } else {
-                immediateCheckTimer.stop();
-                immediateCheckTimer.checkCount = 0;
+            const activeEthernet = root.ethernetInterfaces.find(iface => root.isConnectedState(iface.state));
+            if (activeEthernet && activeEthernet.device) {
+                root.getEthernetDeviceDetails(activeEthernet.device, () => {});
             }
         }
     }
@@ -1603,20 +1416,11 @@ Singleton {
         }
     }
 
-    LoggingCategory {
-        id: lc
-
-        name: "caelestia.qml.services.nmcli"
-        defaultLogLevel: LoggingCategory.Info
-    }
-
     component CommandProcess: Process {
         id: proc
 
         property var callback: null
         property list<string> cmdArgs: []
-        property bool callbackCalled: false
-        property int exitCode: 0
 
         signal processFinished
 
@@ -1631,55 +1435,19 @@ Singleton {
 
         stderr: StdioCollector {
             id: stderrCollector
-
-            onStreamFinished: {
-                const error = text.trim();
-                if (error && error.length > 0) {
-                    const output = (stdoutCollector && stdoutCollector.text) ? stdoutCollector.text : "";
-                    root.handlePasswordRequired(proc, error, output, -1);
-                }
-            }
         }
 
         onExited: code => { // qmllint disable signal-handler-parameters
-            exitCode = code;
-
             Qt.callLater(() => {
-                if (callbackCalled) {
-                    processFinished();
-                    return;
-                }
-
                 if (proc.callback) {
-                    const output = (stdoutCollector && stdoutCollector.text) ? stdoutCollector.text : "";
-                    const error = (stderrCollector && stderrCollector.text) ? stderrCollector.text : "";
-                    const success = exitCode === 0;
-                    const cmdIsConnection = isConnectionCommand(proc.cmdArgs);
-
-                    if (root.handlePasswordRequired(proc, error, output, exitCode)) {
-                        processFinished();
-                        return;
-                    }
-
-                    const needsPassword = cmdIsConnection && root.detectPasswordRequired(error);
-
-                    if (!success && cmdIsConnection && root.pendingConnection) {
-                        const failedSsid = root.pendingConnection.ssid;
-                        root.connectionFailed(failedSsid);
-                    }
-
-                    callbackCalled = true;
-                    callback({
-                        success: success,
-                        output: output,
-                        error: error,
-                        exitCode: proc.exitCode,
-                        needsPassword: needsPassword || false
+                    proc.callback({
+                        success: code === 0,
+                        output: (stdoutCollector && stdoutCollector.text) ? stdoutCollector.text : "",
+                        error: (stderrCollector && stderrCollector.text) ? stderrCollector.text : "",
+                        exitCode: code
                     });
-                    processFinished();
-                } else {
-                    processFinished();
                 }
+                proc.processFinished();
             });
         }
     }

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -493,6 +493,91 @@ Singleton {
         });
     }
 
+    function connectEnterpriseNetwork(ssid: string, bssid: string, params: var, callback: var): void {
+        executeCommand([root.nmcliCommandConnection, "show", ssid], showResult => {
+            const fields = ["802-1x.eap", params.eapMethod || "peap", "802-1x.identity", params.identity || "", "802-1x.anonymous-identity", params.anonymousIdentity || "", "802-1x.phase2-auth", params.phase2Method || "mschapv2", "802-1x.domain-suffix-match", params.domainSuffixMatch || "", "802-1x.system-ca-certs", params.verifyCert ? "yes" : "no", "wifi-sec.key-mgmt", "wpa-eap"];
+
+            if (params.password && params.password.length > 0) {
+                fields.push("802-1x.password", params.password);
+            }
+            if (params.caCertPath && params.caCertPath.length > 0) {
+                fields.push("802-1x.ca-cert", params.caCertPath);
+            }
+
+            if (showResult.success) {
+                executeCommand([root.nmcliCommandConnection, "modify", ssid, ...fields], modifyResult => {
+                    if (!modifyResult.success) {
+                        if (callback)
+                            callback(modifyResult);
+                        return;
+                    }
+                    activateConnection(ssid, callback);
+                });
+            } else {
+                const addCmd = [root.nmcliCommandConnection, "add", root.connectionParamType, root.deviceTypeWifi, root.connectionParamConName, ssid, root.connectionParamIfname, "*", root.connectionParamSsid, ssid, ...fields];
+                if (bssid && bssid.length > 0) {
+                    addCmd.push(root.connectionParamBssid, bssid.toUpperCase());
+                }
+
+                executeCommand(addCmd, addResult => {
+                    if (!addResult.success) {
+                        if (callback)
+                            callback(addResult);
+                        return;
+                    }
+                    activateConnection(ssid, callback);
+                });
+            }
+        });
+    }
+
+    function getEnterpriseConfig(connectionName: string, callback: var): void {
+        executeCommand(["-t", "-f", "802-1x.eap,802-1x.phase2-auth,802-1x.identity,802-1x.anonymous-identity,802-1x.domain-suffix-match,802-1x.ca-cert,802-1x.system-ca-certs", root.nmcliCommandConnection, "show", connectionName], result => {
+            if (!result.success) {
+                if (callback)
+                    callback(null);
+                return;
+            }
+
+            const cfg = {
+                eapMethod: "peap",
+                phase2Method: "mschapv2",
+                identity: "",
+                anonymousIdentity: "",
+                domainSuffixMatch: "",
+                caCertPath: ""
+            };
+
+            const lines = result.output.trim().split("\n");
+            for (const line of lines) {
+                const idx = line.indexOf(":");
+                if (idx < 0)
+                    continue;
+                const key = line.slice(0, idx).trim();
+                const value = line.slice(idx + 1).trim();
+
+                if (value === "" || value === "--")
+                    continue;
+
+                if (key === "802-1x.eap")
+                    cfg.eapMethod = value.split(",")[0].trim();
+                else if (key === "802-1x.phase2-auth")
+                    cfg.phase2Method = value;
+                else if (key === "802-1x.identity")
+                    cfg.identity = value;
+                else if (key === "802-1x.anonymous-identity")
+                    cfg.anonymousIdentity = value;
+                else if (key === "802-1x.domain-suffix-match")
+                    cfg.domainSuffixMatch = value;
+                else if (key === "802-1x.ca-cert")
+                    cfg.caCertPath = value;
+            }
+
+            if (callback)
+                callback(cfg);
+        });
+    }
+
     function loadSavedConnections(callback: var): void {
         executeCommand(["-t", "-f", root.connectionListFields, root.nmcliCommandConnection, "show"], result => {
             if (!result.success) {
@@ -1608,6 +1693,7 @@ Singleton {
         readonly property bool active: lastIpcObject.active
         readonly property string security: lastIpcObject.security
         readonly property bool isSecure: security.length > 0
+        readonly property bool isEnterprise: security.includes("802.1X")
     }
 
     component EthernetDevice: QtObject {

--- a/utils/NetworkConnection.qml
+++ b/utils/NetworkConnection.qml
@@ -36,8 +36,10 @@ QtObject {
      * @param network The network object to connect to (must have ssid property)
      * @param session Optional Session object (for controlcenter - must have network property with showPasswordDialog and pendingNetwork)
      * @param onPasswordNeeded Optional callback function(network) called when password is needed (for bar popouts)
+     * @param onEnterpriseNeeded Optional callback function(network) called when the network is WPA/WPA2/WPA3-Enterprise
+     *        (802.1X, e.g. eduroam) and has no saved profile
      */
-    function handleConnect(network, session, onPasswordNeeded): void {
+    function handleConnect(network, session, onPasswordNeeded, onEnterpriseNeeded): void {
         if (!network) {
             return;
         }
@@ -45,23 +47,24 @@ QtObject {
         if (Nmcli.active && Nmcli.active.ssid !== network.ssid) {
             Nmcli.disconnectFromNetwork();
             Qt.callLater(() => {
-                root.connectToNetwork(network, session, onPasswordNeeded);
+                root.connectToNetwork(network, session, onPasswordNeeded, onEnterpriseNeeded);
             });
         } else {
-            root.connectToNetwork(network, session, onPasswordNeeded);
+            root.connectToNetwork(network, session, onPasswordNeeded, onEnterpriseNeeded);
         }
     }
 
     /**
      * Connect to a wireless network.
      * Handles both secured and open networks, checks for saved profiles,
-     * and shows password dialog if needed.
+     * and shows password/enterprise-credentials dialog if needed.
      *
-     * @param network The network object to connect to (must have ssid, isSecure, bssid properties)
+     * @param network The network object to connect to (must have ssid, isSecure, isEnterprise, bssid properties)
      * @param session Optional Session object (for controlcenter - must have network property with showPasswordDialog and pendingNetwork)
      * @param onPasswordNeeded Optional callback function(network) called when password is needed (for bar popouts)
+     * @param onEnterpriseNeeded Optional callback function(network) called when 802.1X credentials are needed
      */
-    function connectToNetwork(network, session, onPasswordNeeded): void {
+    function connectToNetwork(network, session, onPasswordNeeded, onEnterpriseNeeded): void {
         if (!network) {
             return;
         }
@@ -71,6 +74,10 @@ QtObject {
 
             if (hasSavedProfile) {
                 Nmcli.connectToNetwork(network.ssid, "", network.bssid, null);
+            } else if (network.isEnterprise) {
+                if (onEnterpriseNeeded) {
+                    onEnterpriseNeeded(network);
+                }
             } else {
                 // Use password check with callback
                 Nmcli.connectToNetworkWithPasswordCheck(network.ssid, network.isSecure, result => {
@@ -112,5 +119,22 @@ QtObject {
         }
 
         Nmcli.connectToNetwork(network.ssid, password || "", network.bssid || "", onResult || null);
+    }
+
+    /**
+     * Connect to a WPA/WPA2/WPA3-Enterprise (802.1X) network with the given credentials.
+     * Used by the enterprise credentials page once the user has filled in identity,
+     * password, EAP method and any advanced options.
+     *
+     * @param network The network object to connect to (must have ssid, bssid properties)
+     * @param params { identity, password, eapMethod, phase2Method, anonymousIdentity, domainSuffixMatch, caCertPath, verifyCert }
+     * @param onResult Optional callback function(result) called with connection result
+     */
+    function connectWithEnterpriseCredentials(network, params, onResult): void {
+        if (!network) {
+            return;
+        }
+
+        Nmcli.connectEnterpriseNetwork(network.ssid, network.bssid || "", params || {}, onResult || null);
     }
 }

--- a/utils/NetworkConnection.qml
+++ b/utils/NetworkConnection.qml
@@ -37,7 +37,7 @@ QtObject {
      * @param session Optional Session object (for controlcenter - must have network property with showPasswordDialog and pendingNetwork)
      * @param onPasswordNeeded Optional callback function(network) called when password is needed (for bar popouts)
      * @param onEnterpriseNeeded Optional callback function(network) called when the network is WPA/WPA2/WPA3-Enterprise
-     *        (802.1X, e.g. eduroam) and has no saved profile
+     *        (802.1X, e.g. eduroam) and has no saved profile — a plain password won't work, an identity + EAP method is needed.
      */
     function handleConnect(network, session, onPasswordNeeded, onEnterpriseNeeded): void {
         if (!network) {
@@ -45,8 +45,7 @@ QtObject {
         }
 
         if (Nmcli.active && Nmcli.active.ssid !== network.ssid) {
-            Nmcli.disconnectFromNetwork();
-            Qt.callLater(() => {
+            Nmcli.disconnectFromNetwork(() => {
                 root.connectToNetwork(network, session, onPasswordNeeded, onEnterpriseNeeded);
             });
         } else {
@@ -69,39 +68,20 @@ QtObject {
             return;
         }
 
-        if (network.isSecure) {
-            const hasSavedProfile = Nmcli.hasSavedProfile(network.ssid);
-
-            if (hasSavedProfile) {
-                Nmcli.connectToNetwork(network.ssid, "", network.bssid, null);
-            } else if (network.isEnterprise) {
-                if (onEnterpriseNeeded) {
-                    onEnterpriseNeeded(network);
-                }
-            } else {
-                // Use password check with callback
-                Nmcli.connectToNetworkWithPasswordCheck(network.ssid, network.isSecure, result => {
-                    if (result.needsPassword) {
-                        // Clear pending connection if exists
-                        if (Nmcli.pendingConnection) {
-                            Nmcli.connectionCheckTimer.stop();
-                            Nmcli.immediateCheckTimer.stop();
-                            Nmcli.immediateCheckTimer.checkCount = 0;
-                            Nmcli.pendingConnection = null;
-                        }
-
-                        // Handle password dialog - use session if available, otherwise use callback
-                        if (session && session.network) {
-                            session.network.showPasswordDialog = true;
-                            session.network.pendingNetwork = network;
-                        } else if (onPasswordNeeded) {
-                            onPasswordNeeded(network);
-                        }
-                    }
-                }, network.bssid);
+        if (!network.isSecure || Nmcli.hasSavedProfile(network.ssid)) {
+            // Open, or NetworkManager already holds the secrets.
+            Nmcli.connectToNetwork(network.ssid, "", network.security, null);
+        } else if (network.isEnterprise) {
+            // 802.1X networks (eduroam, corp Wi-Fi) need an identity + EAP
+            // method, not a plain PSK.
+            if (onEnterpriseNeeded) {
+                onEnterpriseNeeded(network);
             }
-        } else {
-            Nmcli.connectToNetwork(network.ssid, "", network.bssid, null);
+        } else if (session && session.network) {
+            session.network.showPasswordDialog = true;
+            session.network.pendingNetwork = network;
+        } else if (onPasswordNeeded) {
+            onPasswordNeeded(network);
         }
     }
 
@@ -118,12 +98,12 @@ QtObject {
             return;
         }
 
-        Nmcli.connectToNetwork(network.ssid, password || "", network.bssid || "", onResult || null);
+        Nmcli.connectToNetwork(network.ssid, password || "", network.security || "", onResult || null);
     }
 
     /**
      * Connect to a WPA/WPA2/WPA3-Enterprise (802.1X) network with the given credentials.
-     * Used by the enterprise credentials page once the user has filled in identity,
+     * Used by the enterprise credentials dialog/page once the user has filled in identity,
      * password, EAP method and any advanced options.
      *
      * @param network The network object to connect to (must have ssid, bssid properties)
@@ -135,6 +115,6 @@ QtObject {
             return;
         }
 
-        Nmcli.connectEnterpriseNetwork(network.ssid, network.bssid || "", params || {}, onResult || null);
+        Nmcli.connectEnterpriseNetwork(network.ssid, params || {}, onResult || null);
     }
 }


### PR DESCRIPTION
Adds WPA/WPA2/WPA3-Enterprise (802.1X, e.g. eduroam, corporate Wi-Fi) support: a dedicated Nexus settings sub-page for identity/EAP credentials, plus a compact matching credentials popout in the bar's quick-access menu, since these networks can't be connected to with a plain PSK.

Adds disconnect/forget actions for saved Wi-Fi profiles, in both the Network settings page and the bar's quick-access popout. Saved networks get a distinct filled lock icon and sort above unsaved ones in the popout.

Redesigns the popout's connect/forget and rescan/settings controls as single segmented pills instead of loose bolted-on icons/stacked buttons, and gives the connected row a persistent tinted background.

Fixes a bug where clicking an unsaved secured network on the settings page silently failed instead of prompting for a password.

<img width="578" height="522" alt="swappy-20260708_160525" src="https://github.com/user-attachments/assets/7cfe76de-2908-47e0-b0fb-6ae45e963e01" />
<img width="556" height="441" alt="swappy-20260708_160604" src="https://github.com/user-attachments/assets/f0535d45-e57f-432f-b3b8-de3f6f9d9aac" />
<img width="890" height="750" alt="swappy-20260708_160835" src="https://github.com/user-attachments/assets/0d8da325-3b70-42b7-a085-959b889204a1" />
<img width="1038" height="776" alt="swappy-20260708_160913" src="https://github.com/user-attachments/assets/0c0fe1b3-8227-4733-ab50-92f76cbe4b4a" />
