### PR TITLE
chore: fix lint warnings

### DIFF
--- a/modules/launcher/services/Apps.qml
+++ b/modules/launcher/services/Apps.qml
@@ -20,7 +20,7 @@ Searcher {
             entry.execute();
     }
 
-    function search(search: string): list<var> {
+    function search(search: string): var {
         const prefix = GlobalConfig.launcher.specialPrefix;
 
         if (search.startsWith(`${prefix}i `)) {

--- a/modules/lock/NotifGroup.qml
+++ b/modules/lock/NotifGroup.qml
@@ -220,7 +220,7 @@ StyledRect {
 
             Repeater {
                 model: ScriptModel {
-                    values: root.notifs.slice(0, root.Config.notifs.groupPreviewNum)
+                    values: root.notifs.slice(0, root.Config.notifs.groupPreviewNum) as Array
                 }
 
                 NotifLine {
@@ -285,7 +285,7 @@ StyledRect {
                 sourceComponent: ColumnLayout {
                     Repeater {
                         model: ScriptModel {
-                            values: root.notifs.slice(root.Config.notifs.groupPreviewNum)
+                            values: root.notifs.slice(root.Config.notifs.groupPreviewNum) as Array
                         }
 
                         NotifLine {}

--- a/modules/sidebar/NotifGroupList.qml
+++ b/modules/sidebar/NotifGroupList.qml
@@ -38,7 +38,7 @@ LazyListView {
     model: ScriptModel {
         values: {
             if (root.expanded)
-                return root.notifs;
+                return root.notifs as Array;
 
             let count = 0;
             let i = 0;
@@ -49,7 +49,7 @@ LazyListView {
                 i++;
             }
 
-            return root.notifs.slice(0, i);
+            return root.notifs.slice(0, i) as Array;
         }
     }
 

--- a/utils/Searcher.qml
+++ b/utils/Searcher.qml
@@ -34,7 +34,7 @@ Singleton {
         return item[key];
     }
 
-    function query(search: string): list<var> {
+    function query(search: string): var {
         search = transformSearch(search.trim().replace(/\s+/g, " "));
         if (!search)
             return [...list];


### PR DESCRIPTION
Quickshell updated `ScriptModel#values` from `QVariantList` to `QList<QJSValue>` so we need to fix CI