### PR TITLE
feat: add utilities panel confs to nexus

### DIFF
--- a/modules/nexus/PageCompRegistry.qml
+++ b/modules/nexus/PageCompRegistry.qml
@@ -119,6 +119,9 @@ QtObject {
                 Component {
                     SidebarPanel {}
                 }
+                Component {
+                    UtilitiesPanel {}
+                }
 
                 // Taskbar component sub-pages
                 Component {
@@ -135,11 +138,6 @@ QtObject {
                 }
                 Component {
                     BarClock {}
-                }
-
-                // Utilities panel sub-page
-                Component {
-                    UtilitiesPanel {}
                 }
             }
         },

--- a/modules/nexus/PageCompRegistry.qml
+++ b/modules/nexus/PageCompRegistry.qml
@@ -136,6 +136,11 @@ QtObject {
                 Component {
                     BarClock {}
                 }
+
+                // Utilities panel sub-page
+                Component {
+                    UtilitiesPanel {}
+                }
             }
         },
         Component {

--- a/modules/nexus/pages/PanelsPage.qml
+++ b/modules/nexus/pages/PanelsPage.qml
@@ -36,11 +36,18 @@ PageBase {
         }
 
         NavRow {
-            last: true
             icon: "dock_to_right"
             label: qsTr("Sidebar")
             status: Config.sidebar.enabled ? qsTr("Enabled") : qsTr("Disabled")
             onClicked: root.nState.openSubPage(4)
+        }
+
+        NavRow {
+            last: true
+            icon: "construction"
+            label: qsTr("Utilities")
+            status: Config.utilities.enabled ? qsTr("Enabled") : qsTr("Disabled")
+            onClicked: root.nState.openSubPage(10)
         }
     }
 }

--- a/modules/nexus/pages/PanelsPage.qml
+++ b/modules/nexus/pages/PanelsPage.qml
@@ -47,7 +47,7 @@ PageBase {
             icon: "construction"
             label: qsTr("Utilities")
             status: Config.utilities.enabled ? qsTr("Enabled") : qsTr("Disabled")
-            onClicked: root.nState.openSubPage(10)
+            onClicked: root.nState.openSubPage(5)
         }
     }
 }

