### PR TITLE
fix: convert lists to `QList<QJSValue>` to satisfy qmllint

### DIFF
--- a/modules/launcher/WallpaperList.qml
+++ b/modules/launcher/WallpaperList.qml
@@ -49,7 +49,7 @@ PathView {
 
         readonly property string search: root.search.text.split(" ").slice(1).join(" ")
 
-        values: Wallpapers.query(search)
+        values: [...Wallpapers.query(search)]
         onValuesChanged: root.currentIndex = search ? 0 : values.findIndex(w => w.path === Wallpapers.actualCurrent)
     }
 

--- a/modules/lock/NotifGroup.qml
+++ b/modules/lock/NotifGroup.qml
@@ -220,7 +220,7 @@ StyledRect {
 
             Repeater {
                 model: ScriptModel {
-                    values: root.notifs.slice(0, root.Config.notifs.groupPreviewNum)
+                    values: [...root.notifs.slice(0, root.Config.notifs.groupPreviewNum)]
                 }
 
                 NotifLine {
@@ -285,7 +285,7 @@ StyledRect {
                 sourceComponent: ColumnLayout {
                     Repeater {
                         model: ScriptModel {
-                            values: root.notifs.slice(root.Config.notifs.groupPreviewNum)
+                            values: [...root.notifs.slice(root.Config.notifs.groupPreviewNum)]
                         }
 
                         NotifLine {}

--- a/modules/sidebar/NotifGroupList.qml
+++ b/modules/sidebar/NotifGroupList.qml
@@ -38,7 +38,7 @@ LazyListView {
     model: ScriptModel {
         values: {
             if (root.expanded)
-                return root.notifs;
+                return [...root.notifs];
 
             let count = 0;
             let i = 0;
@@ -49,7 +49,7 @@ LazyListView {
                 i++;
             }
 
-            return root.notifs.slice(0, i);
+            return [...root.notifs.slice(0, i)];
         }
     }
 


### PR DESCRIPTION
## Summary

Convert typed `list<var>` results to JS arrays before assigning them to `ScriptModel.values`.

### Context

Quickshell commit [`25eb04f`](https://git.outfoxxed.me/quickshell/quickshell/commit/25eb04fb06c09bbdef91664f044ad22195862700) corrected the exported type of `ScriptModel.values` from the undefined `QJSValueList` alias to `QList<QJSValue>`, resolving quickshell-mirror/quickshell#888. With the corrected type, qmllint can now detect assignments from QML's `list<var>` values (`QList<QVariant>`) to `ScriptModel.values` (`QList<QJSValue>`), which fixes the linting warnings:
```
Cannot assign binding of type QList<QVariant> to QList<QJSValue>
```

Using spread syntax, such as:
```qml
values: [...Wallpapers.query(search)]
```
the JS array expected by `ScriptModel` is produced without chaing the source property/function types. This has no effect on runtime behavior and everything works the same as before, except now `qmllint` is satisfied which removes the blocker causing the `Lint code` GH action to fail.

There are still a few remaining warnings of the same type from `AppList.qml`, which intentionally have been left alone as they will already be resolved after #1695 is merged.

## Testing

- Builds successfully
- Passed `qmlformat` and linting conventions
- Ensured `qmllint` warnings from the modified files are now resolved
- Verified runtime behavior with the wallpaper launcher list, lockscreen notification groups, and sidebar notification list remains functional and is consistent with the state prior to this change