### PR TITLE
refactor(weather): change IP-lookup API and enhance request handling

### DIFF
--- a/plugin/src/Caelestia/requests.cpp
+++ b/plugin/src/Caelestia/requests.cpp
@@ -1,15 +1,33 @@
 #include "requests.hpp"
 
+#include <qjsvalue.h>
 #include <qjsvalueiterator.h>
 #include <qloggingcategory.h>
 #include <qnetworkaccessmanager.h>
 #include <qnetworkcookiejar.h>
 #include <qnetworkreply.h>
 #include <qnetworkrequest.h>
+#include <qqmlengine.h>
+#include <qvariant.h>
 
 Q_LOGGING_CATEGORY(lcRequests, "caelestia.requests", QtInfoMsg)
 
 namespace caelestia {
+
+namespace {
+
+QVariantMap responseMetadata(const QNetworkReply* reply) {
+    QVariantMap headers;
+
+    for (const auto& [name, value] : reply->rawHeaderPairs()) {
+        headers.insert(QString::fromLatin1(name).toLower(), QString::fromLatin1(value));
+    }
+
+    return { { "statusCode", reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() },
+        { "headers", headers } };
+}
+
+} // namespace
 
 Requests::Requests(QObject* parent)
     : QObject(parent)
@@ -38,11 +56,17 @@ void Requests::get(const QUrl& url, QJSValue onSuccess, QJSValue onError, QJSVal
 
     auto reply = m_manager->get(request);
 
-    QObject::connect(reply, &QNetworkReply::finished, [reply, onSuccess, onError]() {
+    QObject::connect(reply, &QNetworkReply::finished, this, [this, reply, onSuccess, onError]() {
+        const QString body = QString::fromUtf8(reply->readAll());
+
+        QJSValue metadata;
+        if (auto* engine = qmlEngine(this))
+            metadata = engine->toScriptValue(responseMetadata(reply));
+
         if (reply->error() == QNetworkReply::NoError) {
-            onSuccess.call({ QString(reply->readAll()) });
+            onSuccess.call({ body, metadata });
         } else if (onError.isCallable()) {
-            onError.call({ reply->errorString() });
+            onError.call({ reply->errorString(), metadata });
         } else {
             qCWarning(lcRequests) << "get: request failed with error" << reply->errorString();
         }

--- a/services/Weather.qml
+++ b/services/Weather.qml
@@ -91,7 +91,7 @@ Singleton {
             return false;
 
         const ttlHeader = metadata?.headers?.["x-ttl"];
-        const ttl = ttlHeader === undefined ? NaN : Number(ttlHeader);
+        const ttl = Number(ttlHeader);
 
         const delaySeconds = Number.isFinite(ttl) ? Math.max(1, Math.ceil(ttl) + 1) : 61;
 

--- a/services/Weather.qml
+++ b/services/Weather.qml
@@ -15,6 +15,9 @@ Singleton {
     property list<var> forecast
     property list<var> hourlyForecast
 
+    property bool ipApiRequestPending: false
+    property double ipApiBlockedUntil: 0
+
     readonly property string icon: cc ? Icons.getWeatherIcon(cc.weatherCode) : "cloud_alert"
     readonly property string description: cc?.weatherDesc ?? qsTr("No weather")
     readonly property string temp: formatTemp(cc?.tempC)
@@ -40,16 +43,64 @@ Singleton {
             } else {
                 fetchCoordsFromCity(configLocation);
             }
-        } else if (!loc || timer.elapsed() > 900) {
-            Requests.get("https://ipinfo.io/json", text => {
-                const response = JSON.parse(text);
-                if (response.loc) {
-                    loc = response.loc;
-                    city = response.city ?? "";
-                    timer.restart();
+        } else if ((!loc || timer.elapsed() > 900) && !ipApiRequestPending && Date.now() >= ipApiBlockedUntil) {
+            ipApiRequestPending = true;
+
+            Requests.get("http://ip-api.com/json?fields=status,message,city,lat,lon", (text, metadata) => {
+                ipApiRequestPending = false;
+                recordIpApiRateLimit(metadata);
+
+                // Protect against stale responses overwriting the manually-set location,
+                // in case the config was updated while this request was in-flight.
+                if (GlobalConfig.services.weatherLocation)
+                    return;
+
+                let response;
+                try {
+                    response = JSON.parse(text);
+                } catch (error) {
+                    console.warn(lc, `Unable to parse response from ip-api: ${error}`);
+                    return;
                 }
+
+                const lat = Number(response.lat);
+                const lon = Number(response.lon);
+
+                if (response.status !== "success" || !Number.isFinite(lat) || !Number.isFinite(lon)) {
+                    console.warn(lc, `ip-api lookup failed: ${response.message ?? "invalid response"}`);
+                    return;
+                }
+
+                city = fixCityName(response.city ?? "");
+                timer.restart();
+                loc = `${lat},${lon}`;
+            }, (error, metadata) => {
+                ipApiRequestPending = false;
+
+                if (!recordIpApiRateLimit(metadata))
+                    console.warn(lc, `ip-api request failed: ${error}`);
             });
         }
+    }
+
+    function recordIpApiRateLimit(metadata: var): bool {
+        const remainingHeader = metadata?.headers?.["x-rl"];
+        const exhausted = remainingHeader !== undefined && Number(remainingHeader) === 0;
+
+        if (metadata?.statusCode !== 429 && !exhausted)
+            return false;
+
+        const ttlHeader = metadata?.headers?.["x-ttl"];
+        const ttl = ttlHeader === undefined ? NaN : Number(ttlHeader);
+
+        const delaySeconds = Number.isFinite(ttl) ? Math.max(1, Math.ceil(ttl) + 1) : 61;
+
+        const delayMs = delaySeconds * 1000;
+        ipApiBlockedUntil = Date.now() + delayMs;
+        ipApiRetryTimer.interval = delayMs;
+        ipApiRetryTimer.restart();
+
+        return true;
     }
 
     function fixCityName(cityName: string): string {
@@ -276,7 +327,31 @@ Singleton {
         onTriggered: fetchWeatherData()
     }
 
+    Timer {
+        id: ipApiRetryTimer
+
+        repeat: false
+
+        onTriggered: {
+            const remaining = root.ipApiBlockedUntil - Date.now();
+
+            if (remaining > 0) {
+                interval = Math.ceil(remaining);
+                restart();
+            } else {
+                root.reload();
+            }
+        }
+    }
+
     ElapsedTimer {
         id: timer
+    }
+
+    LoggingCategory {
+        id: lc
+
+        name: "caelestia.qml.services.weather"
+        defaultLogLevel: LoggingCategory.Info
     }
 }


### PR DESCRIPTION
## Summary

Improves the weather service and request handling to use a more forgiving API for IP lookups and handle rate-limiting gracefully.

`requests.cpp` now passes HTTP status codes and response headers to QML callbacks for both success and error cases. This allows QML consumers to implement extended logic based on HTTP responses.

The weather service now leverages the additional data returned by `requests` to implement rate-limiting for location lookups by IP. The IP-lookup API has been changed from `ipinfo.io` to `ip-api.com` and it uses the specific rate-limit headers (`x-rl`, `x-ttl`) to detect and backoff requests as needed. A retry timer ensures re-attempts only occur after the rate-limit expires, so the service will not remain continuously blocked.

Additional improvements include preventing concurrent API requests for IP lookups, error handling for API responses (JSON parsing, API status, data validation), and safeguarding against in-flight IP requests overwriting configuration updates to the manually set location.

## Testing

- Builds successfully
- Passed `qmlformat` and linting checks
- Tested with multiple location derivation methods (IP-based, coordinates, city name)
- Used a local HTTP mock API to verify requests are sent and handled as expected
- Ensured in-flight API requests respect concurrent configuration updates to the manually-set weather location