### PR TITLE
fix(popouts): shape the input mask from where the popout is going

### DIFF
--- a/modules/bar/popouts/ClipWrapper.qml
+++ b/modules/bar/popouts/ClipWrapper.qml
@@ -14,14 +14,10 @@ Item {
     readonly property alias content: content
     property real offsetScale: x > 0 || content.hasCurrent ? 0 : 1
 
-    visible: width > 0 && height > 0
-    clip: true
-
-    implicitWidth: content.implicitWidth * (1 - offsetScale)
-    implicitHeight: content.implicitHeight
-
-    x: content.isDetached ? (parent.width - content.nonAnimWidth) / 2 : 0
-    y: {
+    // Where the popout is headed, before the Behaviors below lag it there. The input mask
+    // (modules/drawers/Regions.qml) is cut from these: a hole shaped from the animated geometry
+    // trails what is drawn, so the pointer falls through the visible popout to the window below.
+    readonly property real targetY: {
         if (content.isDetached)
             return (parent.height - content.nonAnimHeight) / 2;
 
@@ -31,6 +27,19 @@ Item {
             return off + diff;
         return Math.max(off, 0);
     }
+    // While closing there is nothing to settle into, so track the live size and let the hole shrink
+    readonly property bool opening: content.hasCurrent || content.isDetached
+    readonly property real nonAnimWidth: opening ? content.nonAnimWidth : width
+    readonly property real nonAnimHeight: opening ? content.nonAnimHeight : height
+
+    visible: width > 0 && height > 0
+    clip: true
+
+    implicitWidth: content.implicitWidth * (1 - offsetScale)
+    implicitHeight: content.implicitHeight
+
+    x: content.isDetached ? (parent.width - content.nonAnimWidth) / 2 : 0
+    y: targetY
 
     Behavior on offsetScale {
         Anim {}

--- a/modules/drawers/Regions.qml
+++ b/modules/drawers/Regions.qml
@@ -67,9 +67,18 @@ Region {
         height: panel.height * (1 - root.panels.utilities.offsetScale) + root.borderThickness
     }
 
+    // Union of where the popout is and where it is settling, so the hole leads the animation rather
+    // than trailing it: shaped from the animated geometry alone, a cursor moving onto a popout that
+    // is still sliding or growing lands outside the mask and is handed to the window underneath,
+    // which reaches the shell as a pointer leave. No offsetScale — panel.width already has it.
     R {
+        readonly property real settleY: root.panels.popoutsWrapper.targetY
+        readonly property real unionY: Math.min(panel.y, settleY)
+
         panel: root.panels.popoutsWrapper
-        width: panel.width * (1 - root.panels.popoutsWrapper.offsetScale)
+        y: unionY + root.borderThickness
+        width: Math.max(panel.width, root.panels.popoutsWrapper.nonAnimWidth)
+        height: Math.max(panel.y + panel.height, settleY + root.panels.popoutsWrapper.nonAnimHeight) - unionY
     }
 
     component R: Region {


### PR DESCRIPTION
Popouts dismiss themselves when the cursor moves onto them quickly.

`Regions.qml` cuts the popout's hole in the window mask from the wrapper's animated x/y/width. While the popout is sliding from one bar entry to the next, or growing open, that hole trails what is actually drawn. A cursor moving onto the popout lands outside the mask, the compositor routes the pointer to the window underneath, and the pointer leave that follows closes the popout. Moving slowly works, because the hole catches up before the cursor gets there.

The same expression also applies `offsetScale` to a width that already includes it (`ClipWrapper.implicitWidth`), so for the length of the open animation the hole is scaled by `(1 - offsetScale)` twice.

This shapes the hole from the union of the popout's current and settled rects, so it leads the animation rather than trailing it, and drops the duplicate `offsetScale`. `targetY` and the non animated size are exposed on `ClipWrapper` for that.

Geometry is unchanged once the popout is at rest, where the settled values equal the animated ones, so only the transition is affected.

Testing: reproduced and fixed on a downstream branch running a horizontal bar, where the slide between entries makes it easy to hit. `qmlformat` and `scripts/qml-lint-conventions.py` are clean. The left bar goes through the same code, but I have not run main directly, so that path is worth a look.