### PR TITLE
fix(audio): populate pipewire nodes immediately

### DIFF
--- a/services/Audio.qml
+++ b/services/Audio.qml
@@ -105,6 +105,27 @@ Singleton {
         return stream.properties["application.name"] || stream.description || stream.name || qsTr("Unknown Application");
     }
 
+    function refreshNodes(): void {
+        const newSinks = [];
+        const newSources = [];
+        const newStreams = [];
+
+        for (const node of Pipewire.nodes.values) {
+            if (!node.isStream) {
+                if (node.isSink)
+                    newSinks.push(node);
+                else if (node.audio)
+                    newSources.push(node);
+            } else if (node.audio) {
+                newStreams.push(node);
+            }
+        }
+
+        root.sinks = newSinks;
+        root.sources = newSources;
+        root.streams = newStreams;
+    }
+
     onSinkChanged: {
         if (!sink?.ready)
             return;
@@ -129,38 +150,26 @@ Singleton {
         previousSourceName = newSourceName;
     }
 
+    // Populate immediately: Pipewire.nodes may already be filled by the time this
+    // lazily-loaded singleton is created, so onValuesChanged would never fire.
     Component.onCompleted: {
+        refreshNodes();
         previousSinkName = sink?.description || sink?.name || qsTr("Unknown Device");
         previousSourceName = source?.description || source?.name || qsTr("Unknown Device");
     }
 
     Connections {
         function onValuesChanged(): void {
-            const newSinks = [];
-            const newSources = [];
-            const newStreams = [];
-
-            for (const node of Pipewire.nodes.values) {
-                if (!node.isStream) {
-                    if (node.isSink)
-                        newSinks.push(node);
-                    else if (node.audio)
-                        newSources.push(node);
-                } else if (node.audio) {
-                    newStreams.push(node);
-                }
-            }
-
-            root.sinks = newSinks;
-            root.sources = newSources;
-            root.streams = newStreams;
+            root.refreshNodes();
         }
 
         target: Pipewire.nodes
     }
 
+    // Always track the current defaults so volume/mute bind even if the lists
+    // momentarily lag behind the default node.
     PwObjectTracker {
-        objects: [...root.sinks, ...root.sources, ...root.streams]
+        objects: [root.sink, root.source, ...root.sinks, ...root.sources, ...root.streams].filter(n => n)
     }
 
     CavaProvider {


### PR DESCRIPTION
## Issue
Fixes startup race bug if pipwire nodes already exists before caelestia is loaded, PwObjectTracker binds nothing
Volume bar is always empty and regardless of changing volume via Caelestia settings, it doesn't change.

quickshell logs when unmuting mic via quick settings before fix:
```log
 ERROR quickshell.service.pipewire.node: Tried to change mute state for PwNode(0x7f8458862f00, id=63/unbound) which is not bound.
```
