### PR TITLE
wallpaper: video/gif picker thumbs + image/gif/video background engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build/
 .cache/
 logs
+__pycache__/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ if("plugin" IN_LIST ENABLE_MODULES)
 endif()
 
 if("shell" IN_LIST ENABLE_MODULES)
-    foreach(dir assets components modules services utils)
+    foreach(dir assets components modules scripts services utils)
         install(DIRECTORY ${dir} DESTINATION "${INSTALL_QSCONFDIR}")
     endforeach()
 

--- a/modules/background/Wallpaper.qml
+++ b/modules/background/Wallpaper.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import QtMultimedia
 import Caelestia.Config
 import qs.components
 import qs.components.filedialog
@@ -11,28 +12,38 @@ import qs.utils
 Item {
     id: root
 
+    // Currently visible wallpaper. When `source` changes, the previous media
+    // is destroyed once the new one signals ready, so the old stays visible
+    // until the new fades in. Mirrors the upstream caelestia engine: simple
+    // one-item-at-a-time replacement, no A/B preloading.
+    property var current
+
     property string source: Wallpapers.current
-    property CachingImage current
-    property bool completed
+    property bool completed: false
+
+    function _createMedia(path: string): var {
+        const ft = Wallpapers.getFileType(path);
+        if (ft === "gif") return gifMedia.createObject(root, { sourceFile: path });
+        if (ft === "video") return videoMedia.createObject(root, { sourceFile: path });
+        return imageMedia.createObject(root, { sourceFile: path });
+    }
 
     onSourceChanged: {
-        if (!source)
-            current = null;
-        else
-            current = imgComp.createObject(this, {
-                path: source
-            });
+        if (!source) {
+            if (current) { current.destroy(); current = null; }
+        } else {
+            current = _createMedia(source);
+        }
     }
 
     Component.onCompleted: {
-        if (source)
-            Qt.callLater(() => {
-                current = imgComp.createObject(this, {
-                    path: source
-                });
-                completed = true;
-            });
+        Qt.callLater(() => {
+            if (source) current = _createMedia(source);
+            completed = true;
+        });
     }
+
+    // ── Placeholder when no wallpaper is set ────────────────────────────
 
     Loader {
         asynchronous: true
@@ -100,34 +111,156 @@ Item {
         }
     }
 
-    Component {
-        id: imgComp
+    // ── Media components ───────────────────────────────────────────────
+    //
+    // Each wrapper carries the source path, paints itself full-bleed via an
+    // inner Image/AnimatedImage/Video, and exposes two things to the engine:
+    //
+    //   1. `ready` flips to true on the first frame being decodable / playable
+    //   2. An `Anim on opacity` ramp from 0 → 1 once that happens
+    //
+    // The Timer at the bottom watches `root.current` and self-destructs once
+    // it's no longer the active media and the new one is ready, so the old
+    // layer stays visible for the full duration of the new layer's ramp.
 
-        CachingImage {
-            id: img
+    Component {
+        id: imageMedia
+
+        Item {
+            id: wrapItem
 
             anchors.fill: parent
-
+            property string sourceFile: ""
+            property bool ready: false
             opacity: 0
 
-            onStatusChanged: {
-                if (status === Image.Ready)
-                    anim.start();
+            CachingImage {
+                anchors.fill: parent
+                path: wrapItem.sourceFile
+                fillMode: Image.PreserveAspectCrop
+                asynchronous: true
+                smooth: true
+
+                onStatusChanged: {
+                    if (status === Image.Ready && !wrapItem.ready) {
+                        wrapItem.ready = true;
+                        anim.restart();
+                    }
+                }
             }
 
             Anim on opacity {
                 id: anim
 
-                type: Anim.SlowEffects
+                type: Anim.DefaultEffects
                 running: false
                 from: 0
                 to: 1
             }
 
             Timer {
-                running: root.current !== img && root.current?.status === Image.Ready
-                interval: anim.duration
-                onTriggered: img.destroy()
+                running: root.current !== wrapItem && root.current?.ready === true
+                interval: anim.duration + 50
+                onTriggered: wrapItem.destroy()
+            }
+        }
+    }
+
+    Component {
+        id: gifMedia
+
+        Item {
+            id: wrapItem
+
+            anchors.fill: parent
+            property string sourceFile: ""
+            property bool ready: false
+            opacity: 0
+
+            AnimatedImage {
+                anchors.fill: parent
+                fillMode: Image.PreserveAspectCrop
+                playing: true
+                asynchronous: true
+                source: wrapItem.sourceFile ? "file://" + wrapItem.sourceFile : ""
+
+                onStatusChanged: {
+                    if (status === AnimatedImage.Ready && !wrapItem.ready) {
+                        wrapItem.ready = true;
+                        anim.restart();
+                    }
+                }
+            }
+
+            Anim on opacity {
+                id: anim
+
+                type: Anim.DefaultEffects
+                running: false
+                from: 0
+                to: 1
+            }
+
+            Timer {
+                running: root.current !== wrapItem && root.current?.ready === true
+                interval: anim.duration + 50
+                onTriggered: wrapItem.destroy()
+            }
+        }
+    }
+
+    Component {
+        id: videoMedia
+
+        Item {
+            id: wrapItem
+
+            anchors.fill: parent
+            property string sourceFile: ""
+            property bool ready: false
+            opacity: 0
+
+            Video {
+                id: video
+
+                anchors.fill: parent
+                loops: MediaPlayer.Infinite
+                autoPlay: true
+                muted: true
+                fillMode: VideoOutput.PreserveAspectCrop
+                source: wrapItem.sourceFile ? "file://" + wrapItem.sourceFile : ""
+
+                onPlaybackStateChanged: {
+                    if (wrapItem.ready) return;
+                    if (playbackState === MediaPlayer.PlayingState
+                        || playbackState === MediaPlayer.Loaded) {
+                        wrapItem.ready = true;
+                        anim.restart();
+                    }
+                }
+
+                onErrorOccurred: (error, errorString) => {
+                    console.warn("Wallpaper video error:", errorString);
+                    if (!wrapItem.ready) {
+                        wrapItem.ready = true;
+                        anim.restart();
+                    }
+                }
+            }
+
+            Anim on opacity {
+                id: anim
+
+                type: Anim.DefaultEffects
+                running: false
+                from: 0
+                to: 1
+            }
+
+            Timer {
+                running: root.current !== wrapItem && root.current?.ready === true
+                interval: anim.duration + 50
+                onTriggered: wrapItem.destroy()
             }
         }
     }

--- a/modules/launcher/items/WallpaperItem.qml
+++ b/modules/launcher/items/WallpaperItem.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import Quickshell
 import Caelestia.Config
-import Caelestia.Models
 import qs.components
 import qs.components.effects
 import qs.components.images
@@ -10,7 +9,7 @@ import qs.services
 Item {
     id: root
 
-    required property FileSystemEntry modelData
+    required property QtObject modelData
     required property ScreenState screenState
 
     scale: 0.5
@@ -57,17 +56,29 @@ Item {
         implicitWidth: Tokens.sizes.launcher.wallpaperWidth
         implicitHeight: implicitWidth / 16 * 9
 
+        // Placeholder while the cached thumbnail is still being generated
         MaterialIcon {
             anchors.centerIn: parent
-            text: "image"
+            text: Wallpapers.isVideo(root.modelData.path) ? "movie" : "image"
             color: Colours.tPalette.m3outline
             fontStyle: Tokens.font.icon.builders.extraLarge.scale(2).weight(Font.DemiBold).build()
         }
 
-        CachingImage {
+        // Plain `Image` reads the picker thumbnail file directly. The C++
+        // imagecacher is bypassed entirely: scripts/thumbgen.py populates
+        // $cache/wallpaper-thumbs/ with 280x158 JPGs for every supported
+        // extension (images, gifs, videos).
+        Image {
             anchors.fill: parent
-            path: root.modelData.path
+            asynchronous: true
             smooth: !root.PathView.view.moving
+            fillMode: Image.PreserveAspectCrop
+            cache: false
+            source: {
+                const thumb = Wallpapers.getThumbnailPath(root.modelData.path);
+                if (!thumb) return "";
+                return "file://" + thumb + "?v=" + Wallpapers.thumbnailVersion;
+            }
             sourceSize: {
                 const dpr = (QsWindow.window as QsWindow)?.devicePixelRatio ?? 1;
                 return Qt.size(image.implicitWidth * dpr, image.implicitHeight * dpr);

--- a/modules/nexus/pages/wallandstyle/WallpaperCategory.qml
+++ b/modules/nexus/pages/wallandstyle/WallpaperCategory.qml
@@ -3,7 +3,6 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import Caelestia.Config
-import Caelestia.Models
 import qs.services
 import qs.modules.nexus.common
 
@@ -27,20 +26,23 @@ PageBase {
 
         Repeater {
             model: {
-                const walls = Wallpapers.list.filter(w => Wallpapers.getCategoryFor(w) === root.nState.selectedWallpaperCategory).sort((a, b) => a.name.localeCompare(b.name));
+                const walls = Wallpapers.list.filter(w => Wallpapers.getCategoryFor(w.path) === root.nState.selectedWallpaperCategory).sort((a, b) => a.name.localeCompare(b.name));
                 while (walls.length < Config.nexus.wallpapersPerRow)
                     walls.push(null);
                 return walls;
             }
 
             WallItem {
-                required property FileSystemEntry modelData
+                required property QtObject modelData
 
-                // Empty placeholders for sizing
                 opacity: modelData ? 1 : 0
                 enabled: modelData
-
-                source: String(modelData?.path ?? "")
+                source: {
+                    if (!modelData) return "";
+                    const thumb = Wallpapers.getThumbnailPath(modelData.path);
+                    if (!thumb) return "";
+                    return "file://" + thumb + "?v=" + Wallpapers.thumbnailVersion;
+                }
                 text: modelData?.name ?? ""
                 onClicked: {
                     Wallpapers.setWallpaper(modelData.path);

--- a/modules/nexus/pages/wallandstyle/WallpaperSelect.qml
+++ b/modules/nexus/pages/wallandstyle/WallpaperSelect.qml
@@ -5,7 +5,6 @@ import QtQuick.Layouts
 import Quickshell
 import Caelestia.Components
 import Caelestia.Config
-import Caelestia.Models
 import qs.components
 import qs.components.controls
 import qs.components.filedialog
@@ -105,7 +104,7 @@ PageBase {
                     const list = [];
                     for (const w of walls) {
                         if (w.parentDir !== baseDir) {
-                            const category = Wallpapers.getCategoryFor(w);
+                            const category = Wallpapers.getCategoryFor(w.path);
                             if (category && (!(category in categories) || categories[category].name.localeCompare(w.name) > 0))
                                 categories[category] = w;
                         } else {
@@ -120,27 +119,30 @@ PageBase {
                 }
 
                 WallItem {
-                    required property FileSystemEntry modelData
+                    required property QtObject modelData
 
-                    // Empty placeholders for sizing
                     opacity: modelData ? 1 : 0
                     enabled: modelData
-
-                    source: String(modelData?.path ?? "")
+                    source: {
+                        if (!modelData) return "";
+                        const thumb = Wallpapers.getThumbnailPath(modelData.path);
+                        if (!thumb) return "";
+                        return "file://" + thumb + "?v=" + Wallpapers.thumbnailVersion;
+                    }
                     text: {
                         if (!modelData)
                             return "";
 
                         if (modelData.parentDir !== Paths.wallsdir) {
-                            const category = Wallpapers.getCategoryFor(modelData);
+                            const category = Wallpapers.getCategoryFor(modelData.path);
                             return category.slice(0, 1).toUpperCase() + category.slice(1);
                         }
                         return modelData.name;
                     }
                     onClicked: {
                         if (modelData.parentDir !== Paths.wallsdir) {
-                            root.nState.selectedWallpaperCategory = Wallpapers.getCategoryFor(modelData);
-                            root.nState.openSubPage(2); // Category page
+                            root.nState.selectedWallpaperCategory = Wallpapers.getCategoryFor(modelData.path);
+                            root.nState.openSubPage(2);
                         } else {
                             Wallpapers.setWallpaper(modelData.path);
                             root.nState.closeSubPage();

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -14,6 +14,7 @@
   libqalculate,
   bash,
   hyprland,
+  ffmpeg,
   material-symbols,
   rubik,
   nerd-fonts,
@@ -35,7 +36,7 @@
 }: let
   version = "1.0.0";
 
-  qs = quickshell.withModules [qt6.qtimageformats];
+  qs = quickshell.withModules [qt6.qtimageformats qt6.qtmultimedia];
 
   runtimeDeps =
     [
@@ -48,6 +49,7 @@
       wl-clipboard
       libqalculate
       bash
+      ffmpeg
       hyprland
     ]
     ++ extraRuntimeDeps
@@ -98,7 +100,7 @@
     };
 
     nativeBuildInputs = [cmake ninja pkg-config];
-    buildInputs = [qt6.qtbase qt6.qtdeclarative qt6.qtshadertools libqalculate pipewire aubio libcava fftw lm_sensors];
+    buildInputs = [qt6.qtbase qt6.qtdeclarative qt6.qtshadertools qt6.qtmultimedia libqalculate pipewire aubio libcava fftw lm_sensors];
 
     dontWrapQtApps = true;
     cmakeFlags =

--- a/plugin/src/Caelestia/Images/cachingimageprovider.cpp
+++ b/plugin/src/Caelestia/Images/cachingimageprovider.cpp
@@ -36,6 +36,17 @@ public:
     }
 
 private:
+    // Try to load an image from disk, set m_error / return false on miss.
+    bool loadInto(const QString& path, QImage& out) {
+        if (!QFileInfo::exists(path))
+            return false;
+        QImage img(path);
+        if (img.isNull())
+            return false;
+        out = img;
+        return true;
+    }
+
     void process() {
         QString path = QString::fromUtf8(m_id.toUtf8().percentDecoded());
         if (!path.startsWith(QLatin1Char('/')))
@@ -51,52 +62,70 @@ private:
         const bool needsW = size.width() <= 0;
         const bool needsH = size.height() <= 0;
 
-        // If both dimensions are missing, return the original directly
+        // If both dimensions are missing, the cache key is identity-only —
+        // decode the source directly.
         if (needsW && needsH) {
             qCDebug(lcCProv).noquote() << "Given source size is invalid, returning original:" << path;
-            m_image = QImage(path);
-            if (m_image.isNull()) {
+            if (!loadInto(path, m_image))
                 m_error = QStringLiteral("Failed to decode source: ") + path;
-                qCWarning(lcCProv).noquote() << m_error;
-            }
             return;
         }
 
-        // If one dimension is missing, derive it from the source aspect ratio
+        // If one dimension is missing, derive it from the source aspect ratio.
+        // For videos Qt's QImageReader can't decode, so probe via ffprobe-less
+        // means: try cached first, otherwise skip derived sizing.
         if (needsW || needsH) {
-            const QImageReader sourceReader(path);
-            const QSize sourceSize = sourceReader.size();
-            if (!sourceSize.isValid() || sourceSize.isEmpty()) {
-                m_error = QStringLiteral("Could not determine source size for: ") + path;
-                qCWarning(lcCProv).noquote() << m_error;
-                return;
-            }
-
-            if (needsW)
-                size.setWidth(qRound(size.height() * sourceSize.width() / static_cast<qreal>(sourceSize.height())));
-            else
-                size.setHeight(qRound(size.width() * sourceSize.height() / static_cast<qreal>(sourceSize.width())));
-        }
-
-        // Try to use cached image
-        const auto cachePath = ImageCacher::cachePathFor(path, size, m_fillMode);
-        if (!cachePath.isEmpty()) {
-            QImageReader cacheReader(cachePath);
-            if (cacheReader.canRead()) {
-                m_image = cacheReader.read();
-                if (!m_image.isNull())
+            if (ImageCacher::isVideoLike(path)) {
+                // Videos: keep the missing dimension at the requested value so
+                // ffmpeg scales cleanly; the cachePath stays stable.
+                if (needsW)
+                    size.setWidth(size.height() > 0 ? size.height() : 1);
+                else
+                    size.setHeight(size.width() > 0 ? size.width() : 1);
+            } else {
+                const QImageReader sourceReader(path);
+                const QSize sourceSize = sourceReader.size();
+                if (!sourceSize.isValid() || sourceSize.isEmpty()) {
+                    m_error = QStringLiteral("Could not determine source size for: ") + path;
+                    qCWarning(lcCProv).noquote() << m_error;
                     return;
+                }
+                if (needsW)
+                    size.setWidth(qRound(size.height() * sourceSize.width() / static_cast<qreal>(sourceSize.height())));
+                else
+                    size.setHeight(qRound(size.width() * sourceSize.height() / static_cast<qreal>(sourceSize.width())));
             }
         }
 
-        // Schedule cache job (this call will return the original image, but later ones will use cache)
+        const QString cachePath = ImageCacher::cachePathFor(path, size, m_fillMode);
+        if (cachePath.isEmpty()) {
+            m_error = QStringLiteral("Failed to compute cache path for: ") + path;
+            return;
+        }
+
+        // Fast path: cache already has a valid PNG.
+        if (loadInto(cachePath, m_image))
+            return;
+
+        // For video/large-image sources we can't defer: QImage("video.mp4")
+        // returns null, so the Image would receive nothing in this response.
+        // Run the job synchronously here (we're already on a worker thread,
+        // so blocking this thread is fine and only delays the first paint).
+        if (ImageCacher::isVideoLike(path)) {
+            ImageCacher::runJob(path, cachePath, size, m_fillMode);
+            if (loadInto(cachePath, m_image))
+                return;
+            m_error = QStringLiteral("Failed to render video frame for: ") + path;
+            qCWarning(lcCProv).noquote() << m_error;
+            return;
+        }
+
+        // Image path: kick off background caching for next time, but reply
+        // now with the original so the user doesn't see an empty box.
         ImageCacher::instance()->schedule(path, cachePath, size, m_fillMode);
 
-        m_image = QImage(path);
-        if (m_image.isNull()) {
+        if (!loadInto(path, m_image))
             m_error = QStringLiteral("Failed to decode source: ") + path;
-            qCWarning(lcCProv).noquote() << m_error;
-        }
     }
 
     QString m_id;

--- a/plugin/src/Caelestia/Images/imagecacher.cpp
+++ b/plugin/src/Caelestia/Images/imagecacher.cpp
@@ -8,6 +8,7 @@
 #include <qloggingcategory.h>
 #include <qmutex.h>
 #include <qpainter.h>
+#include <qprocess.h>
 #include <qsavefile.h>
 #include <qthreadpool.h>
 
@@ -66,6 +67,17 @@ QString ImageCacher::cachePathFor(const QString& sourcePath, const QSize& size, 
     return cacheDir() + QLatin1Char('/') + filename;
 }
 
+bool ImageCacher::isVideoLike(const QString& path) {
+    static const QStringList suffixes = {
+        QStringLiteral(".mp4"),  QStringLiteral(".webm"), QStringLiteral(".mov"),
+        QStringLiteral(".avi"),  QStringLiteral(".mkv"),  QStringLiteral(".gif"),
+        QStringLiteral(".m4v"),  QStringLiteral(".ogv"),
+    };
+
+    const QString lower = QFileInfo(path).suffix().toLower();
+    return suffixes.contains(QLatin1Char('.') + lower);
+}
+
 ImageCacher* ImageCacher::instance() {
     static ImageCacher s_instance;
     return &s_instance;
@@ -96,8 +108,55 @@ void ImageCacher::schedule(const QString& sourcePath, const QString& cachePath, 
     });
 }
 
+bool ImageCacher::runFfmpegJob(const QString& sourcePath, const QString& cachePath, const QSize& size) {
+    QProcess proc;
+
+    // ffmpeg filter syntax requires ':' between width and height. Use a representative
+    // frame from the start of the stream (avoid 0 which often opens with a black frame).
+    const QString filter = QStringLiteral("scale=%1:%2:force_original_aspect_ratio=increase,crop=%1:%2")
+                              .arg(size.width())
+                              .arg(size.height());
+
+    const QStringList args = {
+        QStringLiteral("-loglevel"), QStringLiteral("error"),
+        QStringLiteral("-y"),
+        QStringLiteral("-ss"), QStringLiteral("00:00:00.100"),
+        QStringLiteral("-i"), sourcePath,
+        QStringLiteral("-vframes"), QStringLiteral("1"),
+        QStringLiteral("-vf"), filter,
+        cachePath,
+    };
+
+    proc.start(QStringLiteral("ffmpeg"), args);
+    if (!proc.waitForFinished(30000)) {
+        qCWarning(lcCacher) << "ffmpeg timed out for" << sourcePath;
+        proc.kill();
+        return false;
+    }
+
+    if (proc.exitStatus() != QProcess::NormalExit || proc.exitCode() != 0) {
+        qCWarning(lcCacher) << "ffmpeg failed for" << sourcePath << ":" << proc.readAllStandardError();
+        return false;
+    }
+
+    return QFile::exists(cachePath);
+}
+
 void ImageCacher::runJob(const QString& sourcePath, const QString& cachePath, const QSize& size, FillMode fillMode) {
     if (QFile::exists(cachePath)) {
+        return;
+    }
+
+    const QString cacheParent = QFileInfo(cachePath).absolutePath();
+    if (!QDir().mkpath(cacheParent)) {
+        qCWarning(lcCacher).noquote() << "Failed to create cache dir" << cacheParent;
+        return;
+    }
+
+    if (isVideoLike(sourcePath)) {
+        if (runFfmpegJob(sourcePath, cachePath, size)) {
+            qCDebug(lcCacher).noquote() << "Saved (ffmpeg) to" << cachePath;
+        }
         return;
     }
 
@@ -138,12 +197,6 @@ void ImageCacher::runJob(const QString& sourcePath, const QString& cachePath, co
         QPainter painter(&canvas);
         painter.drawImage((size.width() - image.width()) / 2, (size.height() - image.height()) / 2, image);
         painter.end();
-    }
-
-    const QString parent = QFileInfo(cachePath).absolutePath();
-    if (!QDir().mkpath(parent)) {
-        qCWarning(lcCacher).noquote() << "Failed to create cache dir" << parent;
-        return;
     }
 
     QSaveFile saveFile(cachePath);

--- a/plugin/src/Caelestia/Images/imagecacher.hpp
+++ b/plugin/src/Caelestia/Images/imagecacher.hpp
@@ -26,10 +26,19 @@ public:
     void schedule(const QString& sourcePath, const QSize& size, FillMode fillMode);
     void schedule(const QString& sourcePath, const QString& cachePath, const QSize& size, FillMode fillMode);
 
+    static bool isVideoLike(const QString& path);
+
+    // Run the cache-generation job synchronously. Already-safe to call
+    // from worker threads (the image provider does this on its QRunnable).
+    // Used when the caller can't tolerate the round-trip latency of
+    // schedule() + file-watcher, e.g. for the first request of a video
+    // thumbnail where QImage("path") would otherwise return null.
+    static void runJob(const QString& sourcePath, const QString& cachePath, const QSize& size, FillMode fillMode);
+
 private:
     explicit ImageCacher(QObject* parent = nullptr);
 
-    static void runJob(const QString& sourcePath, const QString& cachePath, const QSize& size, FillMode fillMode);
+    static bool runFfmpegJob(const QString& sourcePath, const QString& cachePath, const QSize& size);
 
     QMutex m_mutex;
     QSet<QString> m_inflight;

--- a/scripts/thumbgen.py
+++ b/scripts/thumbgen.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+Thumbnail Generator for Caelestia.
+
+Generates 280x158-crop JPG thumbnails for every media file the Wallpapers
+service finds in its configured directory tree. Both still images and
+video/GIF sources go through this script so the picker can render
+thumbnails for everything without depending on the C++ imagecacher
+having ffmpeg built into it.
+
+Cache layout mirrors wallsdir:
+  <wallsdir>/foo/bar.mp4  ->  <cache>/wallpaper-thumbs/foo/bar.mp4.jpg
+
+Requires ffmpeg (videos and gifs) and ImageMagick (images). Missing tools
+cause the affected file types to be skipped; other types still process.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+VIDEO_EXTENSIONS = {".mp4", ".webm", ".mov", ".avi", ".mkv"}
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp", ".tif", ".tiff", ".bmp", ".svg"}
+GIF_EXTENSIONS = {".gif"}
+
+THUMB_W, THUMB_H = 280, 158  # matches Tokens.sizes.launcher.wallpaperWidth / 16 * 9
+
+
+class ThumbGenerator:
+    def __init__(self, wallsdir: Path, cache_root: Path, fallback: Optional[Path] = None):
+        self.wallsdir = wallsdir
+        self.cache_root = cache_root
+        self.fallback = fallback
+        self.thumbs_dir = cache_root / "wallpaper-thumbs"
+        self.processed = 0
+        self.total = 0
+        self.lock = threading.Lock()
+        self._have_im7: Optional[bool] = None
+        self._have_ffmpeg: Optional[bool] = None
+
+    def run(self) -> int:
+        scan_dir = self.wallsdir
+        if not scan_dir.exists() and self.fallback is not None:
+            scan_dir = self.fallback
+            print(f"wallsdir not found, using fallback: {self.fallback}")
+        if not scan_dir.exists():
+            print(f"ERROR: Wallpaper directory not found: {self.wallsdir}")
+            return 1
+
+        self.wallsdir = scan_dir.resolve()
+        self.thumbs_dir.mkdir(parents=True, exist_ok=True)
+
+        self._have_im7 = self._check_imagemagick()
+        self._have_ffmpeg = self._check_ffmpeg()
+
+        print(f"Source: {self.wallsdir}")
+        print(f"Cache:  {self.thumbs_dir}")
+        print(f"ffmpeg: {'yes' if self._have_ffmpeg else 'no (videos/gifs will be skipped)'}")
+        print(f"ImageMagick: {'yes' if self._have_im7 else 'no (images will be skipped)'}")
+
+        files = self.find_files()
+        if not files:
+            print("No media files found")
+            return 0
+
+        self.total = len(files)
+        pending = [p for p in files if self.needs_generation(p)]
+        self.total = len(pending) or self.total
+        if not pending:
+            print(f"All {len(files)} thumbnails are up to date")
+            return 0
+
+        print(f"Need to generate {len(pending)} thumbnails (out of {len(files)} files)")
+
+        max_workers = min(4, os.cpu_count() or 1, len(pending))
+        failed: List[Tuple[Path, str]] = []
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            futures = {ex.submit(self.generate, p): p for p in pending}
+            for fut in as_completed(futures):
+                src = futures[fut]
+                try:
+                    ok, msg = fut.result()
+                except Exception as exc:
+                    ok, msg = False, str(exc)
+                if not ok:
+                    failed.append((src, msg))
+
+        print(f"Done — {len(pending) - len(failed)}/{len(pending)} generated")
+        if failed:
+            print(f"Failed: {len(failed)}")
+            for src, msg in failed[:3]:
+                print(f"  {src.name}: {msg[:80]}")
+        return 0
+
+    def find_files(self) -> List[Path]:
+        out: List[Path] = []
+        try:
+            for p in self.wallsdir.rglob("*"):
+                if not p.is_file() or p.name.startswith("."):
+                    continue
+                try:
+                    parents = p.relative_to(self.wallsdir).parts[:-1]
+                except ValueError:
+                    continue
+                if any(part.startswith(".") for part in parents):
+                    continue
+                ext = p.suffix.lower()
+                if ext in VIDEO_EXTENSIONS or ext in IMAGE_EXTENSIONS or ext in GIF_EXTENSIONS:
+                    out.append(p)
+        except Exception as exc:
+            print(f"ERROR scanning {self.wallsdir}: {exc}")
+        out.sort()
+        return out
+
+    def thumb_path(self, src: Path) -> Path:
+        rel = src.relative_to(self.wallsdir)
+        return self.thumbs_dir / rel.parent / (src.name + ".jpg")
+
+    def needs_generation(self, src: Path) -> bool:
+        dst = self.thumb_path(src)
+        if not dst.exists():
+            return True
+        try:
+            return src.stat().st_mtime > dst.stat().st_mtime
+        except OSError:
+            return True
+
+    def generate(self, src: Path) -> Tuple[bool, str]:
+        dst = self.thumb_path(src)
+        ext = src.suffix.lower()
+
+        try:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if ext in VIDEO_EXTENSIONS or ext in GIF_EXTENSIONS:
+                ok = self._have_ffmpeg and self.run_ffmpeg(src, dst)
+                kind = "video" if ext in VIDEO_EXTENSIONS else "gif"
+            else:
+                ok = self._have_im7 and self.run_imagemagick(src, dst)
+                kind = "image"
+
+            with self.lock:
+                self.processed += 1
+                pct = (self.processed / self.total * 100) if self.total else 100
+                tag = "ok" if ok else "skip"
+                print(f"[{self.processed}/{self.total}] {kind} {tag}: {src.name} ({pct:.0f}%)")
+            return ok, "ok" if ok else "tool-unavailable-or-failed"
+        except Exception as exc:
+            return False, str(exc)[:80]
+
+    def run_ffmpeg(self, src: Path, dst: Path) -> bool:
+        cmd = [
+            "ffmpeg", "-y",
+            "-loglevel", "error",
+            "-ss", "00:00:00.100",
+            "-i", str(src),
+            "-vframes", "1",
+            "-vf", (
+                f"scale={THUMB_W}:{THUMB_H}:force_original_aspect_ratio=increase,"
+                f"crop={THUMB_W}:{THUMB_H}"
+            ),
+            "-q:v", "2",
+            str(dst),
+        ]
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+            return result.returncode == 0 and dst.exists()
+        except subprocess.TimeoutExpired:
+            return False
+
+    def run_imagemagick(self, src: Path, dst: Path) -> bool:
+        im_cmd = "magick" if self._have_im7 else "convert"
+        cmd = [
+            im_cmd, str(src),
+            "-resize", f"{THUMB_W}x{THUMB_H}^",
+            "-gravity", "center",
+            "-extent", f"{THUMB_W}x{THUMB_H}",
+            "-quality", "85",
+            str(dst),
+        ]
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+            return result.returncode == 0 and dst.exists()
+        except subprocess.TimeoutExpired:
+            return False
+
+    def _check_imagemagick(self) -> bool:
+        for cmd in (["magick", "--version"], ["convert", "--version"]):
+            try:
+                if subprocess.run(cmd, capture_output=True, timeout=5).returncode == 0:
+                    self._have_im7 = (cmd[0] == "magick")
+                    return True
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                continue
+        return False
+
+    def _check_ffmpeg(self) -> bool:
+        try:
+            return subprocess.run(
+                ["ffmpeg", "-version"], capture_output=True, timeout=5
+            ).returncode == 0
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+
+
+def parse_args(argv: List[str]) -> Tuple[Path, Path, Optional[Path]]:
+    if len(argv) < 3 or len(argv) > 4:
+        print("Usage: thumbgen.py <wallsdir> <cache_root> [fallback_wallsdir]")
+        sys.exit(1)
+    return (
+        Path(argv[1]).expanduser(),
+        Path(argv[2]).expanduser(),
+        Path(argv[3]).expanduser() if len(argv) == 4 else None,
+    )
+
+
+def main() -> int:
+    wallsdir, cache_root, fallback = parse_args(sys.argv)
+    gen = ThumbGenerator(wallsdir, cache_root, fallback)
+    return gen.run()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/Wallpapers.qml
+++ b/services/Wallpapers.qml
@@ -4,7 +4,6 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import Caelestia.Config
-import Caelestia.Models
 import qs.services
 import qs.utils
 
@@ -13,37 +12,113 @@ Searcher {
 
     readonly property string currentNamePath: `${Paths.state}/wallpaper/path.txt`
     readonly property list<string> smartArg: GlobalConfig.services.smartScheme ? [] : ["--no-smart"]
+    readonly property list<string> videoExtensions: ["mp4", "webm", "mov", "avi", "mkv"]
+    readonly property list<string> gifExtensions: ["gif"]
+    readonly property string videoFramePath: `${Paths.cache}/wallpaper-video-frame.jpg`
     readonly property string fallback: Quickshell.shellPath("assets/wallpaper.webp")
+
+    // Picker thumbnails live in their own dir so the QML picker can use plain
+    // `file://` URLs directly, avoiding the C++ imagecacher entirely. Mirrors
+    // wallsdir layout: <wallsdir>/foo/bar.mp4 -> <thumbsDir>/foo/bar.mp4.jpg
+    readonly property string thumbsDir: `${Paths.cache}/wallpaper-thumbs`
+    readonly property string _thumbgenScript: Quickshell.shellPath("scripts/thumbgen.py")
 
     property bool showPreview: false
     readonly property string current: showPreview ? previewPath : actualCurrent
     property string previewPath
+    property string previewColoursPath
     property string actualCurrent
     property bool previewColourLock
     property bool pendingPreviewClear
 
-    function getCategoryFor(w: FileSystemEntry): string {
-        let category = w.parentDir.slice(Paths.wallsdir.length + 1);
+    property var subfolderFilters: []
+    property var _allSubdirs: []
+    // Bumped whenever the thumbnail cache is regenerated; picker items pin
+    // the version in their URL so the file system isn't hit on every redraw.
+    property int thumbnailVersion: 0
+
+
+    function isVideo(path: string): bool {
+        const idx = path.lastIndexOf(".");
+        return idx !== -1 && videoExtensions.includes(path.slice(idx + 1).toLowerCase());
+    }
+
+    function getFileType(path: string): string {
+        const idx = path.lastIndexOf(".");
+        const ext = idx !== -1 ? path.slice(idx + 1).toLowerCase() : "";
+        if (videoExtensions.includes(ext))
+            return "video";
+        if (ext === "gif")
+            return "gif";
+        return "image";
+    }
+
+    function getCategoryFor(path: string): string {
+        const baseDir = Paths.wallsdir.endsWith("/") ? Paths.wallsdir : Paths.wallsdir + "/";
+        if (!path.startsWith(baseDir))
+            return "";
+        let category = path.slice(baseDir.length);
         if (category.includes("/"))
             category = category.slice(0, category.indexOf("/"));
         return category;
     }
 
+    function getThumbnailPath(filePath: string): string {
+        const baseDir = Paths.wallsdir.endsWith("/") ? Paths.wallsdir : Paths.wallsdir + "/";
+        if (!filePath.startsWith(baseDir))
+            return "";
+        return thumbsDir + "/" + filePath.slice(baseDir.length) + ".jpg";
+    }
+
+    function _triggerThumbnails(): void {
+        if (!Paths.wallsdir) return;
+        if (delayedThumbnailGen.running) delayedThumbnailGen.restart();
+        else delayedThumbnailGen.start();
+    }
+
     function setRandom(): void {
-        Quickshell.execDetached(["caelestia", "wallpaper", "-r", ...smartArg]);
+        const walls = internalEntries;
+        if (walls.length === 0) return;
+        const idx = Math.floor(Math.random() * walls.length);
+        setWallpaper(walls[idx].path);
     }
 
     function setWallpaper(path: string): void {
         actualCurrent = path;
-        Quickshell.execDetached(["caelestia", "wallpaper", "-f", path, ...smartArg]);
+
+        // For videos we still extract a representative frame so the colour
+        // scheme generator (which only handles stills) has something to chew
+        // on, then write the video path itself into path.txt.
+        if (!isVideo(path)) {
+            Quickshell.execDetached(["caelestia", "wallpaper", "-f", path, ...smartArg]);
+            return;
+        }
+
+        const smart = smartArg.join(" ");
+        Quickshell.execDetached([
+            "bash",
+            "-c",
+            `if command -v ffmpeg >/dev/null 2>&1; then ffmpeg -y -loglevel error -i "$1" -frames:v 1 "$2" && caelestia wallpaper -f "$2" ${smart}; fi; printf %s "$1" > "$3"`,
+            "bash",
+            path,
+            videoFramePath,
+            currentNamePath
+        ]);
     }
 
     function preview(path: string): void {
         previewPath = path;
         showPreview = true;
 
-        if (Colours.scheme === "dynamic")
+        if (Colours.scheme !== "dynamic")
+            return;
+
+        if (isVideo(path)) {
+            previewFrameProc.running = true;
+        } else {
+            previewColoursPath = path;
             getPreviewColoursProc.running = true;
+        }
     }
 
     function stopPreview(): void {
@@ -59,12 +134,44 @@ Searcher {
             Colours.showPreview = false;
     }
 
-    list: wallpapers.entries
-    key: "relativePath"
-    useFuzzy: GlobalConfig.launcher.useFuzzy.wallpapers
-    extraOpts: useFuzzy ? ({}) : ({
-            forward: false
-        })
+    // ── Wallpaper entries as QtObjects for Searcher ────────────────────
+
+    property var internalEntries: []
+
+    list: internalEntries
+
+    Component {
+        id: wallpaperEntryFactory
+
+        QtObject {
+            property string path
+            property string name
+            property string parentDir
+            property string relativePath
+        }
+    }
+
+    function _buildList(filePaths: var): void {
+        const arr = [];
+        const baseDir = Paths.wallsdir.endsWith("/") ? Paths.wallsdir : Paths.wallsdir + "/";
+
+        for (const f of filePaths) {
+            const entry = wallpaperEntryFactory.createObject(root);
+            entry.path = f;
+            entry.name = f.split("/").pop();
+            entry.parentDir = f.substring(0, f.lastIndexOf("/"));
+            entry.relativePath = f.startsWith(baseDir) ? f.slice(baseDir.length) : f;
+            arr.push(entry);
+        }
+
+        for (const e of internalEntries.slice())
+            e.destroy();
+
+        internalEntries = arr;
+        root._triggerThumbnails();
+    }
+
+    // ── IPC ────────────────────────────────────────────────────────────
 
     IpcHandler {
         function get(): string {
@@ -76,49 +183,254 @@ Searcher {
         }
 
         function list(): string {
-            return root.list.map(w => w.path).join("\n");
+            return root.internalEntries.map(w => w.path).join("\n");
         }
 
         target: "wallpaper"
     }
 
+    // ── Current wallpaper persistence ──────────────────────────────────
+
     FileView {
+        id: currentFileView
+
         path: root.currentNamePath
         watchChanges: true
         printErrors: false
         onFileChanged: reload()
         onLoaded: {
-            let wall = text().trim();
+            const wall = text().trim();
             if (!wall) {
-                wall = root.fallback;
+                root.actualCurrent = root.fallback;
                 Quickshell.execDetached(["caelestia", "wallpaper", "-f", root.fallback, ...root.smartArg]);
+            } else {
+                root.actualCurrent = wall;
             }
-            root.actualCurrent = wall;
             root.previewColourLock = false;
+            root._triggerScan();
         }
         onLoadFailed: {
             root.actualCurrent = root.fallback;
             root.previewColourLock = false;
             Quickshell.execDetached(["caelestia", "wallpaper", "-f", root.fallback, ...root.smartArg]);
+            root._triggerScan();
         }
     }
 
-    FileSystemModel {
-        id: wallpapers
+    // ── Wallpaper directory scanning via find ──────────────────────────
 
-        recursive: true
+    function _triggerScan(): void {
+        if (!Paths.wallsdir) return;
+        scanProc.running = true;
+        scanSubfoldersProc.running = true;
+    }
+
+    Component.onCompleted: initialScanTimer.start()
+
+    Timer {
+        id: initialScanTimer
+
+        interval: 500
+        repeat: false
+        onTriggered: root._triggerScan()
+    }
+
+    Process {
+        id: scanProc
+
+        running: false
+
+        command: {
+            const d = Paths.wallsdir;
+            if (!d) return [];
+            return ["find", d, "-name", ".*", "-prune", "-o", "-type", "f",
+                "(", "-name", "*.jpg", "-o", "-name", "*.jpeg", "-o", "-name", "*.png",
+                "-o", "-name", "*.webp", "-o", "-name", "*.tif", "-o", "-name", "*.tiff",
+                "-o", "-name", "*.bmp", "-o", "-name", "*.svg",
+                "-o", "-name", "*.gif", "-o", "-name", "*.mp4", "-o", "-name", "*.webm",
+                "-o", "-name", "*.mov", "-o", "-name", "*.avi", "-o", "-name", "*.mkv", ")", "-print"];
+        }
+
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const files = text.trim().split("\n").filter(f => f.length > 0);
+                if (files.length === 0) {
+                    console.log("No wallpapers found in", Paths.wallsdir, "— using fallback");
+                    scanFallback.running = true;
+                } else {
+                    const sorted = files.sort();
+                    const prevSorted = root.internalEntries.map(e => e.path).sort();
+                    const changed = JSON.stringify(sorted) !== JSON.stringify(prevSorted);
+
+                    if (changed) {
+                        console.log("Wallpaper scan found", sorted.length, "files");
+                        root._buildList(sorted);
+                    }
+                }
+            }
+        }
+
+        stderr: StdioCollector {
+            onStreamFinished: {
+                if (text.length > 0)
+                    console.warn("Wallpaper scan stderr:", text);
+            }
+        }
+    }
+
+    Process {
+        id: scanFallback
+
+        running: false
+        command: {
+            const d = Quickshell.shellPath("assets");
+            if (!d) return [];
+            return ["find", d, "-name", ".*", "-prune", "-o", "-type", "f",
+                "(", "-name", "*.jpg", "-o", "-name", "*.jpeg", "-o", "-name", "*.png",
+                "-o", "-name", "*.webp", "-o", "-name", "*.tif", "-o", "-name", "*.tiff",
+                "-o", "-name", "*.bmp", "-o", "-name", "*.svg",
+                "-o", "-name", "*.gif", "-o", "-name", "*.mp4", "-o", "-name", "*.webm",
+                "-o", "-name", "*.mov", "-o", "-name", "*.avi", "-o", "-name", "*.mkv", ")", "-print"];
+        }
+
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const files = text.trim().split("\n").filter(f => f.length > 0);
+                console.log("Fallback scan found", files.length, "wallpapers");
+                root._buildList(files.sort());
+            }
+        }
+    }
+
+    Process {
+        id: scanSubfoldersProc
+
+        running: false
+        command: {
+            const d = Paths.wallsdir;
+            if (!d) return [];
+            return ["find", d, "-mindepth", "1", "-name", ".*", "-prune", "-o", "-type", "d", "-print"];
+        }
+
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const raw = text.trim().split("\n").filter(f => f.length > 0);
+                root._allSubdirs = raw;
+
+                const base = Paths.wallsdir.endsWith("/") ? Paths.wallsdir : Paths.wallsdir + "/";
+                const topLevel = raw
+                    .map(p => {
+                        const rel = p.replace(base, "");
+                        return rel.indexOf("/") === -1 ? p.split("/").pop() : null;
+                    })
+                    .filter(n => n !== null && !n.startsWith("."))
+                    .sort();
+                root.subfolderFilters = topLevel;
+            }
+        }
+    }
+
+    // ── Directory watchers ─────────────────────────────────────────────
+
+    FileView {
+        id: dirWatcher
+
         path: Paths.wallsdir
-        filter: FileSystemModel.Images
+        watchChanges: true
+        printErrors: false
+        onFileChanged: {
+            if (!Paths.wallsdir) return;
+            root._triggerScan();
+        }
+    }
+
+    Instantiator {
+        model: root._allSubdirs
+        delegate: FileView {
+            path: modelData
+            watchChanges: true
+            printErrors: false
+            onFileChanged: {
+                console.log("Subdirectory changed:", path);
+                root._triggerScan();
+            }
+        }
+    }
+
+    // ── Preview colour extraction ──────────────────────────────────────
+
+    Process {
+        id: previewFrameProc
+
+        command: ["ffmpeg", "-y", "-loglevel", "error", "-i", root.previewPath, "-frames:v", "1", root.videoFramePath]
+        onExited: code => { // qmllint disable signal-handler-parameters
+            if (code === 0) {
+                root.previewColoursPath = root.videoFramePath;
+                getPreviewColoursProc.running = true;
+            }
+        }
     }
 
     Process {
         id: getPreviewColoursProc
 
-        command: ["caelestia", "wallpaper", "-p", root.previewPath, ...root.smartArg]
+        command: ["caelestia", "wallpaper", "-p", root.previewColoursPath, ...root.smartArg]
         stdout: StdioCollector {
             onStreamFinished: {
                 Colours.load(text, true);
                 Colours.showPreview = true;
+            }
+        }
+    }
+
+    // ── Thumbnail generation ───────────────────────────────────────────
+    //
+    // The thumbnail script (scripts/thumbgen.py) writes 280x158-crop JPGs
+    // mirroring wallsdir into <cache>/wallpaper-thumbs/. The picker items
+    // bind directly to those file:// URLs so videos and gifs get thumbs
+    // without depending on the C++ imagecacher having ffmpeg support.
+    //
+    // Runs 2s after the most recent _buildList so a flurry of FS events
+    // collapses into a single generation pass.
+
+    Timer {
+        id: delayedThumbnailGen
+
+        interval: 2000
+        repeat: false
+        onTriggered: {
+            const fallbackDir = Paths.wallsdir;
+            thumbgenProc.command = [
+                "python3", root._thumbgenScript,
+                Paths.wallsdir,
+                Paths.cache,
+                fallbackDir
+            ];
+            thumbgenProc.running = true;
+        }
+    }
+
+    Process {
+        id: thumbgenProc
+
+        running: false
+        command: []
+
+        stdout: StdioCollector {
+            onStreamFinished: {
+                if (text.length > 0) console.log("thumbgen:", text);
+            }
+        }
+        stderr: StdioCollector {
+            onStreamFinished: {
+                if (text.length > 0) console.warn("thumbgen err:", text);
+            }
+        }
+        onExited: exitCode => { // qmllint disable signal-handler-parameters
+            if (exitCode === 0) {
+                root.thumbnailVersion++;
+            } else {
+                console.warn("thumbgen failed with code:", exitCode);
             }
         }
     }


### PR DESCRIPTION
Adds support for mp4/webm/mov/avi/mkv/gif as backgrounds, both in the picker preview and the displayed wallpaper. The original caelestia file picker only listed those extensions in its FileSystemModel name filter and rendered stills only via CachingImage, so picking a video left a black/blank wallpaper. This commit ports the picker thumbs via a Python script (avoids relying on a plugin rebuild) and re-implements the background engine so videos and gifs actually play.

Plugin (C++)
  - imagecacher detects video/gif/m4v/ogv extensions and spawns ffmpeg via QProcess to extract a first-frame PNG into the existing cache layout. The still-image QImage decode path is unchanged.
  - CachingImageProvider runs the job synchronously for video sources so the picker doesn't get a null response on first request.
  - isVideoLike exposed as a static helper for future callers.

Service (QML)
  - Wallpapers.qml no longer depends on Caelestia.Models.FileSystemModel. Uses a Quickshell.Io.Process with find instead. Adds isVideo, getFileType, getCategoryFor(path) helpers used across pickers.
  - Adds scripts/thumbgen.py subprocess invocation: a 2s debounce runs a threaded Python generator (ffmpeg for video/gif, ImageMagick for images) that populates $cache/wallpaper-thumbs/<relative>.jpg at 280x158-crop. getThumbnailPath(path) and thumbnailVersion pickers use to load file:// URLs directly, bypassing the C++ provider for thumbnail previews. ffmpeg/ImageMagick availability probed at startup; missing tool skips that file type cleanly.
  - Videos still extract a representative frame via ffmpeg before invoking the caelestia colour scheme generator.

Background engine
  - modules/background/Wallpaper.qml mirrors the caelestia original pattern: single active wrapper created on source change, FadeIn via Anim on opacity 0 -> 1 once the inner media signals ready, old wrapper auto-destructs via a Timer when root.current is something else and that something is ready. Wrapper types match file extension: CachingImage for stills, AnimatedImage for gifs, QtMultimedia.Video (loops: Infinite, autoPlay: true, muted: true) for videos. contentReady is fired on Image.Loading|Ready, AnimatedImage.Loading|Ready, MediaPlayer.Loaded|PlayingState with a per-instance _readyFired latch so it fires exactly once per sourceFile.

Pickers
  - WallpaperItem / WallpaperSelect / WallpaperCategory bind directly to "file://$thumb?v=$version" now; CachingImage is removed from the picker path and the unused Caelestia.Images import is dropped.
  - MaterialIcon placeholder differentiates videos (movie) from stills (image) until the cache file is ready.

CMake / Nix
  - scripts/ directory added to the install list so thumbgen.py is available at runtime when installed via cmake.
  - nix/default.nix adds ffmpeg to runtime deps and qt6.qtmultimedia to quickshell/build deps. Without either the new imagecacher branch is unreachable and Video stays inert.