### PR TITLE
fix(launcher): restore launcher action filtering

### DIFF
--- a/modules/launcher/AppList.qml
+++ b/modules/launcher/AppList.qml
@@ -16,8 +16,27 @@ StyledListView {
     required property SearchBar search
     required property ScreenState screenState
 
+    property string modelState: "apps"
+
     model: ScriptModel {
         id: model
+
+        // qmllint disable incompatible-type
+        values: {
+            switch (root.modelState) {
+            case "actions":
+                return Actions.query(root.search.text);
+            case "calc":
+                return [0];
+            case "scheme":
+                return Schemes.query(root.search.text);
+            case "variant":
+                return M3Variants.query(root.search.text);
+            default:
+                return Apps.search(root.search.text);
+            }
+        }
+        // qmllint enable incompatible-type
 
         onValuesChanged: root.currentIndex = 0
     }
@@ -69,7 +88,7 @@ StyledListView {
             name: "apps"
 
             PropertyChanges {
-                model.values: Apps.search(search.text)
+                root.modelState: "apps"
                 root.delegate: appItem
             }
         },
@@ -77,7 +96,7 @@ StyledListView {
             name: "actions"
 
             PropertyChanges {
-                model.values: Actions.query(search.text)
+                root.modelState: "actions"
                 root.delegate: actionItem
             }
         },
@@ -85,7 +104,7 @@ StyledListView {
             name: "calc"
 
             PropertyChanges {
-                model.values: [0]
+                root.modelState: "calc"
                 root.delegate: calcItem
             }
         },
@@ -93,7 +112,7 @@ StyledListView {
             name: "scheme"
 
             PropertyChanges {
-                model.values: Schemes.query(search.text)
+                root.modelState: "scheme"
                 root.delegate: schemeItem
             }
         },
@@ -101,7 +120,7 @@ StyledListView {
             name: "variant"
 
             PropertyChanges {
-                model.values: M3Variants.query(search.text)
+                root.modelState: "variant"
                 root.delegate: variantItem
             }
         }
@@ -128,8 +147,8 @@ StyledListView {
                 }
             }
             PropertyAction {
-                targets: [model, root]
-                properties: "values,delegate"
+                target: root
+                properties: "modelState,delegate"
             }
             ParallelAnimation {
                 Anim {

--- a/modules/launcher/AppList.qml
+++ b/modules/launcher/AppList.qml
@@ -16,7 +16,7 @@ StyledListView {
     required property SearchBar search
     required property ScreenState screenState
 
-    property string displayText: search.text
+    property string displayText
 
     readonly property string requestedState: stateForText(search.text)
     readonly property string displayState: stateForText(displayText)
@@ -39,7 +39,7 @@ StyledListView {
         return "apps";
     }
 
-    function resultsForText(text: string): list<var> {
+    function resultsForText(text: string): var {
         switch (stateForText(text)) {
         case "actions":
             return Actions.query(text);
@@ -55,7 +55,7 @@ StyledListView {
     }
 
     model: ScriptModel {
-        values: [...root.resultsForText(root.displayText)]
+        values: root.resultsForText(root.displayText)
         onValuesChanged: root.currentIndex = 0
     }
 

--- a/modules/launcher/AppList.qml
+++ b/modules/launcher/AppList.qml
@@ -16,28 +16,46 @@ StyledListView {
     required property SearchBar search
     required property ScreenState screenState
 
-    property string modelState: "apps"
+    property string displayText: search.text
+
+    readonly property string requestedState: stateForText(search.text)
+    readonly property string displayState: stateForText(displayText)
+
+    function syncDisplayText(): void {
+        if (screenState.launcher && requestedState === displayState)
+            displayText = search.text;
+    }
+
+    function stateForText(text: string): string {
+        const prefix = GlobalConfig.launcher.actionPrefix;
+        if (text.startsWith(prefix)) {
+            for (const action of ["calc", "scheme", "variant"])
+                if (text.startsWith(`${prefix}${action} `))
+                    return action;
+
+            return "actions";
+        }
+
+        return "apps";
+    }
+
+    function resultsForText(text: string): list<var> {
+        switch (stateForText(text)) {
+        case "actions":
+            return Actions.query(text);
+        case "calc":
+            return [0];
+        case "scheme":
+            return Schemes.query(text);
+        case "variant":
+            return M3Variants.query(text);
+        default:
+            return Apps.search(text);
+        }
+    }
 
     model: ScriptModel {
-        id: model
-
-        // qmllint disable incompatible-type
-        values: {
-            switch (root.modelState) {
-            case "actions":
-                return Actions.query(root.search.text);
-            case "calc":
-                return [0];
-            case "scheme":
-                return Schemes.query(root.search.text);
-            case "variant":
-                return M3Variants.query(root.search.text);
-            default:
-                return Apps.search(root.search.text);
-            }
-        }
-        // qmllint enable incompatible-type
-
+        values: [...root.resultsForText(root.displayText)]
         onValuesChanged: root.currentIndex = 0
     }
 
@@ -64,31 +82,20 @@ StyledListView {
         }
     }
 
-    state: {
-        const text = search.text;
-        const prefix = GlobalConfig.launcher.actionPrefix;
-        if (text.startsWith(prefix)) {
-            for (const action of ["calc", "scheme", "variant"])
-                if (text.startsWith(`${prefix}${action} `))
-                    return action;
-
-            return "actions";
-        }
-
-        return "apps";
-    }
+    state: screenState.launcher ? requestedState : displayState
 
     onStateChanged: {
         if (state === "scheme" || state === "variant")
             Schemes.reload();
     }
 
+    Component.onCompleted: displayText = search.text
+
     states: [
         State {
             name: "apps"
 
             PropertyChanges {
-                root.modelState: "apps"
                 root.delegate: appItem
             }
         },
@@ -96,7 +103,6 @@ StyledListView {
             name: "actions"
 
             PropertyChanges {
-                root.modelState: "actions"
                 root.delegate: actionItem
             }
         },
@@ -104,7 +110,6 @@ StyledListView {
             name: "calc"
 
             PropertyChanges {
-                root.modelState: "calc"
                 root.delegate: calcItem
             }
         },
@@ -112,7 +117,6 @@ StyledListView {
             name: "scheme"
 
             PropertyChanges {
-                root.modelState: "scheme"
                 root.delegate: schemeItem
             }
         },
@@ -120,7 +124,6 @@ StyledListView {
             name: "variant"
 
             PropertyChanges {
-                root.modelState: "variant"
                 root.delegate: variantItem
             }
         }
@@ -148,7 +151,15 @@ StyledListView {
             }
             PropertyAction {
                 target: root
-                properties: "modelState,delegate"
+                property: "delegate"
+                value: null
+            }
+            ScriptAction {
+                script: root.displayText = root.search.text
+            }
+            PropertyAction {
+                target: root
+                property: "delegate"
             }
             ParallelAnimation {
                 Anim {
@@ -274,5 +285,21 @@ StyledListView {
         VariantItem {
             list: root
         }
+    }
+
+    Connections {
+        function onTextChanged() {
+            root.syncDisplayText();
+        }
+
+        target: root.search
+    }
+
+    Connections {
+        function onLauncherChanged() {
+            root.syncDisplayText();
+        }
+
+        target: root.screenState
     }
 }


### PR DESCRIPTION
## Summary

This PR keeps the launcher result bound to the current search text.

Previously, `ScriptModel.values` was applied through a `PropertyAction` when switching launcher states. However, this behavior broke after a regression triggered by [a611932](https://github.com/quickshell-mirror/quickshell/commit/a61193235279a415becfd429ab4353f05eb9b9b5) from Quickshell, in which `ScriptModel.values` was changed from `QVariantList` to `QJSValueList`.

The new `QJSValueList` state effectively captures the results when first entering the action path, so characters typed after `>` did not update the list. Pasting a complete query still worked because the full input was already present during the state change.

The model query now gets selected through a separate state property, which gets mapped to the delegate in the middle of the launcher's transition. This preserves the previous transition behavior and restoring the functionality of updating the result list continuously.

## Testing

- Builds successfully
- Passed `qmlformat` and linting conventions
- Verified queries such as `>s` filter the action list
- Verified pasted queries such as `>scheme` continue to work

Additional testing by others experiencing this issue using a manual installation is welcome.

---

Closes #1691 