### PR TITLE
feat: add saved networks sub page to nexus

### DIFF
--- a/modules/nexus/NexusState.qml
+++ b/modules/nexus/NexusState.qml
@@ -16,6 +16,7 @@ QtObject {
     property int editingVpnIndex: -1
     property string selectedNetworkSsid
     property string selectedEthernetInterface
+    property bool networkDetailsFromSaved
 
     signal close
     signal subPageOpened(idx: int)

--- a/modules/nexus/PageCompRegistry.qml
+++ b/modules/nexus/PageCompRegistry.qml
@@ -61,6 +61,9 @@ QtObject {
                 Component {
                     AllNetworksPage {}
                 }
+                Component {
+                    SavedNetworksPage {}
+                }
             }
         },
         Component {

--- a/modules/nexus/common/NetworkList.qml
+++ b/modules/nexus/common/NetworkList.qml
@@ -67,6 +67,7 @@ ItemList {
             } else {
                 // Active network: open its detail/settings sub-page.
                 root.nState.selectedNetworkSsid = modelData.ssid;
+                root.nState.networkDetailsFromSaved = false;
                 root.nState.openSubPage(3);
             }
         }

--- a/modules/nexus/pages/NetworkPage.qml
+++ b/modules/nexus/pages/NetworkPage.qml
@@ -123,6 +123,46 @@ PageBase {
             }
         }
 
