### PR TITLE
feat(quicktoggles): add nightlight toggle via hyprsunset support

### DIFF
--- a/modules/utilities/cards/Toggles.qml
+++ b/modules/utilities/cards/Toggles.qml
@@ -17,10 +17,25 @@ StyledRect {
     required property ScreenState screenState
     required property BarPopouts.Wrapper popouts
 
+    readonly property var configuredQuickToggles: {
+        const toggles = Config.utilities.quickToggles;
+        if (toggles.some(item => item.id === "nightLight"))
+            return toggles;
+
+        const nightLight = {
+            id: "nightLight",
+            enabled: true
+        };
+        const vpnIndex = toggles.findIndex(item => item.id === "vpn");
+        if (vpnIndex === -1)
+            return [...toggles, nightLight];
+
+        return [...toggles.slice(0, vpnIndex), nightLight, ...toggles.slice(vpnIndex)];
+    }
     readonly property var quickToggles: {
         const seenIds = new Set();
 
-        return Config.utilities.quickToggles.filter(item => {
+        return configuredQuickToggles.filter(item => {
             if (!(item.enabled ?? true))
                 return false;
 
@@ -137,6 +152,14 @@ StyledRect {
                         icon: "notifications_off"
                         checked: Notifs.dnd
                         onClicked: Notifs.dnd = !Notifs.dnd
+                    }
+                }
+                DelegateChoice {
+                    roleValue: "nightLight"
+                    delegate: Toggle {
+                        icon: "nightlight"
+                        checked: NightLight.enabled
+                        onClicked: NightLight.toggle()
                     }
                 }
                 DelegateChoice {

--- a/services/NightLight.qml
+++ b/services/NightLight.qml
@@ -1,0 +1,104 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import Caelestia
+import Caelestia.Config
+
+// hyprsunset >= 0.4.0: `identity get/true/false` for state and disable.
+// Older versions only support plain `identity`; state detection is unavailable.
+Singleton {
+    id: root
+
+    property bool enabled
+    property var supportsIdentityGet: null
+    property bool legacyApiWarned
+
+    readonly property var config: {
+        const item = GlobalConfig.utilities.quickToggles.find(t => typeof t === "object" && t.id === "nightLight");
+        return typeof item === "object" ? item : {};
+    }
+    readonly property int temperature: config.temperature ?? 4000
+
+    function disableCommand(): list<string> {
+        return supportsIdentityGet === true ? ["hyprctl", "hyprsunset", "identity", "true"] : ["hyprctl", "hyprsunset", "identity"];
+    }
+
+    function setEnabled(value: bool): void {
+        Quickshell.execDetached(value ? ["hyprctl", "hyprsunset", "temperature", String(temperature)] : disableCommand());
+
+        const changed = enabled !== value;
+        enabled = value;
+
+        if (changed && (config.toast ?? true)) {
+            if (value)
+                Toaster.toast(qsTr("Night light enabled"), qsTr("Blue-light filter is now active"), "nightlight");
+            else
+                Toaster.toast(qsTr("Night light disabled"), qsTr("Blue-light filter is now inactive"), "nightlight");
+        }
+    }
+
+    function toggle(): void {
+        setEnabled(!enabled);
+    }
+
+    function warnLegacyApi(): void {
+        if (legacyApiWarned || !(config.toast ?? true))
+            return;
+
+        legacyApiWarned = true;
+        Toaster.toast(qsTr("Night light state unavailable"), qsTr("hyprsunset 0.4.0+ is required to detect the current state"), "warning", Toast.Warning);
+    }
+
+    function parseIdentityGet(output: string): void {
+        const value = output.trim();
+        if (value === "true" || value === "false") {
+            supportsIdentityGet = true;
+            enabled = value === "false";
+            return;
+        }
+
+        supportsIdentityGet = false;
+        warnLegacyApi();
+    }
+
+    function refresh(): void {
+        queryProc.running = true;
+    }
+
+    Component.onCompleted: refresh()
+
+    Process {
+        id: queryProc
+
+        command: ["hyprctl", "hyprsunset", "identity", "get"]
+        stdout: StdioCollector {
+            onStreamFinished: root.parseIdentityGet(text)
+        }
+    }
+
+    IpcHandler {
+        function isEnabled(): bool {
+            return root.enabled;
+        }
+
+        function toggle(): void {
+            root.toggle();
+        }
+
+        function enable(): void {
+            root.setEnabled(true);
+        }
+
+        function disable(): void {
+            root.setEnabled(false);
+        }
+
+        function refresh(): void {
+            root.refresh();
+        }
+
+        target: "nightLight"
+    }
+}


### PR DESCRIPTION
Fixes #1467 

## Test evidence
<img width="449" height="554" alt="image" src="https://github.com/user-attachments/assets/e2daa308-8682-4cbe-b848-96fb11ab19ea" />
<img width="457" height="613" alt="image" src="https://github.com/user-attachments/assets/f343ebf3-fe3c-447b-9cfb-03819fcdbb78" />


## Pre-requisites
Hyrpsunset v0.4.0+
- refer the doc: https://wiki.hypr.land/Hypr-Ecosystem/hyprsunset/
- wlsunset doesn't work with hyprland (due to [missing wlr-gamma-control-unstable-v1 protocol](https://github.com/hyprwm/Hyprland/issues/2629))
- hyprsunset v0.3.0 doesn't provide query command whether nightlight mode is disabled or not.

shell.json should have new quicktoggle:
```json
{
"utilities": {
        "quickToggles": [
            {
                "enabled": true,
                "id": "nightLight",
                "temperature": 4500
            }
        ]
    }
}
```

"temperatore" in the above config decides what temperature to use when enabling nightlight mode.
