### PR TITLE
feat: cap networks shown in nexus

### DIFF
--- a/components/controls/IconTextButton.qml
+++ b/components/controls/IconTextButton.qml
@@ -9,6 +9,7 @@ ButtonBase {
 
     property alias icon: iconLabel.text
     property alias text: label.text
+    property alias spacing: row.spacing
 
     readonly property alias iconLabel: iconLabel
     readonly property alias label: label

--- a/modules/nexus/PageCompRegistry.qml
+++ b/modules/nexus/PageCompRegistry.qml
@@ -58,6 +58,9 @@ QtObject {
                 Component {
                     AddVpnPage {}
                 }
+                Component {
+                    AllNetworksPage {}
+                }
             }
         },
         Component {

--- a/modules/nexus/common/NetworkList.qml
+++ b/modules/nexus/common/NetworkList.qml
@@ -1,0 +1,175 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.utils
+import qs.modules.nexus
+
+ItemList {
+    id: root
+
+    required property NexusState nState
+    property int limit: 0 // 0 = show all
+    property bool enableFilter
+
+    signal networkSelected(ap: Nmcli.AccessPoint)
+
+    function networkFilter(ap: Nmcli.AccessPoint): bool {
+        return true;
+    }
+
+    showList: Nmcli.wifiEnabled
+    placeholderIcon: Nmcli.wifiEnabled ? "wifi_find" : "signal_wifi_off"
+    placeholderText: Nmcli.wifiEnabled ? qsTr("No networks found") : qsTr("Wi-Fi disabled")
+    extraHeight: Nmcli.scanning ? Tokens.rounding.extraSmall : 0 // Inline so it isn't affected by anim
+    list.anchors.top: scanningIndicator.bottom
+
+    model: ScriptModel {
+        values: {
+            const connecting = Nmcli.connectingSsid();
+            // Lower rank sorts higher in the list
+            const rank = n => n.active ? 0 : n.ssid === connecting ? 1 : Nmcli.hasSavedProfile(n.ssid) ? 2 : 3;
+            const sorted = [...Nmcli.networks].sort((a, b) => rank(a) - rank(b) || b.strength - a.strength);
+            if (root.limit > 0 && sorted.length > root.limit)
+                sorted.length = root.limit;
+            return root.enableFilter ? sorted.filter(root.networkFilter) : sorted;
+        }
+    }
+
+    delegate: StateLayer {
+        id: network
+
+        required property int index
+        required property var modelData
+        property bool currentSelected
+        property real textOpacity: disabled ? 0.5 : 1
+
+        disabled: currentSelected || Nmcli.connectingSsid() === modelData.ssid
+
+        anchors.left: root.list.contentItem.left
+        anchors.right: root.list.contentItem.right
+        implicitHeight: networkLayout.implicitHeight + networkLayout.anchors.margins * 2
+        radius: Tokens.rounding.extraSmall
+        bottomLeftRadius: root?.last && index === root.list.count - 1 ? Tokens.rounding.extraLarge : radius
+        bottomRightRadius: root?.last && index === root.list.count - 1 ? Tokens.rounding.extraLarge : radius
+        anchors.fill: undefined
+
+        onClicked: {
+            if (!modelData.active) {
+                NetworkConnection.handleConnect(modelData);
+                currentSelected = true;
+                root.networkSelected(modelData);
+            } else {
+                // Active network: open its detail/settings sub-page.
+                root.nState.selectedNetworkSsid = modelData.ssid;
+                root.nState.openSubPage(3);
+            }
+        }
+
+        Behavior on textOpacity {
+            Anim {
+                type: Anim.DefaultEffects
+            }
+        }
+
+        Connections {
+            function onActiveChanged(): void {
+                if (network.modelData.active)
+                    network.currentSelected = false;
+            }
+
+            target: network.modelData
+        }
+
+        Connections {
+            function onNetworkSelected(ap: Nmcli.AccessPoint): void {
+                if (ap !== network.modelData)
+                    network.currentSelected = false;
+            }
+
+            target: root
+        }
+
+        RowLayout {
+            id: networkLayout
+
+            anchors.fill: parent
+            anchors.margins: Tokens.padding.large
+            anchors.leftMargin: Tokens.padding.extraLarge
+            anchors.rightMargin: Tokens.padding.extraLarge
+            spacing: Tokens.spacing.medium
+
+            MaterialIcon {
+                text: Icons.getNetworkIcon(network.modelData.strength)
+                color: network.modelData.active ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                fontStyle: Tokens.font.icon.medium
+                opacity: network.textOpacity
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+                opacity: network.textOpacity
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: network.modelData.ssid
+                    font: Tokens.font.body.small
+                    elide: Text.ElideRight
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("Security: %1%2").arg(network.modelData.security).arg(network.modelData.active ? qsTr(" • Connected") : Nmcli.hasSavedProfile(network.modelData.ssid) ? qsTr(" • Saved") : "")
+                    color: Colours.palette.m3outline
+                    font: Tokens.font.label.small
+                    elide: Text.ElideRight
+                }
+            }
+
+            AnimLoader {
+                sourceComp: Nmcli.connectingSsid() === network.modelData.ssid ? loadingComp : iconComp
+
+                Component {
+                    id: iconComp
+
+                    MaterialIcon {
+                        text: network.modelData.active ? "settings" : "lock"
+                        color: network.modelData.active ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.medium
+                        opacity: network.textOpacity
+                    }
+                }
+
+                Component {
+                    id: loadingComp
+
+                    LoadingIndicator {
+                        implicitSize: Math.round(Tokens.font.icon.medium.pointSize * 1.3)
+                    }
+                }
+            }
+        }
+    }
+
+    StyledProgressBar {
+        id: scanningIndicator
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.margins: 1
+        implicitHeight: Nmcli.scanning ? Tokens.rounding.extraSmall : 0
+        indeterminate: true
+
+        Behavior on implicitHeight {
+            Anim {
+                type: Anim.DefaultEffects
+            }
+        }
+    }
+}

