### PR TITLE
feat(audio): add per-app call volume control

### DIFF
--- a/modules/bar/popouts/Audio.qml
+++ b/modules/bar/popouts/Audio.qml
@@ -98,6 +98,36 @@ Item {
             }
         }
 
+        // Call volume — only visible when call apps are active
+        StyledText {
+            Layout.topMargin: Tokens.spacing.medium
+            visible: Audio.getCallStreams().length > 0
+            text: qsTr("Call volume (%1)").arg(`${Math.round(Audio.callVolume * 100)}%`)
+            font: Tokens.font.body.builders.medium.weight(Font.Medium).build()
+        }
+
+        CustomMouseArea {
+            Layout.fillWidth: true
+            implicitHeight: Tokens.padding.medium * 3
+            visible: Audio.getCallStreams().length > 0
+
+            onWheel: event => {
+                if (event.angleDelta.y > 0)
+                    Audio.incrementCallVolume();
+                else if (event.angleDelta.y < 0)
+                    Audio.decrementCallVolume();
+            }
+
+            StyledSlider {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                implicitHeight: parent.implicitHeight
+
+                value: Audio.callVolume
+                onInteraction: value => Audio.setCallVolume(value)
+            }
+        }
+
         IconTextButton {
             Layout.fillWidth: true
             Layout.topMargin: Tokens.spacing.medium

--- a/modules/nexus/pages/AudioPage.qml
+++ b/modules/nexus/pages/AudioPage.qml
@@ -72,6 +72,7 @@ PageBase {
             onSelected: node => Audio.setAudioSource(node)
         }
 
+        // Per-app volumes
         // Call volume — quick control for all communication apps at once
         SliderRow {
             Layout.topMargin: Tokens.spacing.large - parent.spacing

--- a/modules/nexus/pages/AudioPage.qml
+++ b/modules/nexus/pages/AudioPage.qml
@@ -72,6 +72,18 @@ PageBase {
             onSelected: node => Audio.setAudioSource(node)
         }
 
+        // Call volume — quick control for all communication apps at once
+        SliderRow {
+            Layout.topMargin: Tokens.spacing.large - parent.spacing
+            first: true
+            icon: "call"
+            label: qsTr("Call volume")
+            valueLabel: Math.round(value * 100) + "%"
+            value: Audio.callVolume
+            enabled: true
+            onMoved: v => Audio.setCallVolume(v)
+        }
+
         // Per-app volumes
         ConnectedRect {
             Layout.fillWidth: true

--- a/modules/osd/Content.qml
+++ b/modules/osd/Content.qml
@@ -19,6 +19,7 @@ Item {
     required property bool muted
     required property real sourceVolume
     required property bool sourceMuted
+    required property real callVolume
     required property real brightness
 
     implicitWidth: layout.implicitWidth + Tokens.padding.large + layout.anchors.horizontalCenterOffset * 2
@@ -75,6 +76,32 @@ Item {
                     value: root.sourceVolume
                     to: GlobalConfig.services.maxVolume
                     onMoved: Audio.setSourceVolume(value)
+                }
+            }
+        }
+
+        // Call volume
+        WrappedLoader {
+            shouldBeActive: Audio.getCallStreams().length > 0
+
+            sourceComponent: CustomMouseArea {
+                function onWheel(event: WheelEvent) {
+                    if (event.angleDelta.y > 0)
+                        Audio.incrementCallVolume();
+                    else if (event.angleDelta.y < 0)
+                        Audio.decrementCallVolume();
+                }
+
+                implicitWidth: Tokens.sizes.osd.sliderWidth
+                implicitHeight: Tokens.sizes.osd.sliderHeight
+
+                FilledSlider {
+                    anchors.fill: parent
+
+                    icon: "call"
+                    value: root.callVolume
+                    to: GlobalConfig.services.maxVolume
+                    onMoved: Audio.setCallVolume(value)
                 }
             }
         }

--- a/modules/osd/Wrapper.qml
+++ b/modules/osd/Wrapper.qml
@@ -23,6 +23,7 @@ Item {
     property bool muted
     property real sourceVolume
     property bool sourceMuted
+    property real callVolume
     property real brightness
 
     function show(): void {
@@ -35,6 +36,7 @@ Item {
         muted = Audio.muted;
         sourceVolume = Audio.sourceVolume;
         sourceMuted = Audio.sourceMuted;
+        callVolume = Audio.callVolume;
         brightness = root.monitor?.brightness ?? 0;
     }
 
@@ -67,6 +69,11 @@ Item {
         function onSourceVolumeChanged(): void {
             root.show();
             root.sourceVolume = Audio.sourceVolume;
+        }
+
+        function onCallVolumeChanged(): void {
+            root.show();
+            root.callVolume = Audio.callVolume;
         }
 
         target: Audio
@@ -107,6 +114,7 @@ Item {
             muted: root.muted
             sourceVolume: root.sourceVolume
             sourceMuted: root.sourceMuted
+            callVolume: root.callVolume
             brightness: root.brightness
         }
     }

--- a/services/Audio.qml
+++ b/services/Audio.qml
@@ -27,6 +27,74 @@ Singleton {
     readonly property bool sourceMuted: !!source?.audio?.muted
     readonly property real sourceVolume: source?.audio?.volume ?? 0
 
+    // Call volume — controls output volume of calling/communication apps
+    // (Discord, Teams, Zoom, etc.) independently of system volume.
+    // Edit this list to customize which apps are considered "call" apps.
+    // Matches against application.name, application.process.binary, and
+    // node name (case-insensitive substring match).
+    readonly property var callAppsPatterns: [
+        "discord", "teams-for-linux", "teams", "zoom", "slack",
+        "telegram-desktop", "signal-desktop", "skypeforlinux", "element",
+        "jitsi-meet", "mumble", "webex", "vesktop", "equicord"
+    ]
+
+    property real callVolume: 1.0
+
+    function getCallStreams() {
+        if (!root.streams)
+            return [];
+        const patterns = callAppsPatterns || [];
+        return root.streams.filter(s => {
+            if (!s || !s.properties)
+                return false;
+            // Only target output/playback streams, not microphone capture
+            const mediaClass = (s.properties["media.class"] || "");
+            if (!mediaClass.startsWith("Stream/Output"))
+                return false;
+            const appName = (s.properties["application.name"] || "").toLowerCase();
+            const binary = (s.properties["application.process.binary"] || "").toLowerCase();
+            const nodeName = (s.name || "").toLowerCase();
+            return patterns.some(pattern =>
+                appName.includes(pattern) || binary.includes(pattern) || nodeName.includes(pattern)
+            );
+        });
+    }
+
+    function setCallVolume(newVolume: real): void {
+        root.callVolume = Math.max(0, Math.min(GlobalConfig.services.maxVolume, newVolume));
+        const streams = getCallStreams();
+        if (!streams)
+            return;
+        for (const s of streams) {
+            if (s?.ready && s?.audio) {
+                s.audio.muted = false;
+                s.audio.volume = root.callVolume;
+            }
+        }
+    }
+
+    function incrementCallVolume(amount: real): void {
+        setCallVolume(root.callVolume + (amount || GlobalConfig.services.audioIncrement));
+    }
+
+    function decrementCallVolume(amount: real): void {
+        setCallVolume(root.callVolume - (amount || GlobalConfig.services.audioIncrement));
+    }
+
+    // Auto-apply call volume when new call streams appear
+    function applyCallVolumeToNewStreams(): void {
+        if (root.callVolume >= 1.0)
+            return;
+        const streams = getCallStreams();
+        if (!streams)
+            return;
+        for (const s of streams) {
+            if (s?.ready && s?.audio && Math.abs(s.audio.volume - root.callVolume) > 0.01) {
+                s.audio.volume = root.callVolume;
+            }
+        }
+    }
+
     readonly property alias cava: cava
     readonly property alias beatTracker: beatTracker
 
@@ -124,6 +192,7 @@ Singleton {
         root.sinks = newSinks;
         root.sources = newSources;
         root.streams = newStreams;
+        root.applyCallVolumeToNewStreams();
     }
 
     onSinkChanged: {

--- a/services/Audio.qml
+++ b/services/Audio.qml
@@ -32,13 +32,12 @@ Singleton {
     // Edit this list to customize which apps are considered "call" apps.
     // Matches against application.name, application.process.binary, and
     // node name (case-insensitive substring match).
-    readonly property var callAppsPatterns: [
-        "discord", "teams-for-linux", "teams", "zoom", "slack",
-        "telegram-desktop", "signal-desktop", "skypeforlinux", "element",
-        "jitsi-meet", "mumble", "webex", "vesktop", "equicord"
-    ]
+    readonly property var callAppsPatterns: ["discord", "teams-for-linux", "teams", "zoom", "slack", "telegram-desktop", "signal-desktop", "skypeforlinux", "element", "jitsi-meet", "mumble", "webex", "vesktop", "equicord"]
 
     property real callVolume: 1.0
+
+    readonly property alias cava: cava
+    readonly property alias beatTracker: beatTracker
 
     function getCallStreams() {
         if (!root.streams)
@@ -54,9 +53,7 @@ Singleton {
             const appName = (s.properties["application.name"] || "").toLowerCase();
             const binary = (s.properties["application.process.binary"] || "").toLowerCase();
             const nodeName = (s.name || "").toLowerCase();
-            return patterns.some(pattern =>
-                appName.includes(pattern) || binary.includes(pattern) || nodeName.includes(pattern)
-            );
+            return patterns.some(pattern => appName.includes(pattern) || binary.includes(pattern) || nodeName.includes(pattern));
         });
     }
 
@@ -94,9 +91,6 @@ Singleton {
             }
         }
     }
-
-    readonly property alias cava: cava
-    readonly property alias beatTracker: beatTracker
 
     function setVolume(newVolume: real): void {
         if (sink?.ready && sink?.audio) {


### PR DESCRIPTION
Adds a **Call Volume** setting that controls the output volume of communication/calling apps (Discord, Teams, Zoom, etc.) independently of the system master volume. This way users don't have to lower the entire system volume during calls — they can keep system audio at 100% and set calls to e.g. 60%.

## How it works

1. A `callAppsPatterns` list in `Audio.qml` defines which apps are "call apps" (matched against `application.name`, `application.process.binary`, and node name)
2. `getCallStreams()` filters active PipeWire output streams matching the patterns
3. `callVolume` property stores the desired level (1.0 = 100%)
4. When set, all matching streams get updated; new call streams are auto-adjusted

## Changes

| File | Change |
|------|--------|
| `services/Audio.qml` | `callAppsPatterns`, `callVolume` property, `getCallStreams()`, `setCallVolume()`/`incrementCallVolume()`/`decrementCallVolume()`, `applyCallVolumeToNewStreams()` |
| `modules/nexus/pages/AudioPage.qml` | "Call volume" slider in Audio settings page |
| `modules/osd/Wrapper.qml` + `Content.qml` | Call volume in OSD overlay (visible when call apps are streaming) |
| `modules/bar/popouts/Audio.qml` | Call volume slider in bar audio popout (visible when call apps are streaming) |

## Supported apps

| Apps matched | Pattern |
|---|---|
| Discord, Vesktop, Equicord | `discord` (via `application.process.binary`) |
| Microsoft Teams | `teams`, `teams-for-linux` |
| Zoom | `zoom` |
| Slack | `slack` |
| Telegram Desktop | `telegram-desktop` |
| Signal Desktop | `signal-desktop` |
| Skype | `skypeforlinux` |
| Element (Matrix) | `element` |
| Jitsi Meet | `jitsi-meet` |
| Mumble | `mumble` |
| Cisco Webex | `webex` |

Edit `callAppsPatterns` in `Audio.qml` to add/remove apps.

## Tested

Working on Caelestia shell v2.2.0 (Arch AUR) — verified with Discord voice calls on Hyprland + PipeWire.