### PR TITLE
fix(laumcher #1691): resolve command filtering, visual glitches, and binding loops 

### DIFF
--- a/modules/launcher/AppList.qml
+++ b/modules/launcher/AppList.qml
@@ -69,7 +69,6 @@ StyledListView {
             name: "apps"
 
             PropertyChanges {
-                model.values: Apps.search(search.text)
                 root.delegate: appItem
             }
         },
@@ -77,7 +76,6 @@ StyledListView {
             name: "actions"
 
             PropertyChanges {
-                model.values: Actions.query(search.text)
                 root.delegate: actionItem
             }
         },
@@ -85,7 +83,6 @@ StyledListView {
             name: "calc"
 
             PropertyChanges {
-                model.values: [0]
                 root.delegate: calcItem
             }
         },
@@ -93,7 +90,6 @@ StyledListView {
             name: "scheme"
 
             PropertyChanges {
-                model.values: Schemes.query(search.text)
                 root.delegate: schemeItem
             }
         },
@@ -101,7 +97,6 @@ StyledListView {
             name: "variant"
 
             PropertyChanges {
-                model.values: M3Variants.query(search.text)
                 root.delegate: variantItem
             }
         }
@@ -128,8 +123,8 @@ StyledListView {
                 }
             }
             PropertyAction {
-                targets: [model, root]
-                properties: "values,delegate"
+                target: root
+                property: "delegate"
             }
             ParallelAnimation {
                 Anim {
@@ -254,6 +249,27 @@ StyledListView {
 
         VariantItem {
             list: root
+        }
+    }
+
+    Binding {
+        target: model
+        property: "values"
+        value: {
+            const text = search.text;
+            const prefix = GlobalConfig.launcher.actionPrefix;
+            if (text.startsWith(prefix)) {
+                if (text.startsWith(`${prefix}calc `))
+                    return [0];
+                if (text.startsWith(`${prefix}scheme `))
+                    return Schemes.query(text);
+                if (text.startsWith(`${prefix}variant `))
+                    return M3Variants.query(text);
+
+                return Actions.query(text.substring(1).trim());
+            }
+
+            return Apps.search(text);
         }
     }
 }

--- a/modules/launcher/Content.qml
+++ b/modules/launcher/Content.qml
@@ -110,7 +110,7 @@ Item {
 
         Connections {
             function onLauncherChanged(): void {
-                if (!root.screenState.launcher)
+                if (root.screenState.launcher)
                     search.text = "";
             }
 

--- a/modules/launcher/items/ActionItem.qml
+++ b/modules/launcher/items/ActionItem.qml
@@ -9,6 +9,8 @@ Item {
     required property var modelData
     required property var list
 
+    readonly property string iconName: root.modelData?.icon ?? ""
+
     implicitHeight: Tokens.sizes.launcher.itemHeight
 
     anchors.left: parent?.left
@@ -29,7 +31,7 @@ Item {
             id: icon
 
             anchors.verticalCenter: parent.verticalCenter
-            text: root.modelData?.icon ?? ""
+            text: (root.modelData && root.modelData.id === undefined) ? iconName : ""
             color: Colours.palette.m3onSurfaceVariant
             fontStyle: Tokens.font.icon.builders.large.scale(1.3).build()
         }

--- a/modules/launcher/items/AppItem.qml
+++ b/modules/launcher/items/AppItem.qml
@@ -13,6 +13,8 @@ Item {
     required property DesktopEntry modelData
     required property ScreenState screenState
 
+    readonly property string iconName: root.modelData?.icon ?? ""
+
     implicitHeight: Tokens.sizes.launcher.itemHeight
 
     anchors.left: parent?.left
@@ -36,7 +38,7 @@ Item {
             id: icon
 
             asynchronous: true
-            source: Quickshell.iconPath(root.modelData?.icon, "image-missing")
+            source: (root.modelData && root.modelData.id !== undefined && iconName !== "") ? Quickshell.iconPath(iconName, "image-missing") : ""
             implicitSize: parent.height * 0.8
 
             anchors.verticalCenter: parent.verticalCenter

--- a/modules/launcher/services/Actions.qml
+++ b/modules/launcher/services/Actions.qml
@@ -11,10 +11,6 @@ import qs.utils
 Searcher {
     id: root
 
-    function transformSearch(search: string): string {
-        return search.slice(GlobalConfig.launcher.actionPrefix.length);
-    }
-
     list: variants.instances
     useFuzzy: GlobalConfig.launcher.useFuzzy.actions
 

--- a/modules/launcher/services/Apps.qml
+++ b/modules/launcher/services/Apps.qml
@@ -23,36 +23,42 @@ Searcher {
     function search(search: string): list<var> {
         const prefix = GlobalConfig.launcher.specialPrefix;
 
-        if (search.startsWith(`${prefix}i `)) {
-            keys = ["id", "name"];
-            weights = [0.9, 0.1];
-        } else if (search.startsWith(`${prefix}c `)) {
-            keys = ["categories", "name"];
-            weights = [0.9, 0.1];
-        } else if (search.startsWith(`${prefix}d `)) {
-            keys = ["comment", "name"];
-            weights = [0.9, 0.1];
-        } else if (search.startsWith(`${prefix}e `)) {
-            keys = ["execString", "name"];
-            weights = [0.9, 0.1];
-        } else if (search.startsWith(`${prefix}w `)) {
-            keys = ["startupClass", "name"];
-            weights = [0.9, 0.1];
-        } else if (search.startsWith(`${prefix}g `)) {
-            keys = ["genericName", "name"];
-            weights = [0.9, 0.1];
-        } else if (search.startsWith(`${prefix}k `)) {
-            keys = ["keywords", "name"];
-            weights = [0.9, 0.1];
-        } else {
-            keys = ["name"];
-            weights = [1];
+        let newKeys = ["name"];
+        let newWeights = [1];
+        let skipPrefixSlice = false;
 
-            if (!search.startsWith(`${prefix}t `))
-                return query(search).map(e => e.entry);
+        if (search.startsWith(`${prefix}i `)) {
+            newKeys = ["id", "name"];
+            newWeights = [0.9, 0.1];
+        } else if (search.startsWith(`${prefix}c `)) {
+            newKeys = ["categories", "name"];
+            newWeights = [0.9, 0.1];
+        } else if (search.startsWith(`${prefix}d `)) {
+            newKeys = ["comment", "name"];
+            newWeights = [0.9, 0.1];
+        } else if (search.startsWith(`${prefix}e `)) {
+            newKeys = ["execString", "name"];
+            newWeights = [0.9, 0.1];
+        } else if (search.startsWith(`${prefix}w `)) {
+            newKeys = ["startupClass", "name"];
+            newWeights = [0.9, 0.1];
+        } else if (search.startsWith(`${prefix}g `)) {
+            newKeys = ["genericName", "name"];
+            newWeights = [0.9, 0.1];
+        } else if (search.startsWith(`${prefix}k `)) {
+            newKeys = ["keywords", "name"];
+            newWeights = [0.9, 0.1];
+        } else {
+            if (!search.startsWith(`${prefix}t `)) {
+                skipPrefixSlice = true;
+            }
         }
 
-        const results = query(search.slice(prefix.length + 2)).map(e => e.entry);
+        if (skipPrefixSlice) {
+            return query(search, newKeys, newWeights).map(e => e.entry);
+        }
+
+        const results = query(search.slice(prefix.length + 2), newKeys, newWeights).map(e => e.entry);
         if (search.startsWith(`${prefix}t `))
             return results.filter(a => a.runInTerminal);
         return results;

--- a/utils/Searcher.qml
+++ b/utils/Searcher.qml
@@ -4,6 +4,8 @@ import QtQuick
 import Quickshell
 
 Singleton {
+    id: root
+
     required property list<QtObject> list
     property string key: "name"
     property bool useFuzzy: false
@@ -13,17 +15,7 @@ Singleton {
     property list<string> keys: [key]
     property list<real> weights: [1]
 
-    readonly property var fzf: useFuzzy ? [] : new Fzf.Finder(list, Object.assign({
-        selector
-    }, extraOpts))
-    readonly property list<var> fuzzyPrepped: useFuzzy ? list.map(e => {
-        const obj = {
-            _item: e
-        };
-        for (const k of keys)
-            obj[k] = Fuzzy.prepare(e[k]);
-        return obj;
-    }) : []
+    property var cache: ({ fzf: null, fuzzyPrepped: [], lastList: null, lastKeys: null })
 
     function transformSearch(search: string): string {
         return search;
@@ -34,19 +26,52 @@ Singleton {
         return item[key];
     }
 
-    function query(search: string): list<var> {
+    function arraysEqual(a, b) {
+        if (!a || !b) return false;
+        if (a.length !== b.length) return false;
+        for (let i = 0; i < a.length; i++) {
+            if (a[i] !== b[i]) return false;
+        }
+        return true;
+    }
+
+    function query(search, queryKeys = keys, queryWeights = weights) {
         search = transformSearch(search.trim().replace(/\s+/g, " "));
         if (!search)
             return [...list];
 
-        if (useFuzzy)
-            return Fuzzy.go(search, fuzzyPrepped, Object.assign({
-                all: true,
-                keys,
-                scoreFn: r => weights.reduce((a, w, i) => a + r[i].score * w, 0)
-            }, extraOpts)).map(r => r.obj._item);
+        if (cache.lastList !== list || !root.arraysEqual(cache.lastKeys, queryKeys) || (cache.fzf && cache.fzf.items.length !== list.length) || (useFuzzy && cache.fuzzyPrepped.length !== list.length)) {
+            cache.lastList = list;
+            cache.lastKeys = queryKeys;
+            cache.fzf = null;
+            cache.fuzzyPrepped = [];
+        }
 
-        return fzf.find(search).sort((a, b) => {
+        if (useFuzzy) {
+            if (cache.fuzzyPrepped.length === 0 && list.length > 0) {
+                cache.fuzzyPrepped = list.map(e => {
+                    const obj = {
+                        _item: e
+                    };
+                    for (const k of queryKeys)
+                        obj[k] = Fuzzy.prepare(e[k]);
+                    return obj;
+                });
+            }
+            return Fuzzy.go(search, cache.fuzzyPrepped, Object.assign({
+                all: true,
+                keys: queryKeys,
+                scoreFn: r => queryWeights.reduce((a, w, i) => a + r[i].score * w, 0)
+            }, extraOpts)).map(r => r.obj._item);
+        }
+
+        if (!cache.fzf) {
+            cache.fzf = new Fzf.Finder(list, Object.assign({
+                selector
+            }, extraOpts));
+        }
+
+        return cache.fzf.find(search).sort((a, b) => {
             if (a.score === b.score)
                 return selector(a.item).trim().length - selector(b.item).trim().length;
             return b.score - a.score;


### PR DESCRIPTION
This pull request resolves the launcher command filtering issue described in https://github.com/caelestia-dots/shell/issues/1691. 

### How It Solves the Issue (In Easy Steps)

1. **Enables Live Search Filtering**: Replaces the static QML `PropertyChanges` blocks with a single dynamic `Binding` in `AppList.qml`. This ensures that when you type after the `>` character (such as `>wall`), the search box query actually triggers updates to the filtered results instead of remaining frozen.
2. **Eliminates Binding Loop Warnings**: Groups all caching variables in `Searcher.qml` into a single JavaScript object (`cache`). Because nested object mutations do not trigger QML property change notifications, this stops the startup binding loop errors and improves search performance.
3. **Clears Search Box on Open (Not Close)**: Changes `Content.qml` to clear the search input text when the launcher slides up (opens) rather than when it slides down (closes). This prevents delegate creation from being aborted mid-transition, which previously corrupted the view and left a plain text list on screen.
4. **Transition-Safe Icon Loading**: Adds safety checks in both `AppItem.qml` and `ActionItem.qml` to only resolve icon names when they match the current delegate type. This prevents the launcher from briefly showing generic "image missing" symbols or giant fallback characters when switching lists.
