### PR TITLE
fix(NowPlayingToast): support delayed "xesam:artist" property on track change

### DIFF
--- a/services/Players.qml
+++ b/services/Players.qml
@@ -15,6 +15,9 @@ Singleton {
     readonly property MprisPlayer active: props.manualActive ?? list.find(p => getIdentity(p) === GlobalConfig.services.defaultPlayer) ?? list[0] ?? null
     property alias manualActive: props.manualActive
 
+    // Dedup key for progressive metadata (e.g. mpv-mpris/yt-dlp player fills title then artist later).
+    property string lastNowPlayingKey: ""
+
     function getIdentity(player: MprisPlayer): string {
         if (!player)
             return "";
@@ -37,14 +40,43 @@ Singleton {
         return "";
     }
 
+    // Quickshell only emits postTrackChanged when trackid/url/title change, so late
+    // artist updates (common with mpv-mpris + yt-dlp player) never retrigger it. Watch
+    // title/artist too and toast once both are usable.
+    function maybeToastNowPlaying(): void {
+        if (!GlobalConfig.utilities.toasts.nowPlaying)
+            return;
+
+        const player = root.active;
+        if (!player)
+            return;
+
+        const title = player.trackTitle ?? "";
+        const artist = player.trackArtist ?? "";
+        if (!title || !artist)
+            return;
+
+        const key = `${getIdentity(player)}\0${player.uniqueId}\0${title}\0${artist}`;
+        if (key === lastNowPlayingKey)
+            return;
+
+        lastNowPlayingKey = key;
+        Toaster.toast(qsTr("Now Playing"), qsTr("%1 - %2").arg(artist).arg(title), "music_note");
+    }
+
+    onActiveChanged: lastNowPlayingKey = ""
+
     Connections {
-        function onPostTrackChanged() {
-            if (!GlobalConfig.utilities.toasts.nowPlaying) {
-                return;
-            }
-            if (root.active.trackArtist != "" && root.active.trackTitle != "") {
-                Toaster.toast(qsTr("Now Playing"), qsTr("%1 - %2").arg(root.active.trackArtist).arg(root.active.trackTitle), "music_note");
-            }
+        function onPostTrackChanged(): void {
+            root.maybeToastNowPlaying();
+        }
+
+        function onTrackTitleChanged(): void {
+            root.maybeToastNowPlaying();
+        }
+
+        function onTrackArtistChanged(): void {
+            root.maybeToastNowPlaying();
         }
 
         target: root.active


### PR DESCRIPTION
## Setup

I use [shellbeats](https://github.com/lalo-space/shellbeats) as my music player, using yt-dlp to stream music from youtube.
Using [mpv-mpris plugin](https://github.com/hoyon/mpv-mpris), I was able to get the "Music" tab working in the top panel. 

## Issue
However, "Now playing" toasts weren't working. I narrowed the issue down to the chain of PropertiesChanged signal being set by the mpv player:

```
dbus-monitor "type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged'"

signal time=1783999107.052163 sender=org.freedesktop.DBus -> destination=:1.2146 serial=4294967295 path=/org/freedesktop/DBus; interface=org.freedesktop.DBus; member=NameAcquired
   string ":1.2146"
signal time=1783999107.052192 sender=org.freedesktop.DBus -> destination=:1.2146 serial=4294967295 path=/org/freedesktop/DBus; interface=org.freedesktop.DBus; member=NameLost
   string ":1.2146"
signal time=1783999115.953310 sender=:1.1182 -> destination=(null destination) serial=349 path=/org/mpris/MediaPlayer2; interface=org.freedesktop.DBus.Properties; member=PropertiesChanged
   string "org.mpris.MediaPlayer2.Player"
   array [
      dict entry(
         string "Metadata"
         variant             array [
               dict entry(
                  string "mpris:artUrl"
                  variant                      string "https://i1.ytimg.com/vi/F-Rlu60Wn-Q/hqdefault.jpg"
               )
               dict entry(
                  string "mpris:trackid"
                  variant                      object path "/mpv/mpris/Track/0"
               )
               dict entry(
                  string "xesam:title"
                  variant                      string "watch?v=F-Rlu60Wn-Q"
               )
               dict entry(
                  string "xesam:url"
                  variant                      string "https://www.youtube.com/watch?v=F-Rlu60Wn-Q"
               )
            ]
      )
   ]
   array [
   ]
signal time=1783999118.856712 sender=:1.1182 -> destination=(null destination) serial=353 path=/org/mpris/MediaPlayer2; interface=org.freedesktop.DBus.Properties; member=PropertiesChanged
   string "org.mpris.MediaPlayer2.Player"
   array [
      dict entry(
         string "Metadata"
         variant             array [
               dict entry(
                  string "mpris:artUrl"
                  variant                      string "https://i1.ytimg.com/vi/F-Rlu60Wn-Q/hqdefault.jpg"
               )
               dict entry(
                  string "mpris:trackid"
                  variant                      object path "/mpv/mpris/Track/0"
               )
               dict entry(
                  string "xesam:title"
                  variant                      string "Memories - Maroon 5 (Nicole Cross Official Cover Video)"
               )
               dict entry(
                  string "xesam:url"
                  variant                      string "https://www.youtube.com/watch?v=F-Rlu60Wn-Q"
               )
            ]
      )
   ]
   array [
   ]
signal time=1783999119.258065 sender=:1.1182 -> destination=(null destination) serial=357 path=/org/mpris/MediaPlayer2; interface=org.freedesktop.DBus.Properties; member=PropertiesChanged
   string "org.mpris.MediaPlayer2.Player"
   array [
      dict entry(
         string "Metadata"
         variant             array [
               dict entry(
                  string "xesam:artist"
                  variant                      array [
                        string "Nicole Cross"
                     ]
               )
               dict entry(
                  string "mpris:artUrl"
                  variant                      string "https://i1.ytimg.com/vi/F-Rlu60Wn-Q/hqdefault.jpg"
               )
               dict entry(
                  string "mpris:trackid"
                  variant                      object path "/mpv/mpris/Track/0"
               )
               dict entry(
                  string "xesam:title"
                  variant                      string "Memories - Maroon 5 (Nicole Cross Official Cover Video)"
               )
               dict entry(
                  string "xesam:url"
                  variant                      string "https://www.youtube.com/watch?v=F-Rlu60Wn-Q"
               )
               dict entry(
                  string "mpris:length"
                  variant                      int64 166138775
               )
               dict entry(
                  string "xesam:contentCreated"
                  variant                      string "2019-10-04T00:00:00Z"
               )
            ]
      )
   ]
   array [
   ]
^C⏎      
```

"Now Playing" toast required artist and title to be defined with the metadata, but that was missing in the first signal, but present in the third signal due to delayed streaming pipeline (shellbeats -> yt-dlp -> mpv)