### PR TITLE
feat(lock): add support for visage and add generic face-auth config

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,9 @@ For example, to disable the bar on DP-1:
 >   `favouriteApps`, `hiddenApps`, `actions`)
 > - `launcher.useFuzzy` (`apps`, `actions`, `schemes`, `variants`, `wallpapers`)
 > - `notifs` (`expire`, `fullscreen`, `defaultExpireTimeout`, `fullscreenExpireTimeout`, `actionOnClick`)
-> - `lock` (`enableFprint`, `maxFprintTries`)
+> - `lock` (`enableFprint`, `maxFprintTries`, `enableFaceUnlock`, `faceAuthProvider`,
+>   `maxFaceAuthTries`, `triggerFaceAuthOnWake`; deprecated Howdy aliases: `enableHowdy`,
+>   `maxHowdyTries`, `triggerHowdyOnWake`)
 > - `nexus` (`networkRescanInterval`)
 > - `utilities.toasts` (all except `fullscreen`)
 > - `utilities.vpn` (`enabled`, `provider`)
@@ -676,6 +678,10 @@ For example, to disable the bar on DP-1:
         "recolourLogo": true,
         "enableFprint": true,
         "maxFprintTries": 3,
+        "enableFaceUnlock": true,
+        "faceAuthProvider": "howdy",
+        "maxFaceAuthTries": 3,
+        "triggerFaceAuthOnWake": true,
         "enableHowdy": true,
         "maxHowdyTries": 3,
         "triggerHowdyOnWake": true,

--- a/assets/pam.d/visage
+++ b/assets/pam.d/visage
@@ -1,0 +1,3 @@
+#%PAM-1.0
+
+auth    required    pam_visage.so

