### PR TITLE
feat: native video wallpaper support via QML MediaPlayer

### DIFF
--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -147,13 +147,15 @@ Item {
 
         Item {
             id: videoContainer
-            anchors.fill: root
 
             property string path
+
+            anchors.fill: root
             opacity: 0
 
             MediaPlayer {
                 id: player
+
                 source: videoContainer.path ? "file://" + videoContainer.path : ""
                 videoOutput: output
                 loops: MediaPlayer.Infinite // qmllint disable unqualified
@@ -171,12 +173,15 @@ Item {
 
             VideoOutput {
                 id: output
+                // qmllint disable unqualified
+                // qmllint disable unresolved-type
                 anchors.fill: videoContainer
                 fillMode: VideoOutput.PreserveAspectCrop // qmllint disable unqualified
             }
 
             Anim on opacity {
                 id: videoAnim
+
                 type: Anim.SlowEffects
                 running: false
                 from: 0

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -173,6 +173,7 @@ Item {
 
             VideoOutput {
                 id: output
+
                 // qmllint disable unqualified
                 // qmllint disable unresolved-type
                 anchors.fill: videoContainer

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import QtMultimedia
 import Caelestia.Config
 import qs.components
 import qs.components.filedialog
@@ -12,24 +13,25 @@ Item {
     id: root
 
     property string source: Wallpapers.current
-    property CachingImage current
+    property Item current
     property bool completed
 
     onSourceChanged: {
         if (!source)
             current = null;
+        else if (Images.isVideoFile(source))
+            current = videoComp.createObject(this, { path: source });
         else
-            current = imgComp.createObject(this, {
-                path: source
-            });
+            current = imgComp.createObject(this, { path: source });
     }
 
     Component.onCompleted: {
         if (source)
             Qt.callLater(() => {
-                current = imgComp.createObject(this, {
-                    path: source
-                });
+                if (Images.isVideoFile(source))
+                    current = videoComp.createObject(this, { path: source });
+                else
+                    current = imgComp.createObject(this, { path: source });
                 completed = true;
             });
     }
@@ -125,9 +127,58 @@ Item {
             }
 
             Timer {
-                running: root.current !== img && root.current?.status === Image.Ready
+                running: root.current !== img && (root.current?.status === Image.Ready || root.current?.status === undefined)
                 interval: anim.duration
                 onTriggered: img.destroy()
+            }
+        }
+    }
+
+    Component {
+        id: videoComp
+
+        Item {
+            id: videoContainer
+            anchors.fill: parent
+
+            property string path
+            opacity: 0
+
+            MediaPlayer {
+                id: player
+                source: videoContainer.path ? "file://" + videoContainer.path : ""
+                videoOutput: output
+                loops: MediaPlayer.Infinite
+                autoPlay: true
+
+                onPlaybackStateChanged: {
+                    if (playbackState === MediaPlayer.PlayingState)
+                        videoAnim.start();
+                }
+
+                onErrorOccurred: function(error, errorString) {
+                    console.warn("Video wallpaper error:", errorString)
+                }
+            }
+
+            VideoOutput {
+                id: output
+                anchors.fill: parent
+                fillMode: VideoOutput.PreserveAspectCrop
+            }
+
+            Anim on opacity {
+                id: videoAnim
+                type: Anim.SlowEffects
+                running: false
+                from: 0
+                to: 1
+            }
+
+            Timer {
+                running: root.current !== videoContainer && (root.current?.status === Image.Ready || root.current?.status === undefined)
+                interval: videoAnim.duration
+                onTriggered: videoContainer.destroy()
             }
         }
     }

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -20,18 +20,26 @@ Item {
         if (!source)
             current = null;
         else if (Images.isVideoFile(source))
-            current = videoComp.createObject(this, { path: source });
+            current = videoComp.createObject(this, {
+                path: source
+            });
         else
-            current = imgComp.createObject(this, { path: source });
+            current = imgComp.createObject(this, {
+                path: source
+            });
     }
 
     Component.onCompleted: {
         if (source)
             Qt.callLater(() => {
                 if (Images.isVideoFile(source))
-                    current = videoComp.createObject(this, { path: source });
+                    current = videoComp.createObject(this, {
+                        path: source
+                    });
                 else
-                    current = imgComp.createObject(this, { path: source });
+                    current = imgComp.createObject(this, {
+                        path: source
+                    });
                 completed = true;
             });
     }
@@ -127,7 +135,7 @@ Item {
             }
 
             Timer {
-                running: root.current !== img && (root.current?.status === Image.Ready || root.current?.status === undefined)
+                running: root.current !== img && (root.current?.status === Image.Ready || root.current?.status === undefined) // qmllint disable missing-property
                 interval: anim.duration
                 onTriggered: img.destroy()
             }
@@ -139,7 +147,7 @@ Item {
 
         Item {
             id: videoContainer
-            anchors.fill: parent
+            anchors.fill: root
 
             property string path
             opacity: 0
@@ -148,23 +156,23 @@ Item {
                 id: player
                 source: videoContainer.path ? "file://" + videoContainer.path : ""
                 videoOutput: output
-                loops: MediaPlayer.Infinite
+                loops: MediaPlayer.Infinite // qmllint disable unqualified
                 autoPlay: true
 
-                onPlaybackStateChanged: {
-                    if (playbackState === MediaPlayer.PlayingState)
+                onPlaybackStateChanged: function (playbackState) {
+                    if (playbackState === MediaPlayer.PlayingState) // qmllint disable unqualified
                         videoAnim.start();
                 }
 
-                onErrorOccurred: function(error, errorString) {
-                    console.warn("Video wallpaper error:", errorString)
+                onErrorOccurred: function (error, errorString) {
+                    console.warn("Video wallpaper error:", errorString);
                 }
             }
 
             VideoOutput {
                 id: output
                 anchors.fill: parent
-                fillMode: VideoOutput.PreserveAspectCrop
+                fillMode: VideoOutput.PreserveAspectCrop // qmllint disable unqualified
             }
 
             Anim on opacity {
@@ -176,7 +184,7 @@ Item {
             }
 
             Timer {
-                running: root.current !== videoContainer && (root.current?.status === Image.Ready || root.current?.status === undefined)
+                running: root.current !== videoContainer && (root.current?.status === Image.Ready || root.current?.status === undefined) // qmllint disable missing-property
                 interval: videoAnim.duration
                 onTriggered: videoContainer.destroy()
             }

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -171,7 +171,7 @@ Item {
 
             VideoOutput {
                 id: output
-                anchors.fill: parent
+                anchors.fill: videoContainer
                 fillMode: VideoOutput.PreserveAspectCrop // qmllint disable unqualified
             }
 

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -2,6 +2,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtMultimedia
+import Caelestia
 import Caelestia.Config
 import qs.components
 import qs.components.filedialog
@@ -15,31 +16,48 @@ Item {
     property string source: Wallpapers.current
     property Item current
     property bool completed
+    readonly property bool isPaused: (Hypr.focusedWorkspace?.toplevels.values.some(t => t.lastIpcObject.fullscreen > 1) ?? false) || GameMode.enabled // qmllint disable unqualified
+
+    function thumbPathFor(videoSource) {
+        var dir = videoSource.substring(0, videoSource.lastIndexOf("/"));
+        var name = videoSource.substring(videoSource.lastIndexOf("/") + 1);
+        var stem = name.substring(0, name.lastIndexOf("."));
+        return dir + "/.thumbs/" + stem + ".jpg";
+    }
 
     onSourceChanged: {
         if (!source)
             current = null;
-        else if (Images.isVideoFile(source))
-            current = videoComp.createObject(this, {
-                path: source
-            });
+        else if (Images.isVideoFile(source)) {
+            if (isPaused)
+                current = imgComp.createObject(this, { path: thumbPathFor(source) });
+            else
+                current = videoComp.createObject(this, { path: source });
+        } else
+            current = imgComp.createObject(this, { path: source });
+    }
+
+    onIsPausedChanged: {
+        if (!source || !Images.isVideoFile(source))
+            return;
+        if (current)
+            current.destroy();
+        if (isPaused)
+            current = imgComp.createObject(root, { path: thumbPathFor(source) });
         else
-            current = imgComp.createObject(this, {
-                path: source
-            });
+            current = videoComp.createObject(root, { path: source });
     }
 
     Component.onCompleted: {
         if (source)
             Qt.callLater(() => {
-                if (Images.isVideoFile(source))
-                    current = videoComp.createObject(this, {
-                        path: source
-                    });
-                else
-                    current = imgComp.createObject(this, {
-                        path: source
-                    });
+                if (Images.isVideoFile(source)) {
+                    if (isPaused)
+                        current = imgComp.createObject(this, { path: thumbPathFor(source) });
+                    else
+                        current = videoComp.createObject(this, { path: source });
+                } else
+                    current = imgComp.createObject(this, { path: source });
                 completed = true;
             });
     }
@@ -190,7 +208,7 @@ Item {
             }
 
             Timer {
-                running: root.current !== videoContainer && (root.current?.status === Image.Ready || root.current?.status === undefined) // qmllint disable missing-property
+                running: root.current !== videoContainer // qmllint disable missing-property
                 interval: videoAnim.duration
                 onTriggered: videoContainer.destroy()
             }

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -191,7 +191,7 @@ Item {
 
                 source: videoContainer.path ? "file://" + videoContainer.path : ""
                 videoOutput: output
-                loops: MediaPlayer.Infinite // qmllint disable unqualified
+                loops: MediaPlayer.Infinite
                 autoPlay: true
 
                 onPlaybackStateChanged: function (playbackState) {

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -195,7 +195,7 @@ Item {
                 autoPlay: true
 
                 onPlaybackStateChanged: function (playbackState) {
-                    if (playbackState === MediaPlayer.PlayingState) // qmllint disable unqualified
+                    if (playbackState === MediaPlayer.PlayingState)
                         videoAnim.start();
                 }
 

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -15,7 +15,7 @@ Item {
     property string source: Wallpapers.current
     property Item current
     property bool completed
-    readonly property bool isPaused: (Hypr.focusedWorkspace?.toplevels.values.some(t => t.lastIpcObject.fullscreen > 1) ?? false) || GameMode.enabled // qmllint disable unqualified
+    readonly property bool isPaused: (Hypr.focusedWorkspace?.toplevels.values.some(t => t.lastIpcObject.fullscreen > 1) ?? false) || GameMode.enabled
 
     function thumbPathFor(videoSource) {
         var dir = videoSource.substring(0, videoSource.lastIndexOf("/"));

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -207,7 +207,6 @@ Item {
             VideoOutput {
                 id: output
 
-                // qmllint disable unqualified
                 anchors.fill: videoContainer
                 fillMode: VideoOutput.PreserveAspectCrop // qmllint disable unqualified
             }

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -2,7 +2,6 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtMultimedia
-import Caelestia
 import Caelestia.Config
 import qs.components
 import qs.components.filedialog
@@ -30,11 +29,17 @@ Item {
             current = null;
         else if (Images.isVideoFile(source)) {
             if (isPaused)
-                current = imgComp.createObject(this, { path: thumbPathFor(source) });
+                current = imgComp.createObject(this, {
+                    path: thumbPathFor(source)
+                });
             else
-                current = videoComp.createObject(this, { path: source });
+                current = videoComp.createObject(this, {
+                    path: source
+                });
         } else
-            current = imgComp.createObject(this, { path: source });
+            current = imgComp.createObject(this, {
+                path: source
+            });
     }
 
     onIsPausedChanged: {
@@ -43,9 +48,13 @@ Item {
         if (current)
             current.destroy();
         if (isPaused)
-            current = imgComp.createObject(root, { path: thumbPathFor(source) });
+            current = imgComp.createObject(root, {
+                path: thumbPathFor(source)
+            });
         else
-            current = videoComp.createObject(root, { path: source });
+            current = videoComp.createObject(root, {
+                path: source
+            });
     }
 
     Component.onCompleted: {
@@ -53,11 +62,17 @@ Item {
             Qt.callLater(() => {
                 if (Images.isVideoFile(source)) {
                     if (isPaused)
-                        current = imgComp.createObject(this, { path: thumbPathFor(source) });
+                        current = imgComp.createObject(this, {
+                            path: thumbPathFor(source)
+                        });
                     else
-                        current = videoComp.createObject(this, { path: source });
+                        current = videoComp.createObject(this, {
+                            path: source
+                        });
                 } else
-                    current = imgComp.createObject(this, { path: source });
+                    current = imgComp.createObject(this, {
+                        path: source
+                    });
                 completed = true;
             });
     }

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -208,7 +208,6 @@ Item {
                 id: output
 
                 // qmllint disable unqualified
-                // qmllint disable unresolved-type
                 anchors.fill: videoContainer
                 fillMode: VideoOutput.PreserveAspectCrop // qmllint disable unqualified
             }

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -221,7 +221,7 @@ Item {
             }
 
             Timer {
-                running: root.current !== videoContainer // qmllint disable missing-property
+                running: root.current !== videoContainer
                 interval: videoAnim.duration
                 onTriggered: videoContainer.destroy()
             }

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -208,7 +208,7 @@ Item {
                 id: output
 
                 anchors.fill: videoContainer
-                fillMode: VideoOutput.PreserveAspectCrop // qmllint disable unqualified
+                fillMode: VideoOutput.PreserveAspectCrop
             }
 
             Anim on opacity {

--- a/modules/launcher/ContentList.qml
+++ b/modules/launcher/ContentList.qml
@@ -51,6 +51,10 @@ Item {
                 root.implicitHeight: root.Tokens.sizes.launcher.wallpaperHeight
                 wallpaperList.active: true
             }
+
+            StateChangeScript {
+                script: Wallpapers.updateThumbs()
+            }
         }
     ]
 

--- a/modules/launcher/items/WallpaperItem.qml
+++ b/modules/launcher/items/WallpaperItem.qml
@@ -6,12 +6,22 @@ import qs.components
 import qs.components.effects
 import qs.components.images
 import qs.services
+import qs.utils
 
 Item {
     id: root
 
     required property FileSystemEntry modelData
     required property ScreenState screenState
+
+    readonly property bool isVideo: Images.isVideoFile(root.modelData.path)
+    readonly property string thumbnailPath: {
+        if (!isVideo) return root.modelData.path;
+        const i = root.modelData.path.lastIndexOf('/');
+        const dir = root.modelData.path.substring(0, i);
+        const name = root.modelData.path.substring(i + 1).replace(/\.[^.]+$/, '');
+        return `${dir}/.thumbs/${name}.jpg`;
+    }
 
     scale: 0.5
     opacity: 0
@@ -59,18 +69,36 @@ Item {
 
         MaterialIcon {
             anchors.centerIn: parent
-            text: "image"
+            text: root.isVideo ? "videocam" : "image"
             color: Colours.tPalette.m3outline
             fontStyle: Tokens.font.icon.builders.extraLarge.scale(2).weight(Font.DemiBold).build()
         }
 
         CachingImage {
             anchors.fill: parent
-            path: root.modelData.path
+            path: root.thumbnailPath
             smooth: !root.PathView.view.moving
             sourceSize: {
                 const dpr = (QsWindow.window as QsWindow)?.devicePixelRatio ?? 1;
                 return Qt.size(image.implicitWidth * dpr, image.implicitHeight * dpr);
+            }
+        }
+
+        StyledRect {
+            anchors.left: parent.left
+            anchors.top: parent.top
+            anchors.margins: 4
+            radius: Tokens.rounding.small
+            color: "#CC000000"
+            implicitWidth: badgeIcon.implicitWidth + 8
+            implicitHeight: badgeIcon.implicitHeight + 4
+
+            MaterialIcon {
+                id: badgeIcon
+                anchors.centerIn: parent
+                text: root.isVideo ? "videocam" : "image"
+                color: "white"
+                fontStyle: Tokens.font.icon.builders.extraSmall.scale(1).build()
             }
         }
     }

--- a/modules/launcher/items/WallpaperItem.qml
+++ b/modules/launcher/items/WallpaperItem.qml
@@ -16,7 +16,8 @@ Item {
 
     readonly property bool isVideo: Images.isVideoFile(root.modelData.path)
     readonly property string thumbnailPath: {
-        if (!isVideo) return root.modelData.path;
+        if (!isVideo)
+            return root.modelData.path;
         const i = root.modelData.path.lastIndexOf('/');
         const dir = root.modelData.path.substring(0, i);
         const name = root.modelData.path.substring(i + 1).replace(/\.[^.]+$/, '');

--- a/modules/launcher/items/WallpaperItem.qml
+++ b/modules/launcher/items/WallpaperItem.qml
@@ -96,6 +96,7 @@ Item {
 
             MaterialIcon {
                 id: badgeIcon
+
                 anchors.centerIn: parent
                 text: root.isVideo ? "videocam" : "image"
                 color: "white"

--- a/modules/launcher/items/WallpaperItem.qml
+++ b/modules/launcher/items/WallpaperItem.qml
@@ -98,7 +98,7 @@ Item {
                 anchors.centerIn: parent
                 text: root.isVideo ? "videocam" : "image"
                 color: "white"
-                fontStyle: Tokens.font.icon.builders.extraSmall.scale(1).build()
+                fontStyle: Tokens.font.icon.builders.small.scale(1).build()
             }
         }
     }

--- a/modules/nexus/common/WallItem.qml
+++ b/modules/nexus/common/WallItem.qml
@@ -6,16 +6,26 @@ import Quickshell
 import Caelestia.Config
 import qs.components
 import qs.components.controls
-import qs.services
+import qs.utils
 
 Item {
     id: root
 
-    property alias source: img.source
+    property string source
     property alias text: label.text
     property alias radius: imgWrapper.radius
     property alias imgHeight: imgWrapper.implicitHeight
     property bool fillLabel: true
+
+    readonly property bool isVideo: Images.isVideoFile(root.source)
+    readonly property string thumbnailPath: {
+        if (!root.isVideo)
+            return root.source;
+        const i = root.source.lastIndexOf('/');
+        const dir = root.source.substring(0, i);
+        const name = root.source.substring(i + 1).replace(/\.[^.]+$/, '');
+        return `${dir}/.thumbs/${name}.jpg`;
+    }
 
     signal clicked
 
@@ -36,33 +46,11 @@ Item {
             radius: Tokens.rounding.largeIncreased
             color: Colours.tPalette.m3surfaceContainer
 
-            Loader {
+            MaterialIcon {
                 anchors.centerIn: parent
-
-                opacity: img.status === Image.Ready ? 0 : 1
-                active: opacity > 0
-
-                sourceComponent: StyledRect {
-                    implicitWidth: loadingIndicator.implicitSize + Tokens.padding.large * 2
-                    implicitHeight: loadingIndicator.implicitSize + Tokens.padding.large * 2
-
-                    color: Colours.palette.m3primaryContainer
-                    radius: Tokens.rounding.full
-
-                    LoadingIndicator {
-                        id: loadingIndicator
-
-                        anchors.centerIn: parent
-                        containsIcon: true
-                        implicitSize: Math.min(imgWrapper.width, imgWrapper.height) * 0.3
-                    }
-                }
-
-                Behavior on opacity {
-                    Anim {
-                        type: Anim.DefaultEffects
-                    }
-                }
+                text: root.isVideo ? "videocam" : "image"
+                color: Colours.tPalette.m3outline
+                fontStyle: Tokens.font.icon.builders.extraLarge.scale(2).weight(Font.DemiBold).build()
             }
 
             Image {
@@ -71,6 +59,7 @@ Item {
                 anchors.fill: parent
                 asynchronous: true
                 fillMode: Image.PreserveAspectCrop
+                source: root.thumbnailPath
                 sourceSize: {
                     const dpr = (QsWindow.window as QsWindow)?.devicePixelRatio ?? 1;
                     return Qt.size(width * dpr, height * dpr);
@@ -82,6 +71,41 @@ Item {
                     Anim {
                         type: Anim.SlowEffects
                     }
+                }
+            }
+
+            StyledRect {
+                anchors.left: parent.left
+                anchors.top: parent.top
+                anchors.margins: 4
+                radius: Tokens.rounding.small
+                color: "#CC000000"
+                implicitWidth: badgeIcon.implicitWidth + 8
+                implicitHeight: badgeIcon.implicitHeight + 4
+
+                MaterialIcon {
+                    id: badgeIcon
+                    anchors.centerIn: parent
+                    text: root.isVideo ? "videocam" : "image"
+                    color: "white"
+                    fontStyle: Tokens.font.icon.builders.small.scale(1).build()
+                }
+            }
+
+            StyledRect {
+                anchors.centerIn: parent
+                visible: root.isVideo && img.status === Image.Error
+                radius: Tokens.rounding.full
+                color: Colours.palette.m3primaryContainer
+                implicitWidth: fallbackIcon.implicitWidth + Tokens.padding.large * 2
+                implicitHeight: fallbackIcon.implicitHeight + Tokens.padding.large * 2
+
+                MaterialIcon {
+                    id: fallbackIcon
+                    anchors.centerIn: parent
+                    text: "play_circle"
+                    color: Colours.palette.m3primary
+                    fontStyle: Tokens.font.icon.builders.medium.scale(1.5).build()
                 }
             }
         }

--- a/modules/nexus/common/WallItem.qml
+++ b/modules/nexus/common/WallItem.qml
@@ -85,6 +85,7 @@ Item {
 
                 MaterialIcon {
                     id: badgeIcon
+
                     anchors.centerIn: parent
                     text: root.isVideo ? "videocam" : "image"
                     color: "white"
@@ -102,6 +103,7 @@ Item {
 
                 MaterialIcon {
                     id: fallbackIcon
+
                     anchors.centerIn: parent
                     text: "play_circle"
                     color: Colours.palette.m3primary

--- a/modules/nexus/pages/WallpaperAndStyle.qml
+++ b/modules/nexus/pages/WallpaperAndStyle.qml
@@ -8,6 +8,7 @@ import qs.components
 import qs.components.controls
 import qs.components.images
 import qs.services
+import qs.utils
 import qs.modules.nexus.common
 
 PageBase {
@@ -114,7 +115,9 @@ PageBase {
 
                     interval: 100
                     onTriggered: {
-                        if (wallImg.status !== Image.Ready)
+                        if (wallImg.status === Image.Error)
+                            wallIndicatorLoader.opacity = 0;
+                        else if (wallImg.status !== Image.Ready)
                             wallIndicatorLoader.opacity = 1;
                     }
                 }
@@ -123,7 +126,16 @@ PageBase {
                     id: wallImg
 
                     anchors.fill: parent
-                    source: Wallpapers.current
+                    source: {
+                        const cur = Wallpapers.current;
+                        if (Images.isVideoFile(cur)) {
+                            const i = cur.lastIndexOf('/');
+                            const dir = cur.substring(0, i);
+                            const name = cur.substring(i + 1).replace(/\.[^.]+$/, '');
+                            return `${dir}/.thumbs/${name}.jpg`;
+                        }
+                        return cur;
+                    }
                     preventInit: wallIndicatorLoader.opacity > 0
                     fadeOutAnim: Anim.DefaultEffects
                     fadeInAnim: Anim.SlowEffects

--- a/modules/nexus/pages/wallandstyle/WallpaperSelect.qml
+++ b/modules/nexus/pages/wallandstyle/WallpaperSelect.qml
@@ -19,6 +19,8 @@ PageBase {
     title: qsTr("Wallpapers")
     isSubPage: true
 
+    Component.onCompleted: Wallpapers.updateThumbs()
+
     ColumnLayout {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top
@@ -192,6 +194,4 @@ PageBase {
             }
         }
     }
-
-    Component.onCompleted: Wallpapers.updateThumbs()
 }

--- a/modules/nexus/pages/wallandstyle/WallpaperSelect.qml
+++ b/modules/nexus/pages/wallandstyle/WallpaperSelect.qml
@@ -101,10 +101,13 @@ PageBase {
                 model: {
                     const walls = Wallpapers.list;
                     const baseDir = Paths.wallsdir;
+                    const videoBase = Paths.videowallsdir;
                     const categories = {};
                     const list = [];
                     for (const w of walls) {
-                        if (w.parentDir !== baseDir) {
+                        if (w.parentDir === videoBase) {
+                            list.push(w);
+                        } else if (w.parentDir !== baseDir) {
                             const category = Wallpapers.getCategoryFor(w);
                             if (category && (!(category in categories) || categories[category].name.localeCompare(w.name) > 0))
                                 categories[category] = w;
@@ -113,7 +116,11 @@ PageBase {
                         }
                     }
                     list.push(...Object.values(categories));
-                    list.sort((a, b) => ((a.parentDir === baseDir) - (b.parentDir === baseDir)) || a.name.localeCompare(b.name));
+                    list.sort((a, b) => {
+                        const aIsDirect = a.parentDir === baseDir || a.parentDir === videoBase;
+                        const bIsDirect = b.parentDir === baseDir || b.parentDir === videoBase;
+                        return (bIsDirect - aIsDirect) || a.name.localeCompare(b.name);
+                    });
                     while (list.length < Config.nexus.wallpapersPerRow)
                         list.push(null);
                     return list;
@@ -131,14 +138,14 @@ PageBase {
                         if (!modelData)
                             return "";
 
-                        if (modelData.parentDir !== Paths.wallsdir) {
+                        if (modelData.parentDir !== Paths.wallsdir && modelData.parentDir !== Paths.videowallsdir) {
                             const category = Wallpapers.getCategoryFor(modelData);
                             return category.slice(0, 1).toUpperCase() + category.slice(1);
                         }
                         return modelData.name;
                     }
                     onClicked: {
-                        if (modelData.parentDir !== Paths.wallsdir) {
+                        if (modelData.parentDir !== Paths.wallsdir && modelData.parentDir !== Paths.videowallsdir) {
                             root.nState.selectedWallpaperCategory = Wallpapers.getCategoryFor(modelData);
                             root.nState.openSubPage(2); // Category page
                         } else {

--- a/modules/nexus/pages/wallandstyle/WallpaperSelect.qml
+++ b/modules/nexus/pages/wallandstyle/WallpaperSelect.qml
@@ -192,4 +192,6 @@ PageBase {
             }
         }
     }
+
+    Component.onCompleted: Wallpapers.updateThumbs()
 }

--- a/services/Wallpapers.qml
+++ b/services/Wallpapers.qml
@@ -59,7 +59,7 @@ Searcher {
             Colours.showPreview = false;
     }
 
-    list: wallpapers.entries
+    list: [...wallpapers.entries, ...videoWallpapers.entries]
     key: "relativePath"
     useFuzzy: GlobalConfig.launcher.useFuzzy.wallpapers
     extraOpts: useFuzzy ? ({}) : ({
@@ -109,6 +109,14 @@ Searcher {
         recursive: true
         path: Paths.wallsdir
         filter: FileSystemModel.Images
+    }
+
+    FileSystemModel {
+        id: videoWallpapers
+
+        recursive: true
+        path: Paths.videowallsdir
+        nameFilters: Images.validVideoExtensions.map(ext => "*." + ext)
     }
 
     Process {

--- a/services/Wallpapers.qml
+++ b/services/Wallpapers.qml
@@ -46,6 +46,11 @@ Searcher {
             getPreviewColoursProc.running = true;
     }
 
+    function updateThumbs(): void {
+        if (Paths.videowallsdir !== Paths.wallsdir)
+            thumbProcess.running = true;
+    }
+
     function stopPreview(): void {
         showPreview = false;
         if (previewColourLock)
@@ -129,6 +134,16 @@ Searcher {
                 if (root.showPreview)
                     Colours.showPreview = true;
             }
+        }
+    }
+
+    Process {
+        id: thumbProcess
+
+        command: ["caelestia", "wallpaper", "--update-thumbs"]
+        onExited: { // qmllint disable signal-handler-parameters
+            videoWallpapers.path = "";
+            videoWallpapers.path = Paths.videowallsdir;
         }
     }
 }

--- a/services/Wallpapers.qml
+++ b/services/Wallpapers.qml
@@ -126,7 +126,8 @@ Searcher {
         stdout: StdioCollector {
             onStreamFinished: {
                 Colours.load(text, true);
-                Colours.showPreview = true;
+                if (root.showPreview)
+                    Colours.showPreview = true;
             }
         }
     }

--- a/shell.qml
+++ b/shell.qml
@@ -3,6 +3,7 @@
 //@ pragma DefaultEnv QS_DROP_EXPENSIVE_FONTS=1
 //@ pragma DefaultEnv QSG_RENDER_LOOP=threaded
 //@ pragma DefaultEnv QT_QUICK_FLICKABLE_WHEEL_DECELERATION=10000
+//@ pragma Env QT_MEDIA_BACKEND=ffmpeg
 
 import "modules"
 import "modules/drawers"

--- a/utils/Images.qml
+++ b/utils/Images.qml
@@ -5,8 +5,17 @@ import Quickshell
 Singleton {
     readonly property list<string> validImageTypes: ["jpeg", "png", "webp", "tiff", "svg"]
     readonly property list<string> validImageExtensions: ["jpg", "jpeg", "png", "webp", "tif", "tiff", "svg"]
+    readonly property list<string> validVideoExtensions: ["mp4", "webm", "mkv", "avi", "mov"]
 
     function isValidImageByName(name: string): bool {
         return validImageExtensions.some(t => name.endsWith(`.${t}`));
+    }
+
+    function isValidVideoByName(name: string): bool {
+        return validVideoExtensions.some(t => name.endsWith(`.${t}`));
+    }
+
+    function isVideoFile(path: string): bool {
+        return isValidVideoByName(path.split('/').pop());
     }
 }

--- a/utils/Paths.qml
+++ b/utils/Paths.qml
@@ -20,6 +20,7 @@ Singleton {
     readonly property string imagecache: `${cache}/imagecache`
     readonly property string notifimagecache: `${imagecache}/notifs`
     readonly property string wallsdir: Quickshell.env("CAELESTIA_WALLPAPERS_DIR") || absolutePath(GlobalConfig.paths.wallpaperDir)
+    readonly property string videowallsdir: Quickshell.env("CAELESTIA_VIDEO_WALLPAPERS_DIR") || `${home}/Videos/Wallpapers`
     readonly property string recsdir: Quickshell.env("CAELESTIA_RECORDINGS_DIR") || `${videos}/Recordings`
     readonly property string libdir: Quickshell.env("CAELESTIA_LIB_DIR") || "/usr/lib/caelestia"
 


### PR DESCRIPTION
- Wallpaper.qml: single-layer architecture with MediaPlayer+VideoOutput for videos, CachingImage for images, fade-in animations, timer-based cleanup preventing flash between transitions
- WallpaperItem.qml: video/image badge icons, thumbnail via .thumbs/
- Wallpapers.qml: merged image+video FileSystemModels
- Images.qml: isValidVideoByName, isVideoFile utilities
- Paths.qml: videowallsdir property
- shell.qml: QT_MEDIA_BACKEND=ffmpeg

Edit: this PR has a CLI part https://github.com/caelestia-dots/cli/pull/136

Edit 2: 
- isPaused: unloads video on fullscreen/game mode, shows static thumbnail

Edit 3:
- Nexus: video thumbnails with badge in wallpaper grid, fixed preview

Edit 4:
- Auto generate video wallpaper thumbnails and refresh on completion