+        // Saved networks button
+        ConnectedRect {
+            Layout.fillWidth: true
+            implicitHeight: savedNetworksLayout.implicitHeight + savedNetworksLayout.anchors.margins * 2
+
+            StateLayer {
+                onClicked: root.nState.openSubPage(6) // Saved networks sub-page
+            }
+
+            RowLayout {
+                id: savedNetworksLayout
+
+                anchors.fill: parent
+                anchors.margins: Tokens.padding.medium
+                anchors.leftMargin: Tokens.padding.largeIncreased
+                anchors.rightMargin: Tokens.padding.largeIncreased
+                spacing: Tokens.spacing.medium
+
+                MaterialIcon {
+                    text: "bookmark"
+                    color: Colours.palette.m3onSurfaceVariant
+                    fontStyle: Tokens.font.icon.medium
+                    fill: 1
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("Saved networks")
+                    font: Tokens.font.body.small
+                    elide: Text.ElideRight
+                }
+
+                MaterialIcon {
+                    text: "chevron_right"
+                    color: Colours.palette.m3onSurfaceVariant
+                    fontStyle: Tokens.font.icon.medium
+                }
+            }
+        }
+
         ConnectedRect {
             Layout.fillWidth: true
             implicitHeight: addNetworkLayout.implicitHeight + addNetworkLayout.anchors.margins * 2

--- a/modules/nexus/pages/network/NetworkDetailPage.qml
+++ b/modules/nexus/pages/network/NetworkDetailPage.qml
@@ -17,6 +17,7 @@ PageBase {
     readonly property string ssid: nState.selectedNetworkSsid
     readonly property var ap: Nmcli.findNetwork(root.ssid)
     readonly property var details: Nmcli.wirelessDeviceDetails
+    readonly property bool isActive: !!Nmcli.active && Nmcli.active.ssid === root.ssid
 
     // Locally-edited IPv4 form state.
     property string ipMethod: "auto" // "auto" | "auto-dns" | "manual"
@@ -80,8 +81,9 @@ PageBase {
     }
 
     // Close if the network is no longer active (e.g. disconnected elsewhere).
+    // ...But not when the page was opened from saved networks
     onApChanged: {
-        if (root.ipLoaded && !root.ap)
+        if (!nState.networkDetailsFromSaved && root.ipLoaded && !root.ap)
             nState.closeSubPage();
     }
 
@@ -103,14 +105,14 @@ PageBase {
         ButtonRow {
             Layout.bottomMargin: Tokens.spacing.large - parent.spacing
             Layout.alignment: Qt.AlignHCenter
-            Layout.minimumWidth: Math.round(root.cappedWidth * 0.7)
+            Layout.minimumWidth: Math.round(root.cappedWidth * (root.isActive ? 0.7 : 0.5))
             spacing: Tokens.spacing.small
 
             ButtonBase {
                 id: forgetBtn
 
                 fillWidth: true
-                shapeMorph: true
+                shapeMorph: root.isActive
                 isRound: true
                 inactiveColour: Colours.palette.m3errorContainer
                 inactiveOnColour: Colours.palette.m3onErrorContainer
@@ -147,6 +149,7 @@ PageBase {
             ButtonBase {
                 id: disconnectBtn
 
+                visible: root.isActive
                 fillWidth: true
                 shapeMorph: true
                 isRound: true
@@ -183,10 +186,11 @@ PageBase {
             }
         }
 
-        // ---- Connection info -------------------------------------------------
+        // ---- Connection info (only shows when active) ---------------------------------
         SectionHeader {
             first: true
             text: qsTr("Connection")
+            visible: root.isActive
         }
 
         InfoRow {
@@ -194,30 +198,35 @@ PageBase {
             icon: "signal_wifi_4_bar"
             label: qsTr("Signal")
             value: root.ap ? qsTr("%1%").arg(root.ap.strength) : qsTr("—")
+            visible: root.isActive
         }
 
         InfoRow {
             icon: "lock"
             label: qsTr("Security")
             value: root.ap?.security || qsTr("Open")
+            visible: root.isActive
         }
 
         InfoRow {
             icon: "graphic_eq"
             label: qsTr("Frequency")
             value: root.ap && root.ap.frequency > 0 ? qsTr("%1 MHz").arg(root.ap.frequency) : qsTr("—")
+            visible: root.isActive
         }
 
         InfoRow {
             icon: "lan"
             label: qsTr("IP address")
             value: root.details?.ipAddress || qsTr("—")
+            visible: root.isActive
         }
 
         InfoRow {
             icon: "router"
             label: qsTr("Gateway")
             value: root.details?.gateway || qsTr("—")
+            visible: root.isActive
         }
 
         InfoRow {
@@ -225,10 +234,12 @@ PageBase {
             icon: "memory"
             label: qsTr("MAC address")
             value: root.details?.macAddress || qsTr("—")
+            visible: root.isActive
         }
 
         // ---- Behaviour -------------------------------------------------------
         SectionHeader {
+            first: !root.isActive
             text: qsTr("Behaviour")
         }
 

--- a/modules/nexus/pages/network/SavedNetworksPage.qml
+++ b/modules/nexus/pages/network/SavedNetworksPage.qml
@@ -1,0 +1,116 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Caelestia.Config
+import qs.components
+import qs.services
+import qs.utils
+import qs.modules.nexus.common
+
+PageBase {
+    id: root
+
+    title: qsTr("Saved networks")
+    isSubPage: true
+
+    Component.onCompleted: Nmcli.loadSavedConnections(() => {})
+
+    ColumnLayout {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        width: root.cappedWidth
+        spacing: Tokens.spacing.extraSmall / 2
+
+        ItemList {
+            id: savedList
+
+            showList: true
+            first: true
+            last: true
+            placeholderIcon: "wifi_find"
+            placeholderText: qsTr("No saved networks")
+
+            model: ScriptModel {
+                values: [...Nmcli.savedConnectionSsids].sort((a, b) => a.localeCompare(b))
+            }
+
+            delegate: StateLayer {
+                id: saved
+
+                required property int index
+                required property var modelData
+                readonly property var ap: Nmcli.findNetwork(modelData)
+                readonly property bool isActive: !!Nmcli.active && Nmcli.active.ssid === modelData
+
+                anchors.left: savedList.list.contentItem.left
+                anchors.right: savedList.list.contentItem.right
+                implicitHeight: savedLayout.implicitHeight + savedLayout.anchors.margins * 2
+                radius: Tokens.rounding.extraSmall
+                topLeftRadius: index === 0 ? Tokens.rounding.extraLarge : radius
+                topRightRadius: index === 0 ? Tokens.rounding.extraLarge : radius
+                bottomLeftRadius: index === savedList?.list.count - 1 ? Tokens.rounding.extraLarge : radius
+                bottomRightRadius: index === savedList?.list.count - 1 ? Tokens.rounding.extraLarge : radius
+                anchors.fill: undefined
+
+                onClicked: {
+                    root.nState.selectedNetworkSsid = saved.modelData;
+                    root.nState.networkDetailsFromSaved = true;
+                    root.nState.openSubPage(3); // Shared network detail/edit sub-page
+                }
+
+                RowLayout {
+                    id: savedLayout
+
+                    anchors.fill: parent
+                    anchors.margins: Tokens.padding.large
+                    anchors.leftMargin: Tokens.padding.extraLarge
+                    anchors.rightMargin: Tokens.padding.extraLarge
+                    spacing: Tokens.spacing.medium
+
+                    MaterialIcon {
+                        text: saved.ap ? Icons.getNetworkIcon(saved.ap.strength, !["", "none"].includes(Nmcli.savedSecurityFor(saved.modelData))) : "signal_wifi_off"
+                        color: saved.isActive ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.medium
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 0
+
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: saved.modelData
+                            font: Tokens.font.body.small
+                            elide: Text.ElideRight
+                        }
+
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: {
+                                let security;
+                                if (saved.ap)
+                                    security = saved.ap.security || qsTr("Open");
+                                else
+                                    security = Nmcli.securityLabel(Nmcli.savedSecurityFor(saved.modelData)) || qsTr("Unknown");
+                                if (saved.isActive)
+                                    return qsTr("Connected • %1").arg(security);
+                                return security;
+                            }
+                            color: saved.isActive ? Colours.palette.m3primary : Colours.palette.m3outline
+                            font: Tokens.font.label.small
+                            elide: Text.ElideRight
+                        }
+                    }
+
+                    MaterialIcon {
+                        text: "chevron_right"
+                        color: Colours.palette.m3onSurfaceVariant
+                        fontStyle: Tokens.font.icon.medium
+                    }
+                }
+            }
+        }
+    }
+}

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -21,6 +21,8 @@ Singleton {
     readonly property AccessPoint active: networks.find(n => n.active) ?? null
     property list<string> savedConnections: []
     property list<string> savedConnectionSsids: []
+    // Map of saved Wi-Fi SSID (lowercased) -> security type
+    property var savedConnectionSecurity: ({})
 
     property var wifiConnectionQueue: []
     property int currentSsidQueryIndex: 0
@@ -499,6 +501,7 @@ Singleton {
             if (!result.success) {
                 root.savedConnections = [];
                 root.savedConnectionSsids = [];
+                root.savedConnectionSecurity = {};
                 if (callback)
                     callback([]);
                 return;
@@ -528,6 +531,8 @@ Singleton {
 
         root.savedConnections = connections;
 
+        root.savedConnectionSecurity = {};
+
         if (wifiConnections.length > 0) {
             root.wifiConnectionQueue = wifiConnections;
             root.currentSsidQueryIndex = 0;
@@ -546,7 +551,7 @@ Singleton {
             const connectionName = root.wifiConnectionQueue[root.currentSsidQueryIndex];
             root.currentSsidQueryIndex++;
 
-            executeCommand(["-t", "-f", root.wirelessSsidField, root.nmcliCommandConnection, "show", connectionName], result => {
+            executeCommand(["-t", "-f", `${root.wirelessSsidField},${root.securityKeyMgmt}`, root.nmcliCommandConnection, "show", connectionName], result => {
                 if (result.success) {
                     processSsidOutput(result.output);
                 }
@@ -561,21 +566,61 @@ Singleton {
     }
 
     function processSsidOutput(output: string): void {
-        const lines = output.trim().split("\n");
-        for (const line of lines) {
-            if (line.startsWith("802-11-wireless.ssid:")) {
-                const ssid = line.substring("802-11-wireless.ssid:".length).trim();
-                if (ssid && ssid.length > 0) {
-                    const ssidLower = ssid.toLowerCase();
-                    const exists = root.savedConnectionSsids.some(s => s && s.toLowerCase() === ssidLower);
-                    if (!exists) {
-                        const newList = root.savedConnectionSsids.slice();
-                        newList.push(ssid);
-                        root.savedConnectionSsids = newList;
-                    }
-                }
-            }
+        const ssidPrefix = "802-11-wireless.ssid:";
+        const keyMgmtPrefix = `${root.securityKeyMgmt}:`;
+
+        let ssid = "";
+        let keyMgmt = "";
+        for (const line of output.trim().split("\n")) {
+            if (line.startsWith(ssidPrefix))
+                ssid = line.substring(ssidPrefix.length).trim();
+            else if (line.startsWith(keyMgmtPrefix))
+                keyMgmt = line.substring(keyMgmtPrefix.length).trim();
         }
+
+        if (!ssid || ssid.length === 0)
+            return;
+
+        const ssidLower = ssid.toLowerCase();
+
+        const exists = root.savedConnectionSsids.some(s => s && s.toLowerCase() === ssidLower);
+        if (!exists) {
+            const newList = root.savedConnectionSsids.slice();
+            newList.push(ssid);
+            root.savedConnectionSsids = newList;
+        }
+
+        const security = Object.assign({}, root.savedConnectionSecurity);
+        security[ssidLower] = keyMgmt;
+        root.savedConnectionSecurity = security;
+    }
+
+    function securityLabel(keyMgmt: string): string {
+        switch ((keyMgmt || "").trim().toLowerCase()) {
+        case "":
+        case "none":
+            return qsTr("Open");
+        case "sae":
+            return "WPA3";
+        case "wpa-psk":
+            return "WPA2";
+        case "wpa-eap":
+        case "wpa-eap-suite-b-192":
+            return qsTr("Enterprise");
+        case "owe":
+            return qsTr("Enhanced Open");
+        case "ieee8021x":
+            return "802.1X";
+        default:
+            return keyMgmt.trim();
+        }
+    }
+
+    // Cached security label for a saved SSID, or "" if unknown (e.g. not loaded).
+    function savedSecurityFor(ssid: string): string {
+        if (!ssid || ssid.length === 0)
+            return "";
+        return root.savedConnectionSecurity[ssid.toLowerCase().trim()] || "";
     }
 
     function hasSavedProfile(ssid: string): bool {


### PR DESCRIPTION
Adds a saved networks button and subpage to the network page in the nexus. Saved networks can be modified and forgotten from there.