--- a/modules/lock/Pam.qml
+++ b/modules/lock/Pam.qml
@@ -22,7 +22,15 @@ Scope {
 
     readonly property alias passwd: passwd
     readonly property alias fprint: fprint
-    readonly property alias howdy: howdy
+    readonly property alias face: face
+    // Backward-compatible alias for UI / IPC that still says howdy
+    readonly property alias howdy: face
+
+    // Prefer generic face unlock keys; fall back to deprecated Howdy keys.
+    readonly property bool faceEnabled: GlobalConfig.lock.enableFaceUnlock || GlobalConfig.lock.enableHowdy
+    readonly property string faceProvider: GlobalConfig.lock.enableFaceUnlock ? GlobalConfig.lock.faceAuthProvider : "howdy"
+    readonly property int faceMaxTries: GlobalConfig.lock.enableFaceUnlock ? GlobalConfig.lock.maxFaceAuthTries : GlobalConfig.lock.maxHowdyTries
+    readonly property bool faceOnWake: GlobalConfig.lock.enableFaceUnlock ? GlobalConfig.lock.triggerFaceAuthOnWake : GlobalConfig.lock.triggerHowdyOnWake
 
     property string lockMessage
     property int state
@@ -30,20 +38,30 @@ Scope {
 
     signal flashMsg
 
+    function faceAvailCommand(provider: string): list<string> {
+        switch (provider) {
+        case "visage":
+            return ["sh", "-c", "command -v visage >/dev/null && [ -e /usr/lib/security/pam_visage.so ]"];
+        case "howdy":
+        default:
+            return ["sh", "-c", "command -v howdy >/dev/null"];
+        }
+    }
+
     function handleKey(event: KeyEvent): void {
         if (passwd.active)
             return;
 
-        // Trigger howdy on enter while empty buffer
-        if (howdy.canAttempt && !howdy.active && (event.key === Qt.Key_Enter || event.key === Qt.Key_Return) && buffer.length === 0)
-            return howdy.start(); // Gate on active so double enter still allows empty password
+        // Trigger face auth on enter while empty buffer
+        if (face.canAttempt && !face.active && (event.key === Qt.Key_Enter || event.key === Qt.Key_Return) && buffer.length === 0)
+            return face.start(); // Gate on active so double enter still allows empty password
 
         if (state === Pam.MaxTries)
             return;
 
-        // Abort howdy on pwd input
-        if (howdy.active)
-            howdy.abort();
+        // Abort face auth on pwd input
+        if (face.active)
+            face.abort();
 
         if (event.key === Qt.Key_Enter || event.key === Qt.Key_Return) {
             passwd.start();
@@ -68,7 +86,7 @@ Scope {
     }
 
     function clearTransientState(): void {
-        for (const obj of [root, fprint, howdy])
+        for (const obj of [root, fprint, face])
             if (obj.state !== Pam.MaxTries)
                 obj.state = Pam.None;
     }
@@ -133,19 +151,20 @@ Scope {
         onAvailProcExited: root.restartFprint()
     }
 
+    // Pluggable face PAM: assets/pam.d/<faceAuthProvider> + matching pam_*.so
     ManualPamContext {
-        id: howdy
+        id: face
 
-        config: "howdy"
-        availCommand: ["sh", "-c", "command -v howdy"]
-        enabled: GlobalConfig.lock.enableHowdy
-        maxTries: GlobalConfig.lock.maxHowdyTries
+        config: root.faceProvider
+        availCommand: root.faceAvailCommand(root.faceProvider)
+        enabled: root.faceEnabled
+        maxTries: root.faceMaxTries
     }
 
     Connections {
         function onResumed(): void {
-            if (howdy.canAttempt && !howdy.active && GlobalConfig.lock.triggerHowdyOnWake)
-                howdy.start();
+            if (face.canAttempt && !face.active && root.faceOnWake)
+                face.start();
         }
 
         target: SessionManager
@@ -155,9 +174,9 @@ Scope {
         function onSecureChanged(): void {
             if (root.lock.secure) {
                 fprint.checkAvailable();
-                howdy.checkAvailable();
+                face.checkAvailable();
                 fprint.reset();
-                howdy.reset();
+                face.reset();
                 root.buffer = "";
                 root.state = Pam.None;
                 root.lockMessage = "";
@@ -166,7 +185,7 @@ Scope {
 
         function onUnlock(): void {
             fprint.abort();
-            howdy.abort();
+            face.abort();
             passwd.abort();
         }
 
@@ -178,9 +197,25 @@ Scope {
             root.restartFprint();
         }
 
+        function onEnableFaceUnlockChanged(): void {
+            if (!root.faceEnabled && face.active)
+                face.abort();
+            else if (root.lock.secure)
+                face.checkAvailable();
+        }
+
         function onEnableHowdyChanged(): void {
-            if (!GlobalConfig.lock.enableHowdy && howdy.active)
-                howdy.abort();
+            if (!root.faceEnabled && face.active)
+                face.abort();
+            else if (root.lock.secure)
+                face.checkAvailable();
+        }
+
+        function onFaceAuthProviderChanged(): void {
+            if (face.active)
+                face.abort();
+            if (root.lock.secure)
+                face.checkAvailable();
         }
 
         target: GlobalConfig.lock
@@ -191,7 +226,7 @@ Scope {
 
         required property bool enabled
         required property int maxTries
-        property alias config: pam.config
+        property string config
         property alias availCommand: availProc.command
         property bool retryOnFail
 
@@ -227,6 +262,7 @@ Scope {
         PamContext {
             id: pam
 
+            config: ctx.config
             configDirectory: Quickshell.shellPath("assets/pam.d")
 
             onCompleted: res => {

--- a/modules/lock/center/InputField.qml
+++ b/modules/lock/center/InputField.qml
@@ -48,7 +48,7 @@ Item {
         text: {
             if (root.pam.passwd.active)
                 return qsTr("Loading...");
-            if (root.pam.howdy.active)
+            if (root.pam.face.active)
                 return qsTr("Scanning face...");
             if (root.pam.state === Pam.MaxTries)
                 return qsTr("Max tries reached");

--- a/modules/lock/center/PasswordInput.qml
+++ b/modules/lock/center/PasswordInput.qml
@@ -66,7 +66,7 @@ StyledRect {
             AnimLoader {
                 anchors.centerIn: parent
                 anchors.verticalCenterOffset: sourceComponent === iconComp ? 1 : 0
-                sourceComp: root.lock.pam.passwd.active || root.lock.pam.howdy.active ? loadingComp : iconComp
+                sourceComp: root.lock.pam.passwd.active || root.lock.pam.face.active ? loadingComp : iconComp
             }
 
             Component {
@@ -76,17 +76,17 @@ StyledRect {
                     animate: true
                     text: {
                         if (root.lock.pam.fprint.tries >= GlobalConfig.lock.maxFprintTries) {
-                            if (root.lock.pam.howdy.canAttempt)
+                            if (root.lock.pam.face.canAttempt)
                                 return "face";
                             return "fingerprint_off";
                         }
                         if (root.lock.pam.fprint.active)
                             return "fingerprint";
-                        if (root.lock.pam.howdy.canAttempt)
+                        if (root.lock.pam.face.canAttempt)
                             return "face";
                         return "lock";
                     }
-                    color: !root.lock.pam.howdy.canAttempt && root.lock.pam.fprint.tries >= GlobalConfig.lock.maxFprintTries ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
+                    color: !root.lock.pam.face.canAttempt && root.lock.pam.fprint.tries >= GlobalConfig.lock.maxFprintTries ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
                     fontStyle: Tokens.font.icon.builders.medium.scale(root.centerScale).build()
                     fill: text === "face"
                 }

--- a/modules/lock/center/StateMessage.qml
+++ b/modules/lock/center/StateMessage.qml
@@ -15,22 +15,22 @@ Item {
         // Errors
         if (pam.fprint.state === Pam.Error)
             return qsTr("FP ERROR: %1").arg(pam.fprint.message);
-        if (pam.howdy.state === Pam.Error)
-            return qsTr("FACE ERROR: %1").arg(pam.howdy.message);
+        if (pam.face.state === Pam.Error)
+            return qsTr("FACE ERROR: %1").arg(pam.face.message);
         if (pam.state === Pam.Error)
             return qsTr("PW ERROR: %1").arg(pam.passwd.message);
 
-        // Fprint/howdy fail
+        // Fprint/face fail
         if (pam.state !== Pam.MaxTries) {
             if (pam.fprint.state === Pam.Failed)
                 return qsTr("Fingerprint not recognized (%1/%2). Please try again or use password.").arg(pam.fprint.tries).arg(GlobalConfig.lock.maxFprintTries);
-            if (pam.howdy.state === Pam.Failed)
-                return qsTr("Face not recognized (%1/%2). Please try again or use password.").arg(pam.howdy.tries).arg(GlobalConfig.lock.maxHowdyTries);
+            if (pam.face.state === Pam.Failed)
+                return qsTr("Face not recognized (%1/%2). Please try again or use password.").arg(pam.face.tries).arg(pam.face.maxTries);
         } else {
             if (pam.fprint.state === Pam.Failed)
                 return qsTr("Fingerprint not recognized (%1/%2). Please try again.").arg(pam.fprint.tries).arg(GlobalConfig.lock.maxFprintTries);
-            if (pam.howdy.state === Pam.Failed)
-                return qsTr("Face not recognized (%1/%2). Please try again.").arg(pam.howdy.tries).arg(GlobalConfig.lock.maxHowdyTries);
+            if (pam.face.state === Pam.Failed)
+                return qsTr("Face not recognized (%1/%2). Please try again.").arg(pam.face.tries).arg(pam.face.maxTries);
         }
 
         if (pam.lockMessage) // Password max tries message
@@ -40,7 +40,7 @@ Item {
         if (pam.state === Pam.Failed) {
             if (pam.fprint.available && pam.fprint.state !== Pam.MaxTries)
                 return qsTr("Incorrect password. Please try again or use fingerprint.");
-            if (pam.howdy.available && pam.howdy.state !== Pam.MaxTries)
+            if (pam.face.available && pam.face.state !== Pam.MaxTries)
                 return qsTr("Incorrect password. Please try again or use face.");
             return qsTr("Incorrect password. Please try again.");
         }
@@ -49,15 +49,15 @@ Item {
         if (pam.state === Pam.MaxTries) {
             if (pam.fprint.available && pam.fprint.state !== Pam.MaxTries)
                 return qsTr("Maximum password attempts reached. Please use fingerprint.");
-            if (pam.howdy.available && pam.howdy.state !== Pam.MaxTries)
+            if (pam.face.available && pam.face.state !== Pam.MaxTries)
                 return qsTr("Maximum password attempts reached. Please use face.");
-            if (pam.fprint.available || pam.howdy.available)
+            if (pam.fprint.available || pam.face.available)
                 return qsTr("Maximum attempts for all authentication methods reached.");
             return qsTr("Maximum password attempts reached.");
         }
         if (pam.fprint.state === Pam.MaxTries)
             return qsTr("Maximum fingerprint attempts reached. Please use password.");
-        if (pam.howdy.state === Pam.MaxTries)
+        if (pam.face.state === Pam.MaxTries)
             return qsTr("Maximum face attempts reached. Please use password.");
 
         return "";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -151,6 +151,8 @@ in
         --replace-fail pam_fprintd.so /run/current-system/sw/lib/security/pam_fprintd.so
       substituteInPlace assets/pam.d/howdy \
         --replace-fail pam_howdy.so /run/current-system/sw/lib/security/pam_howdy.so
+      substituteInPlace assets/pam.d/visage \
+        --replace-fail pam_visage.so /run/current-system/sw/lib/security/pam_visage.so
     '';
 
     postInstall = ''

--- a/plugin/src/Caelestia/Config/lockconfig.hpp
+++ b/plugin/src/Caelestia/Config/lockconfig.hpp
@@ -2,7 +2,11 @@
 
 #include "configobject.hpp"
 
+#include <qstring.h>
+
 namespace caelestia::config {
+
+using Qt::StringLiterals::operator""_s;
 
 class LockConfig : public ConfigObject {
     Q_OBJECT
@@ -12,6 +16,12 @@ class LockConfig : public ConfigObject {
     CONFIG_PROPERTY(bool, recolourLogo, true)
     CONFIG_GLOBAL_PROPERTY(bool, enableFprint, true)
     CONFIG_GLOBAL_PROPERTY(int, maxFprintTries, 3)
+    // Generic face unlock (Howdy / Visage / future PAM face backends)
+    CONFIG_GLOBAL_PROPERTY(bool, enableFaceUnlock, true)
+    CONFIG_GLOBAL_PROPERTY(QString, faceAuthProvider, u"howdy"_s)
+    CONFIG_GLOBAL_PROPERTY(int, maxFaceAuthTries, 3)
+    CONFIG_GLOBAL_PROPERTY(bool, triggerFaceAuthOnWake, true)
+    // Deprecated Howdy-specific keys — kept for backward compatibility
     CONFIG_GLOBAL_PROPERTY(bool, enableHowdy, true)
     CONFIG_GLOBAL_PROPERTY(int, maxHowdyTries, 3)
     CONFIG_GLOBAL_PROPERTY(bool, triggerHowdyOnWake, true)


### PR DESCRIPTION
Extends prior PR: https://github.com/caelestia-dots/shell/pull/1515

## Feature
Considering howdy is not actively maintained (last release [v3.0.0](https://github.com/boltgolt/howdy/pull/1023) was 1 year ago and not officially released), I was checking out other secure face unlock options.

[visage](https://github.com/sovren-software/visage) seemed promising so far and I want to integrate with Caelestia lock screen for daily-use.

## Compatibility
I've kept howdy-related config fields - `lock.enableHowdy`,   `lock.maxHowdyTries`, `lock.triggerHowdyOnWake` - for backwards compatibility.
It would be preferable to keep a generic config name and change the face recognition provider with a simple config like `lock.faceAuthProvider` but considering some users might have already started to use in their daily-use, maybe a deprecation notice along with new fields might be safer.