--- a/modules/nexus/pages/panels/TaskbarPanel.qml
+++ b/modules/nexus/pages/panels/TaskbarPanel.qml
@@ -58,28 +58,28 @@ PageBase {
             icon: "workspaces"
             label: qsTr("Workspaces")
             status: qsTr("Indicators, window icons")
-            onClicked: root.nState.openSubPage(5)
+            onClicked: root.nState.openSubPage(6)
         }
 
         NavRow {
             icon: "web_asset"
             label: qsTr("Active window")
             status: qsTr("Title display, popout")
-            onClicked: root.nState.openSubPage(6)
+            onClicked: root.nState.openSubPage(7)
         }
 
         NavRow {
             icon: "widgets"
             label: qsTr("Tray")
             status: qsTr("System tray icons")
-            onClicked: root.nState.openSubPage(7)
+            onClicked: root.nState.openSubPage(8)
         }
 
         NavRow {
             icon: "signal_cellular_alt"
             label: qsTr("Status icons")
             status: qsTr("Visible indicators")
-            onClicked: root.nState.openSubPage(8)
+            onClicked: root.nState.openSubPage(9)
         }
 
         NavRow {
@@ -87,7 +87,7 @@ PageBase {
             icon: "schedule"
             label: qsTr("Clock")
             status: qsTr("Date, icon, background")
-            onClicked: root.nState.openSubPage(9)
+            onClicked: root.nState.openSubPage(10)
         }
 
         // Scroll actions

--- a/modules/nexus/pages/panels/UtilitiesPanel.qml
+++ b/modules/nexus/pages/panels/UtilitiesPanel.qml
@@ -1,0 +1,113 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick.Layouts
+import Caelestia.Config
+import qs.modules.nexus.common
+
+PageBase {
+    id: root
+
+    title: qsTr("Utilities")
+    isSubPage: true
+
+    function isToggleOn(id: string): bool {
+        const item = Config.utilities.quickToggles.find(t => t.id === id);
+        return item ? (item.enabled ?? true) : false;
+    }
+
+    function setToggleOn(id: string, on: bool): void {
+        let found = false;
+        const next = Config.utilities.quickToggles.map(item => {
+            if (item.id !== id)
+                return item;
+            found = true;
+            return Object.assign({}, item, {
+                enabled: on
+            });
+        });
+        if (!found)
+            next.push({
+                id,
+                enabled: on
+            });
+        GlobalConfig.utilities.quickToggles = next;
+    }
+
+    ColumnLayout {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        width: root.cappedWidth
+        spacing: Tokens.spacing.extraSmall / 2
+
+        // General
+        SectionHeader {
+            first: true
+            text: qsTr("General")
+        }
+
+        ToggleRow {
+            first: true
+            last: true
+            text: qsTr("Enabled")
+            subtext: qsTr("Show the utilities panel")
+            checked: Config.utilities.enabled
+            onToggled: GlobalConfig.utilities.enabled = checked
+        }
+
+        // Quick toggles
+        SectionHeader {
+            text: qsTr("Quick toggles")
+        }
+
+        ToggleRow {
+            first: true
+            text: qsTr("Wi-Fi")
+            subtext: qsTr("Toggle wireless networking")
+            checked: root.isToggleOn("wifi")
+            onToggled: root.setToggleOn("wifi", checked)
+        }
+
+        ToggleRow {
+            text: qsTr("Bluetooth")
+            subtext: qsTr("Toggle the Bluetooth adapter")
+            checked: root.isToggleOn("bluetooth")
+            onToggled: root.setToggleOn("bluetooth", checked)
+        }
+
+        ToggleRow {
+            text: qsTr("Microphone")
+            subtext: qsTr("Mute or unmute the default source")
+            checked: root.isToggleOn("mic")
+            onToggled: root.setToggleOn("mic", checked)
+        }
+
+        ToggleRow {
+            text: qsTr("Settings")
+            subtext: qsTr("Open the settings window")
+            checked: root.isToggleOn("settings")
+            onToggled: root.setToggleOn("settings", checked)
+        }
+
+        ToggleRow {
+            text: qsTr("Game mode")
+            subtext: qsTr("Toggle game mode")
+            checked: root.isToggleOn("gameMode")
+            onToggled: root.setToggleOn("gameMode", checked)
+        }
+
+        ToggleRow {
+            text: qsTr("Do not disturb")
+            subtext: qsTr("Silence notifications")
+            checked: root.isToggleOn("dnd")
+            onToggled: root.setToggleOn("dnd", checked)
+        }
+
+        ToggleRow {
+            last: true
+            text: qsTr("VPN")
+            subtext: qsTr("Connect or disconnect the VPN")
+            checked: root.isToggleOn("vpn")
+            onToggled: root.setToggleOn("vpn", checked)
+        }
+    }
+}

--- a/modules/nexus/pages/panels/UtilitiesPanel.qml
+++ b/modules/nexus/pages/panels/UtilitiesPanel.qml
@@ -7,9 +7,6 @@ import qs.modules.nexus.common
 PageBase {
     id: root
 
-    title: qsTr("Utilities")
-    isSubPage: true
-
     function isToggleOn(id: string): bool {
         const item = Config.utilities.quickToggles.find(t => t.id === id);
         return item ? (item.enabled ?? true) : false;
@@ -32,6 +29,9 @@ PageBase {
             });
         GlobalConfig.utilities.quickToggles = next;
     }
+
+    title: qsTr("Utilities")
+    isSubPage: true
 
     ColumnLayout {
         anchors.horizontalCenter: parent.horizontalCenter

--- a/modules/nexus/pages/panels/UtilitiesPanel.qml
+++ b/modules/nexus/pages/panels/UtilitiesPanel.qml
@@ -54,6 +54,34 @@ PageBase {
             onToggled: GlobalConfig.utilities.enabled = checked
         }
 
+        // Cards
+        SectionHeader {
+            text: qsTr("Cards")
+        }
+
+        ToggleRow {
+            first: true
+            text: qsTr("Keep awake")
+            subtext: qsTr("Show the idle inhibitor card")
+            checked: Config.utilities.cards.keepAwake
+            onToggled: GlobalConfig.utilities.cards.keepAwake = checked
+        }
+
+        ToggleRow {
+            text: qsTr("Screen recorder")
+            subtext: qsTr("Show the screen recorder card")
+            checked: Config.utilities.cards.recorder
+            onToggled: GlobalConfig.utilities.cards.recorder = checked
+        }
+
+        ToggleRow {
+            last: true
+            text: qsTr("Quick toggles")
+            subtext: qsTr("Show the quick toggles card")
+            checked: Config.utilities.cards.quickToggles
+            onToggled: GlobalConfig.utilities.cards.quickToggles = checked
+        }
+
         // Quick toggles
         SectionHeader {
             text: qsTr("Quick toggles")
@@ -63,6 +91,7 @@ PageBase {
             first: true
             text: qsTr("Wi-Fi")
             subtext: qsTr("Toggle wireless networking")
+            disabled: !Config.utilities.cards.quickToggles
             checked: root.isToggleOn("wifi")
             onToggled: root.setToggleOn("wifi", checked)
         }
@@ -70,6 +99,7 @@ PageBase {
         ToggleRow {
             text: qsTr("Bluetooth")
             subtext: qsTr("Toggle the Bluetooth adapter")
+            disabled: !Config.utilities.cards.quickToggles
             checked: root.isToggleOn("bluetooth")
             onToggled: root.setToggleOn("bluetooth", checked)
         }
@@ -77,6 +107,7 @@ PageBase {
         ToggleRow {
             text: qsTr("Microphone")
             subtext: qsTr("Mute or unmute the default source")
+            disabled: !Config.utilities.cards.quickToggles
             checked: root.isToggleOn("mic")
             onToggled: root.setToggleOn("mic", checked)
         }
@@ -84,6 +115,7 @@ PageBase {
         ToggleRow {
             text: qsTr("Settings")
             subtext: qsTr("Open the settings window")
+            disabled: !Config.utilities.cards.quickToggles
             checked: root.isToggleOn("settings")
             onToggled: root.setToggleOn("settings", checked)
         }
@@ -91,6 +123,7 @@ PageBase {
         ToggleRow {
             text: qsTr("Game mode")
             subtext: qsTr("Toggle game mode")
+            disabled: !Config.utilities.cards.quickToggles
             checked: root.isToggleOn("gameMode")
             onToggled: root.setToggleOn("gameMode", checked)
         }
@@ -98,6 +131,7 @@ PageBase {
         ToggleRow {
             text: qsTr("Do not disturb")
             subtext: qsTr("Silence notifications")
+            disabled: !Config.utilities.cards.quickToggles
             checked: root.isToggleOn("dnd")
             onToggled: root.setToggleOn("dnd", checked)
         }
@@ -106,6 +140,7 @@ PageBase {
             last: true
             text: qsTr("VPN")
             subtext: qsTr("Connect or disconnect the VPN")
+            disabled: !Config.utilities.cards.quickToggles
             checked: root.isToggleOn("vpn")
             onToggled: root.setToggleOn("vpn", checked)
         }

--- a/modules/utilities/Content.qml
+++ b/modules/utilities/Content.qml
@@ -16,7 +16,7 @@ Item {
     required property matrix4x4 deformMatrix
 
     readonly property int enabledCards: (idleInhibit.active ? 1 : 0) + (record.active ? 1 : 0) + (toggles.active ? 1 : 0)
-    readonly property real nonAnimHeight: ((idleInhibit.item as IdleInhibit)?.nonAnimHeight ?? 0) + ((record.item as Record)?.nonAnimHeight ?? 0) + (toggles.item?.implicitHeight ?? 0) + layout.spacing * Math.max(0, enabledCards - 1)
+    readonly property real nonAnimHeight: ((idleInhibit.item as IdleInhibit)?.nonAnimHeight ?? 0) + ((record.item as Record)?.nonAnimHeight ?? 0) + ((toggles.item as Toggles)?.implicitHeight ?? 0) + layout.spacing * Math.max(0, enabledCards - 1)
 
     implicitWidth: layout.implicitWidth
     implicitHeight: layout.implicitHeight

--- a/modules/utilities/Content.qml
+++ b/modules/utilities/Content.qml
@@ -1,3 +1,5 @@
+pragma ComponentBehavior: Bound
+
 import "cards"
 import QtQuick
 import QtQuick.Layouts
@@ -13,7 +15,8 @@ Item {
     required property BarPopouts.Wrapper popouts
     required property matrix4x4 deformMatrix
 
-    readonly property real nonAnimHeight: idleInhibit.nonAnimHeight + record.nonAnimHeight + toggles.implicitHeight + layout.spacing * 2
+    readonly property int enabledCards: (idleInhibit.active ? 1 : 0) + (record.active ? 1 : 0) + (toggles.active ? 1 : 0)
+    readonly property real nonAnimHeight: ((idleInhibit.item as IdleInhibit)?.nonAnimHeight ?? 0) + ((record.item as Record)?.nonAnimHeight ?? 0) + (toggles.item?.implicitHeight ?? 0) + layout.spacing * Math.max(0, enabledCards - 1)
 
     implicitWidth: layout.implicitWidth
     implicitHeight: layout.implicitHeight
@@ -24,29 +27,47 @@ Item {
         anchors.fill: parent
         spacing: Tokens.spacing.medium
 
-        IdleInhibit {
+        Loader {
             id: idleInhibit
 
-            objectName: "utilitiesKeepAwake"
+            Layout.fillWidth: true
+            active: Config.utilities.cards.keepAwake
+            visible: active
+
+            sourceComponent: IdleInhibit {
+                objectName: "utilitiesKeepAwake"
+            }
         }
 
-        Record {
+        Loader {
             id: record
 
-            objectName: "utilitiesScreenRecorder"
-
-            props: root.props
-            screenState: root.screenState
+            Layout.fillWidth: true
+            active: Config.utilities.cards.recorder
+            visible: active
             z: 1
+
+            sourceComponent: Record {
+                objectName: "utilitiesScreenRecorder"
+
+                props: root.props
+                screenState: root.screenState
+            }
         }
 
-        Toggles {
+        Loader {
             id: toggles
 
-            objectName: "utilitiesQuickToggles"
+            Layout.fillWidth: true
+            active: Config.utilities.cards.quickToggles
+            visible: active
 
-            screenState: root.screenState
-            popouts: root.popouts
+            sourceComponent: Toggles {
+                objectName: "utilitiesQuickToggles"
+
+                screenState: root.screenState
+                popouts: root.popouts
+            }
         }
     }
 

--- a/modules/utilities/cards/IdleInhibit.qml
+++ b/modules/utilities/cards/IdleInhibit.qml
@@ -10,7 +10,6 @@ StyledRect {
 
     readonly property real nonAnimHeight: layout.implicitHeight + (IdleInhibitor.enabled ? activeChip.implicitHeight + activeChip.anchors.topMargin : 0) + Tokens.padding.extraLargeIncreased
 
-    Layout.fillWidth: true
     implicitHeight: nonAnimHeight
 
     radius: Tokens.rounding.large

--- a/modules/utilities/cards/Record.qml
+++ b/modules/utilities/cards/Record.qml
@@ -15,7 +15,6 @@ StyledRect {
     required property ScreenState screenState
     readonly property real nonAnimHeight: btnLayout.implicitHeight + listOrControls.implicitHeight + layout.spacing + layout.anchors.margins * 2
 
-    Layout.fillWidth: true
     implicitHeight: layout.implicitHeight + layout.anchors.margins * 2
 
     radius: Tokens.rounding.large

--- a/modules/utilities/cards/Toggles.qml
+++ b/modules/utilities/cards/Toggles.qml
@@ -39,7 +39,6 @@ StyledRect {
     readonly property int splitIndex: Math.ceil(quickToggles.length / 2)
     readonly property bool needExtraRow: quickToggles.length > 6
 
-    Layout.fillWidth: true
     implicitHeight: layout.implicitHeight + Tokens.padding.extraLargeIncreased
 
     radius: Tokens.rounding.large

--- a/plugin/src/Caelestia/Config/utilitiesconfig.hpp
+++ b/plugin/src/Caelestia/Config/utilitiesconfig.hpp
@@ -45,12 +45,26 @@ public:
         : ConfigObject(parent) {}
 };
 
+class UtilitiesCards : public ConfigObject {
+    Q_OBJECT
+    QML_ANONYMOUS
+
+    CONFIG_PROPERTY(bool, keepAwake, true)
+    CONFIG_PROPERTY(bool, recorder, true)
+    CONFIG_PROPERTY(bool, quickToggles, true)
+
+public:
+    explicit UtilitiesCards(QObject* parent = nullptr)
+        : ConfigObject(parent) {}
+};
+
 class UtilitiesConfig : public ConfigObject {
     Q_OBJECT
     QML_ANONYMOUS
 
     CONFIG_PROPERTY(bool, enabled, true)
     CONFIG_PROPERTY(int, maxToasts, 4)
+    CONFIG_SUBOBJECT(UtilitiesCards, cards)
     CONFIG_SUBOBJECT(UtilitiesToasts, toasts)
     CONFIG_SUBOBJECT(UtilitiesVpn, vpn)
     CONFIG_PROPERTY(QVariantList, quickToggles,
@@ -67,6 +81,7 @@ class UtilitiesConfig : public ConfigObject {
 public:
     explicit UtilitiesConfig(QObject* parent = nullptr)
         : ConfigObject(parent)
+        , m_cards(new UtilitiesCards(this))
         , m_toasts(new UtilitiesToasts(this))
         , m_vpn(new UtilitiesVpn(this)) {}
 };


### PR DESCRIPTION
Adds options for the utilities panel to the nexus, which I somehow forgot to add with the rest of them...

Also adds new options to disable each card in the utilities drawer individually.