--- a/modules/nexus/pages/NetworkPage.qml
+++ b/modules/nexus/pages/NetworkPage.qml
@@ -71,7 +71,7 @@ PageBase {
             nState: root.nState
             limit: GlobalConfig.nexus.maxNetworksShown
 
-            Behavior on Layout.topMargin {
+            Behavior on Layout.bottomMargin {
                 Anim {
                     type: Anim.DefaultEffects
                 }

--- a/modules/nexus/pages/NetworkPage.qml
+++ b/modules/nexus/pages/NetworkPage.qml
@@ -7,13 +7,10 @@ import Caelestia.Config
 import qs.components
 import qs.components.controls
 import qs.services
-import qs.utils
 import qs.modules.nexus.common
 
 PageBase {
     id: root
-
-    signal networkSelected(ap: Nmcli.AccessPoint)
 
     title: qsTr("Network")
 
@@ -69,150 +66,59 @@ PageBase {
             onToggled: Nmcli.enableWifi(checked)
         }
 
-        ItemList {
-            id: networkList
+        NetworkList {
+            Layout.bottomMargin: Nmcli.wifiEnabled && Nmcli.networks.length > GlobalConfig.nexus.maxNetworksShown ? 0 : -parent.spacing
+            nState: root.nState
+            limit: GlobalConfig.nexus.maxNetworksShown
 
-            showList: Nmcli.wifiEnabled
-            placeholderIcon: Nmcli.wifiEnabled ? "wifi_find" : "signal_wifi_off"
-            placeholderText: Nmcli.wifiEnabled ? qsTr("No networks found") : qsTr("Wi-Fi disabled")
-            extraHeight: Nmcli.scanning ? Tokens.rounding.extraSmall : 0 // Inline so it isn't affected by anim
-            list.anchors.top: scanningIndicator.bottom
+            Behavior on Layout.topMargin {
+                Anim {
+                    type: Anim.DefaultEffects
+                }
+            }
+        }
 
-            model: ScriptModel {
-                values: {
-                    const connecting = Nmcli.connectingSsid();
-                    // Lower rank sorts higher in the list
-                    const rank = n => n.active ? 0 : n.ssid === connecting ? 1 : Nmcli.hasSavedProfile(n.ssid) ? 2 : 3;
-                    return [...Nmcli.networks].sort((a, b) => rank(a) - rank(b) || b.strength - a.strength);
+        // All networks button, only when > max networks
+        ConnectedRect {
+            Layout.fillWidth: true
+            Layout.preferredHeight: Nmcli.wifiEnabled && Nmcli.networks.length > GlobalConfig.nexus.maxNetworksShown ? showAllLayout.implicitHeight + Tokens.padding.medium * 2 : 0
+            clip: true
+
+            Behavior on Layout.preferredHeight {
+                Anim {
+                    type: Anim.DefaultEffects
                 }
             }
 
-            delegate: StateLayer {
-                id: network
-
-                required property var modelData
-                property bool currentSelected
-                property real textOpacity: disabled ? 0.5 : 1
-
-                disabled: currentSelected || Nmcli.connectingSsid() === modelData.ssid
-
-                anchors.left: networkList.list.contentItem.left
-                anchors.right: networkList.list.contentItem.right
-                implicitHeight: networkLayout.implicitHeight + networkLayout.anchors.margins * 2
-                radius: Tokens.rounding.extraSmall
-                anchors.fill: undefined
-
-                onClicked: {
-                    if (!modelData.active) {
-                        NetworkConnection.handleConnect(modelData);
-                        currentSelected = true;
-                        root.networkSelected(modelData);
-                    } else {
-                        // Active network: open its detail/settings sub-page.
-                        root.nState.selectedNetworkSsid = modelData.ssid;
-                        root.nState.openSubPage(3);
-                    }
-                }
-
-                Behavior on textOpacity {
-                    Anim {
-                        type: Anim.DefaultEffects
-                    }
-                }
-
-                Connections {
-                    function onActiveChanged(): void {
-                        if (network.modelData.active)
-                            network.currentSelected = false;
-                    }
-
-                    target: network.modelData
-                }
-
-                Connections {
-                    function onNetworkSelected(ap: Nmcli.AccessPoint): void {
-                        if (ap !== network.modelData)
-                            network.currentSelected = false;
-                    }
-
-                    target: root
-                }
-
-                RowLayout {
-                    id: networkLayout
-
-                    anchors.fill: parent
-                    anchors.margins: Tokens.padding.large
-                    anchors.leftMargin: Tokens.padding.extraLarge
-                    anchors.rightMargin: Tokens.padding.extraLarge
-                    spacing: Tokens.spacing.medium
-
-                    MaterialIcon {
-                        text: Icons.getNetworkIcon(network.modelData.strength)
-                        color: network.modelData.active ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
-                        fontStyle: Tokens.font.icon.medium
-                        opacity: network.textOpacity
-                    }
-
-                    ColumnLayout {
-                        Layout.fillWidth: true
-                        spacing: 0
-                        opacity: network.textOpacity
-
-                        StyledText {
-                            Layout.fillWidth: true
-                            text: network.modelData.ssid
-                            font: Tokens.font.body.small
-                            elide: Text.ElideRight
-                        }
-
-                        StyledText {
-                            Layout.fillWidth: true
-                            text: qsTr("Security: %1%2").arg(network.modelData.security).arg(network.modelData.active ? qsTr(" • Connected") : Nmcli.hasSavedProfile(network.modelData.ssid) ? qsTr(" • Saved") : "")
-                            color: Colours.palette.m3outline
-                            font: Tokens.font.label.small
-                            elide: Text.ElideRight
-                        }
-                    }
-
-                    AnimLoader {
-                        sourceComp: Nmcli.connectingSsid() === network.modelData.ssid ? loadingComp : iconComp
-
-                        Component {
-                            id: iconComp
-
-                            MaterialIcon {
-                                text: network.modelData.active ? "settings" : "lock"
-                                color: network.modelData.active ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
-                                fontStyle: Tokens.font.icon.medium
-                                opacity: network.textOpacity
-                            }
-                        }
-
-                        Component {
-                            id: loadingComp
-
-                            LoadingIndicator {
-                                implicitSize: Math.round(Tokens.font.icon.medium.pointSize * 1.3)
-                            }
-                        }
-                    }
-                }
+            StateLayer {
+                onClicked: root.nState.openSubPage(5) // All networks sub-page
             }
 
-            StyledProgressBar {
-                id: scanningIndicator
+            RowLayout {
+                id: showAllLayout
 
                 anchors.left: parent.left
                 anchors.right: parent.right
-                anchors.margins: 1
-                implicitHeight: Nmcli.scanning ? Tokens.rounding.extraSmall : 0
-                indeterminate: true
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.margins: Tokens.padding.largeIncreased
+                spacing: Tokens.spacing.medium
 
-                Behavior on implicitHeight {
-                    Anim {
-                        type: Anim.DefaultEffects
-                    }
+                MaterialIcon {
+                    text: "expand_content"
+                    fontStyle: Tokens.font.icon.medium
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("Show all networks (%1)").arg(Nmcli.networks.length)
+                    font: Tokens.font.body.small
+                    elide: Text.ElideRight
+                }
+
+                MaterialIcon {
+                    text: "chevron_right"
+                    color: Colours.palette.m3onSurfaceVariant
+                    fontStyle: Tokens.font.icon.medium
                 }
             }
         }

--- a/modules/nexus/pages/network/AllNetworksPage.qml
+++ b/modules/nexus/pages/network/AllNetworksPage.qml
@@ -1,0 +1,168 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.modules.nexus.common
+
+PageBase {
+    id: root
+
+    title: qsTr("All networks")
+    isSubPage: true
+    flickable.bottomMargin: Tokens.padding.extraExtraLarge * 2 // Extra scrolling space at the bottom
+
+    ColumnLayout {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        width: root.cappedWidth
+        spacing: Tokens.spacing.extraSmall / 2
+
+        Timer {
+            running: root.visible && Nmcli.wifiEnabled
+            repeat: true
+            triggeredOnStart: true
+            interval: GlobalConfig.nexus.networkRescanInterval
+            onTriggered: Nmcli.rescanWifi()
+        }
+
+        ConnectedRect {
+            Layout.fillWidth: true
+            implicitHeight: headerLayout.implicitHeight + Tokens.padding.medium * 2
+            first: true
+
+            RowLayout {
+                id: headerLayout
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.leftMargin: Tokens.padding.largeIncreased
+                anchors.rightMargin: Tokens.padding.large
+                anchors.verticalCenterOffset: 1
+
+                spacing: Tokens.spacing.extraSmall / 2
+
+                StyledText {
+                    text: qsTr("Filters")
+                    font: Tokens.font.title.small
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                FilterButton {
+                    id: savedFilter
+
+                    function internalFilter(ap: Nmcli.AccessPoint): bool {
+                        return Nmcli.hasSavedProfile(ap.ssid);
+                    }
+
+                    text: qsTr("Saved")
+                    topLeftRadius: pressed ? pressedRadius : implicitHeight / 2
+                    bottomLeftRadius: pressed ? pressedRadius : implicitHeight / 2
+
+                    Behavior on topLeftRadius {
+                        Anim {
+                            type: Anim.DefaultEffects
+                        }
+                    }
+
+                    Behavior on bottomLeftRadius {
+                        Anim {
+                            type: Anim.DefaultEffects
+                        }
+                    }
+                }
+
+                FilterButton {
+                    id: secureFilter
+
+                    function internalFilter(ap: Nmcli.AccessPoint): bool {
+                        return ap.security !== "none";
+                    }
+
+                    text: qsTr("Secured")
+                }
+
+                FilterButton {
+                    id: highFreqFilter
+
+                    function internalFilter(ap: Nmcli.AccessPoint): bool {
+                        return ap.frequency >= 4900 && ap.frequency <= 5900;
+                    }
+
+                    text: qsTr("5 GHz")
+                }
+
+                FilterButton {
+                    id: lowFreqFilter
+
+                    function internalFilter(ap: Nmcli.AccessPoint): bool {
+                        return ap.frequency >= 2400 && ap.frequency <= 2500;
+                    }
+
+                    text: qsTr("2.4 GHz")
+                    topRightRadius: pressed ? pressedRadius : implicitHeight / 2
+                    bottomRightRadius: pressed ? pressedRadius : implicitHeight / 2
+
+                    Behavior on topRightRadius {
+                        Anim {
+                            type: Anim.DefaultEffects
+                        }
+                    }
+
+                    Behavior on bottomRightRadius {
+                        Anim {
+                            type: Anim.DefaultEffects
+                        }
+                    }
+                }
+            }
+        }
+
+        NetworkList {
+            id: networkList
+
+            function networkFilter(ap: Nmcli.AccessPoint): bool {
+                return savedFilter.filter(ap) && secureFilter.filter(ap) && highFreqFilter.filter(ap) && lowFreqFilter.filter(ap);
+            }
+
+            nState: root.nState
+            enableFilter: true
+            last: true
+        }
+    }
+
+    component FilterButton: IconTextButton {
+        id: filter
+
+        property int filterState // 0 = default, 1 = on, 2 = negate
+
+        function filter(ap: Nmcli.AccessPoint): bool {
+            if (filterState === 0)
+                return true;
+            if (filterState === 1)
+                return internalFilter(ap);
+            return !internalFilter(ap);
+        }
+
+        function internalFilter(ap: Nmcli.AccessPoint): bool {
+            return true;
+        }
+
+        onClicked: filterState = (filterState + 1) % 3
+
+        defaultRadius: Tokens.rounding.small
+        pressedRadius: Tokens.rounding.extraSmall
+        spacing: Tokens.spacing.extraSmall
+
+        icon: ["check_indeterminate_small", "check", "close"][filterState]
+        inactiveColour: [Colours.palette.m3secondaryContainer, Colours.palette.m3primary, Colours.palette.m3tertiary][filterState]
+        inactiveOnColour: [Colours.palette.m3onSecondaryContainer, Colours.palette.m3onPrimary, Colours.palette.m3onTertiary][filterState]
+    }
+}

--- a/plugin/src/Caelestia/Config/nexusconfig.hpp
+++ b/plugin/src/Caelestia/Config/nexusconfig.hpp
@@ -9,6 +9,7 @@ class NexusConfig : public ConfigObject {
     QML_ANONYMOUS
 
     CONFIG_PROPERTY(int, wallpapersPerRow, 4)
+    CONFIG_PROPERTY(int, maxNetworksShown, 5)
     CONFIG_GLOBAL_PROPERTY(int, networkRescanInterval, 15000)
 
 public:


### PR DESCRIPTION
Instead of a full list of potentially many networks, cap the networks shown at a configurable number (5 by default), and show a "Show all networks" button to navigate to a subpage containing all networks.