### PR TITLE
feat: configurable bar position and dashboard edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,14 @@ For example, to disable the bar on DP-1:
 > This is meant to serve as a reference of all the available options, and you should
 > only add the ones you want to change to `shell.json`.
 
+> [!NOTE]
+> `bar.position` accepts `left`, `top` or `bottom`. `dashboard.position` accepts `top` or `left`.
+> Unrecognised values fall back to the default, and a dashboard configured on the bar's own edge
+> opens from the other one, since a bar covers the edge it would be revealed from.
+>
+> On a bottom bar the launcher's hover zone is covered by the bar, so it opens by keybind only,
+> and the utilities panel opens from the `power` entry instead of the bottom-right corner.
+
 <details><summary>Example</summary>
 
 ```json
@@ -415,6 +423,7 @@ For example, to disable the bar on DP-1:
         }
     },
     "bar": {
+        "position": "left",
         "persistent": true,
         "showOnHover": true,
         "dragThreshold": 20,
@@ -527,6 +536,7 @@ For example, to disable the bar on DP-1:
         "smoothing": 20
     },
     "dashboard": {
+        "position": "top",
         "enabled": true,
         "showOnHover": true,
         "showDashboard": true,

--- a/modules/background/Background.qml
+++ b/modules/background/Background.qml
@@ -15,6 +15,7 @@ Variants {
         id: win
 
         required property ShellScreen modelData
+        readonly property var edgeGeometry: ShellState.componentsFor(screen)?.rootWindow?.geometry
 
         screen: modelData
         name: "background"
@@ -64,7 +65,9 @@ Variants {
             active: Config.background.desktopClock.enabled
 
             anchors.margins: Tokens.padding.extraLargeIncreased
-            anchors.leftMargin: Tokens.padding.extraLargeIncreased + Tokens.sizes.bar.innerWidth + Math.max(Tokens.padding.small, Config.border.thickness)
+            anchors.leftMargin: Tokens.padding.extraLargeIncreased + ((win.edgeGeometry?.barOnLeft ?? true) && state.endsWith("-left") ? Tokens.sizes.bar.innerWidth + Math.max(Tokens.padding.small, Config.border.thickness) : 0)
+            anchors.topMargin: Tokens.padding.extraLargeIncreased + (win.edgeGeometry?.barOnTop && state.startsWith("top-") ? Tokens.sizes.bar.innerWidth + Math.max(Tokens.padding.small, Config.border.thickness) : 0)
+            anchors.bottomMargin: Tokens.padding.extraLargeIncreased + (win.edgeGeometry?.barOnBottom && state.startsWith("bottom-") ? Tokens.sizes.bar.innerWidth + Math.max(Tokens.padding.small, Config.border.thickness) : 0)
 
             state: Config.background.desktopClock.position
             states: [

--- a/modules/background/Visualiser.qml
+++ b/modules/background/Visualiser.qml
@@ -15,6 +15,7 @@ Item {
     required property ShellScreen screen
     required property Item wallpaper
 
+    readonly property var edgeGeometry: ShellState.componentsFor(screen)?.rootWindow?.geometry
     readonly property bool shouldBeActive: Config.background.visualiser.enabled && (!Config.background.visualiser.autoHide || (Hypr.monitorFor(screen)?.activeWorkspace?.toplevels?.values.every(t => t.lastIpcObject?.floating) ?? true))
     property real offset: shouldBeActive ? 0 : screen.height * 0.2
 
@@ -60,7 +61,9 @@ Item {
 
                     anchors.fill: parent
                     anchors.margins: Config.border.thickness
-                    anchors.leftMargin: (ShellState.componentsFor(root.screen)?.bar?.exclusiveZone ?? 0) + Tokens.spacing.small * Config.background.visualiser.spacing
+                    anchors.leftMargin: (root.edgeGeometry?.barOnLeft ?? true) ? (ShellState.componentsFor(root.screen)?.bar?.exclusiveZone ?? 0) + Tokens.spacing.small * Config.background.visualiser.spacing : Config.border.thickness
+                    anchors.topMargin: root.edgeGeometry?.barOnTop ? (ShellState.componentsFor(root.screen)?.bar?.exclusiveZone ?? 0) + Tokens.spacing.small * Config.background.visualiser.spacing : Config.border.thickness
+                    anchors.bottomMargin: root.edgeGeometry?.barOnBottom ? (ShellState.componentsFor(root.screen)?.bar?.exclusiveZone ?? 0) + Tokens.spacing.small * Config.background.visualiser.spacing : Config.border.thickness
 
                     values: Audio.cava.values
                     primaryColor: Qt.alpha(Colours.palette.m3primary, 0.7)

--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -10,14 +10,15 @@ import Caelestia.Config
 import qs.components
 import qs.services
 
-ColumnLayout {
+GridLayout {
     id: root
 
     required property ShellScreen screen
     required property ScreenState screenState
     required property BarPopouts.Wrapper popouts
     required property bool fullscreen
-    readonly property int vPadding: Tokens.padding.large
+    required property bool horizontal
+    readonly property int axisPadding: Tokens.padding.large
 
     function closeTray(): void {
         if (!Config.bar.tray.compact)
@@ -30,8 +31,18 @@ ColumnLayout {
         }
     }
 
-    function checkPopout(y: real): void {
-        const ch = childAt(width / 2, y) as EntryWrapper;
+    function axisCenterOf(item: Item): real {
+        const c = item.mapToItem(root, item.implicitWidth / 2, item.implicitHeight / 2);
+        return horizontal ? c.x : c.y;
+    }
+
+    function entryAt(pos: real): string {
+        const ch = (horizontal ? childAt(pos, height / 2) : childAt(width / 2, pos)) as EntryWrapper;
+        return ch?.entryId ?? "";
+    }
+
+    function checkPopout(pos: real): void {
+        const ch = (horizontal ? childAt(pos, height / 2) : childAt(width / 2, pos)) as EntryWrapper;
 
         if (ch?.entryId !== "tray")
             closeTray();
@@ -42,24 +53,24 @@ ColumnLayout {
         }
 
         const id = ch.entryId;
-        const top = ch.y;
+        const start = horizontal ? ch.x : ch.y;
 
         if (id === "statusIcons" && Config.bar.popouts.statusIcons) {
             const items = (ch.item as StatusIcons).items;
-            const icon = items.childAt(items.width / 2, mapToItem(items, 0, y).y);
+            const icon = horizontal ? items.childAt(mapToItem(items, pos, 0).x, items.height / 2) : items.childAt(items.width / 2, mapToItem(items, 0, pos).y);
             if (icon) {
                 popouts.currentName = icon.name;
-                popouts.currentCenter = Qt.binding(() => icon.mapToItem(root, 0, icon.implicitHeight / 2).y);
+                popouts.currentCenter = Qt.binding(() => axisCenterOf(icon));
                 popouts.hasCurrent = true;
             }
         } else if (id === "tray" && Config.bar.popouts.tray) {
             const tray = ch.item as Tray;
-            if (!Config.bar.tray.compact || (tray.expanded && !tray.expandIcon.contains(mapToItem(tray.expandIcon, tray.implicitWidth / 2, y)))) {
-                const index = Math.floor(((y - top - tray.padding * 2 + tray.spacing) / tray.layout.implicitHeight) * tray.items.count);
+            if (!Config.bar.tray.compact || (tray.expanded && !tray.expandIcon.contains(horizontal ? mapToItem(tray.expandIcon, pos, tray.implicitHeight / 2) : mapToItem(tray.expandIcon, tray.implicitWidth / 2, pos)))) {
+                const index = Math.floor(((pos - start - tray.padding * 2 + tray.spacing) / (horizontal ? tray.layout.implicitWidth : tray.layout.implicitHeight)) * tray.items.count);
                 const trayItem = tray.items.itemAt(index);
                 if (trayItem) {
                     popouts.currentName = `traymenu${index}`;
-                    popouts.currentCenter = Qt.binding(() => trayItem.mapToItem(root, 0, trayItem.implicitHeight / 2).y);
+                    popouts.currentCenter = Qt.binding(() => axisCenterOf(trayItem));
                     popouts.hasCurrent = true;
                 } else {
                     popouts.hasCurrent = false;
@@ -70,13 +81,15 @@ ColumnLayout {
             }
         } else if (id === "activeWindow" && Config.bar.popouts.activeWindow && Config.bar.activeWindow.showOnHover) {
             popouts.currentName = id.toLowerCase();
-            popouts.currentCenter = (ch.item as Item).mapToItem(root, 0, (ch.item as Item).implicitHeight / 2).y ?? 0;
+            popouts.currentCenter = axisCenterOf(ch.item as Item);
             popouts.hasCurrent = true;
+        } else if (id === "power" && horizontal) {
+            popouts.hasCurrent = false;
         }
     }
 
-    function handleWheel(y: real, angleDelta: point): void {
-        const ch = childAt(width / 2, y) as EntryWrapper;
+    function handleWheel(pos: real, angleDelta: point): void {
+        const ch = (horizontal ? childAt(pos, height / 2) : childAt(width / 2, pos)) as EntryWrapper;
         if (ch?.entryId === "workspaces" && Config.bar.scrollActions.workspaces) {
             // Workspace scroll
             const mon = (GlobalConfig.bar.workspaces.perMonitorWorkspaces ? Hypr.monitorFor(screen) : Hypr.focusedMonitor);
@@ -85,14 +98,14 @@ ColumnLayout {
                 Hypr.dispatch(Hypr.usingLua ? `hl.dsp.workspace.toggle_special("${specialWs.slice(8)}")` : `togglespecialworkspace ${specialWs.slice(8)}`);
             else if (angleDelta.y < 0 || (GlobalConfig.bar.workspaces.perMonitorWorkspaces ? mon.activeWorkspace?.id : Hypr.activeWsId) > 1)
                 Hypr.dispatch(Hypr.usingLua ? `hl.dsp.focus({ workspace = "r${angleDelta.y > 0 ? "-" : "+"}1" })` : `workspace r${angleDelta.y > 0 ? "-" : "+"}1`);
-        } else if (y < screen.height / 2 && Config.bar.scrollActions.volume) {
-            // Volume scroll on top half
+        } else if (pos < (horizontal ? screen.width : screen.height) / 2 && Config.bar.scrollActions.volume) {
+            // Volume scroll on top/left half
             if (angleDelta.y > 0)
                 Audio.incrementVolume();
             else if (angleDelta.y < 0)
                 Audio.decrementVolume();
         } else if (Config.bar.scrollActions.brightness) {
-            // Brightness scroll on bottom half
+            // Brightness scroll on bottom/right half
             const monitor = Brightness.getMonitorForScreen(screen);
             if (angleDelta.y > 0)
                 monitor.setBrightness(monitor.brightness + GlobalConfig.services.brightnessIncrement);
@@ -101,7 +114,9 @@ ColumnLayout {
         }
     }
 
-    spacing: Tokens.spacing.medium
+    columns: horizontal ? -1 : 1
+    rowSpacing: Tokens.spacing.medium
+    columnSpacing: Tokens.spacing.medium
 
     Repeater {
         id: repeater
@@ -116,7 +131,8 @@ ColumnLayout {
             DelegateChoice {
                 roleValue: "spacer"
                 delegate: EntryWrapper {
-                    Layout.fillHeight: true
+                    Layout.fillHeight: !root.horizontal
+                    Layout.fillWidth: root.horizontal
                 }
             }
             DelegateChoice {
@@ -134,6 +150,7 @@ ColumnLayout {
                         objectName: "taskbarWorkspaces"
                         screen: root.screen
                         fullscreen: root.fullscreen
+                        horizontal: root.horizontal
                     }
                 }
             }
@@ -144,6 +161,7 @@ ColumnLayout {
                         objectName: "taskbarActiveWindow"
                         bar: root
                         monitor: Brightness.getMonitorForScreen(root.screen)
+                        horizontal: root.horizontal
                     }
                 }
             }
@@ -152,6 +170,7 @@ ColumnLayout {
                 delegate: EntryWrapper {
                     Tray {
                         objectName: "taskbarTray"
+                        horizontal: root.horizontal
                     }
                 }
             }
@@ -160,6 +179,7 @@ ColumnLayout {
                 delegate: EntryWrapper {
                     Clock {
                         objectName: "taskbarClock"
+                        horizontal: root.horizontal
                     }
                 }
             }
@@ -168,6 +188,7 @@ ColumnLayout {
                 delegate: EntryWrapper {
                     StatusIcons {
                         objectName: "taskbarStatusIcons"
+                        horizontal: root.horizontal
                     }
                 }
             }
@@ -189,9 +210,11 @@ ColumnLayout {
         default property Item item
         readonly property string entryId: modelData.id
 
-        Layout.topMargin: index === 0 ? root.vPadding : 0
-        Layout.bottomMargin: index === repeater.count - 1 ? root.vPadding : 0
-        Layout.alignment: Qt.AlignHCenter
+        Layout.topMargin: !root.horizontal && index === 0 ? root.axisPadding : 0
+        Layout.bottomMargin: !root.horizontal && index === repeater.count - 1 ? root.axisPadding : 0
+        Layout.leftMargin: root.horizontal && index === 0 ? root.axisPadding : 0
+        Layout.rightMargin: root.horizontal && index === repeater.count - 1 ? root.axisPadding : 0
+        Layout.alignment: root.horizontal ? Qt.AlignVCenter : Qt.AlignHCenter
 
         implicitWidth: item?.implicitWidth ?? 0
         implicitHeight: item?.implicitHeight ?? 0

--- a/modules/bar/BarWrapper.qml
+++ b/modules/bar/BarWrapper.qml
@@ -14,38 +14,46 @@ Item {
     required property ScreenState screenState
     required property BarPopouts.Wrapper popouts
     required property bool fullscreen
+    required property string position
 
+    readonly property bool horizontal: position !== "left"
     readonly property bool disabled: Strings.testRegexList(Config.bar.excludedScreens, screen.name)
 
-    readonly property int clampedWidth: Math.max(Config.border.minThickness, implicitWidth)
+    readonly property int clampedExtent: Math.max(Config.border.minThickness, extent)
     readonly property int padding: Math.max(Tokens.padding.small, Config.border.thickness)
-    readonly property int contentWidth: Tokens.sizes.bar.innerWidth + padding * 2
-    readonly property int exclusiveZone: !disabled && (Config.bar.persistent || screenState.bar) ? contentWidth : Config.border.thickness
+    readonly property int contentThickness: Tokens.sizes.bar.innerWidth + padding * 2
+    readonly property int exclusiveZone: !disabled && (Config.bar.persistent || screenState.bar) ? contentThickness : Config.border.thickness
     readonly property bool shouldBeVisible: !fullscreen && !disabled && (Config.bar.persistent || screenState.bar || isHovered)
     property bool isHovered
+    property real extent: fullscreen ? 0 : Config.border.thickness
 
     function closeTray(): void {
         (content.item as Bar)?.closeTray();
     }
 
-    function checkPopout(y: real): void {
-        (content.item as Bar)?.checkPopout(y);
+    function checkPopout(pos: real): void {
+        (content.item as Bar)?.checkPopout(pos);
     }
 
-    function handleWheel(y: real, angleDelta: point): void {
-        (content.item as Bar)?.handleWheel(y, angleDelta);
+    function entryAt(pos: real): string {
+        return (content.item as Bar)?.entryAt(pos) ?? "";
+    }
+
+    function handleWheel(pos: real, angleDelta: point): void {
+        (content.item as Bar)?.handleWheel(pos, angleDelta);
     }
 
     clip: true
-    visible: width > Config.border.thickness
-    implicitWidth: fullscreen ? 0 : Config.border.thickness
+    visible: extent > Config.border.thickness
+    implicitWidth: extent
+    implicitHeight: extent
 
     states: State {
         name: "visible"
         when: root.shouldBeVisible
 
         PropertyChanges {
-            root.implicitWidth: root.contentWidth
+            root.extent: root.contentThickness
         }
     }
 
@@ -56,7 +64,7 @@ Item {
 
             Anim {
                 target: root
-                property: "implicitWidth"
+                property: "extent"
             }
         },
         Transition {
@@ -65,7 +73,7 @@ Item {
 
             Anim {
                 target: root
-                property: "implicitWidth"
+                property: "extent"
                 type: Anim.Emphasized
             }
         }
@@ -74,18 +82,22 @@ Item {
     Loader {
         id: content
 
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
+        anchors.top: root.position !== "top" ? parent.top : undefined
+        anchors.bottom: root.position !== "bottom" ? parent.bottom : undefined
+        anchors.left: root.horizontal ? parent.left : undefined
         anchors.right: parent.right
+
+        width: root.contentThickness
+        height: root.contentThickness
 
         active: root.shouldBeVisible
 
         sourceComponent: Bar {
-            width: root.contentWidth
             screen: root.screen
             screenState: root.screenState
             popouts: root.popouts // qmllint disable incompatible-type
             fullscreen: root.fullscreen
+            horizontal: root.horizontal
         }
     }
 }

--- a/modules/bar/components/ActiveWindow.qml
+++ b/modules/bar/components/ActiveWindow.qml
@@ -11,6 +11,7 @@ Item {
 
     required property var bar
     required property Brightness.Monitor monitor
+    required property bool horizontal
     property color colour: Colours.palette.m3primary
 
     readonly property string windowTitle: {
@@ -26,17 +27,17 @@ Item {
         return title;
     }
 
-    readonly property int maxHeight: {
+    readonly property int maxSize: {
         const otherModules = bar.children.filter(c => c.entryId && c.item !== this && c.entryId !== "spacer");
-        const otherHeight = otherModules.reduce((acc, curr) => acc + (curr.item.nonAnimHeight ?? curr.height), 0);
+        const otherSize = otherModules.reduce((acc, curr) => acc + (horizontal ? (curr.item.nonAnimWidth ?? curr.width) : (curr.item.nonAnimHeight ?? curr.height)), 0);
         // Length - 2 cause repeater counts as a child
-        return bar.height - otherHeight - bar.spacing * (bar.children.length - 1) - bar.vPadding * 2;
+        return horizontal ? bar.width - otherSize - bar.columnSpacing * (bar.children.length - 1) - bar.axisPadding * 2 : bar.height - otherSize - bar.rowSpacing * (bar.children.length - 1) - bar.axisPadding * 2;
     }
     property Title current: text1
 
     clip: true
-    implicitWidth: Math.max(icon.implicitWidth, current.implicitHeight)
-    implicitHeight: icon.implicitHeight + current.implicitWidth + current.anchors.topMargin
+    implicitWidth: horizontal ? icon.implicitWidth + current.implicitWidth + current.anchors.leftMargin : Math.max(icon.implicitWidth, current.implicitHeight)
+    implicitHeight: horizontal ? Math.max(icon.implicitHeight, current.implicitHeight) : icon.implicitHeight + current.implicitWidth + current.anchors.topMargin
 
     Loader {
         asynchronous: true
@@ -57,7 +58,7 @@ Item {
                     popouts.hasCurrent = false;
                 } else {
                     popouts.currentName = "activewindow";
-                    popouts.currentCenter = root.mapToItem(root.bar, 0, root.implicitHeight / 2).y;
+                    popouts.currentCenter = root.bar.axisCenterOf(root);
                     popouts.hasCurrent = true;
                 }
             }
@@ -67,7 +68,9 @@ Item {
     MaterialIcon {
         id: icon
 
-        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.horizontalCenter: root.horizontal ? undefined : parent.horizontalCenter
+        anchors.verticalCenter: root.horizontal ? parent.verticalCenter : undefined
+        anchors.left: root.horizontal ? parent.left : undefined
 
         animate: true
         text: Icons.getAppCategoryIcon(Hypr.activeToplevel?.lastIpcObject.class, "desktop_windows")
@@ -88,7 +91,7 @@ Item {
         text: root.windowTitle
         font: root.Tokens.font.body.builders.small.letterSpacing(1.4).build()
         elide: Qt.ElideRight
-        elideWidth: root.maxHeight - icon.height
+        elideWidth: root.maxSize - (root.horizontal ? icon.width + root.current.anchors.leftMargin : icon.height)
 
         onTextChanged: {
             const next = root.current === text1 ? text2 : text1;
@@ -102,12 +105,21 @@ Item {
         Anim {}
     }
 
+    Behavior on implicitWidth {
+        enabled: root.horizontal
+
+        Anim {}
+    }
+
     component Title: StyledText {
         id: text
 
-        anchors.horizontalCenter: icon.horizontalCenter
-        anchors.top: icon.bottom
-        anchors.topMargin: Tokens.spacing.small
+        anchors.horizontalCenter: root.horizontal ? undefined : icon.horizontalCenter
+        anchors.verticalCenter: root.horizontal ? icon.verticalCenter : undefined
+        anchors.left: root.horizontal ? icon.right : undefined
+        anchors.top: root.horizontal ? undefined : icon.bottom
+        anchors.leftMargin: root.horizontal ? Tokens.spacing.small : 0
+        anchors.topMargin: root.horizontal ? 0 : Tokens.spacing.small
 
         font: metrics.font
         color: root.colour
@@ -116,17 +128,17 @@ Item {
 
         transform: [
             Translate {
-                x: root.Config.bar.activeWindow.inverted ? -text.implicitWidth + text.implicitHeight : 0
+                x: !root.horizontal && root.Config.bar.activeWindow.inverted ? -text.implicitWidth + text.implicitHeight : 0
             },
             Rotation {
-                angle: root.Config.bar.activeWindow.inverted ? 270 : 90
+                angle: root.horizontal ? 0 : root.Config.bar.activeWindow.inverted ? 270 : 90
                 origin.x: text.implicitHeight / 2
                 origin.y: text.implicitHeight / 2
             }
         ]
 
-        width: implicitHeight
-        height: implicitWidth
+        width: root.horizontal ? implicitWidth : implicitHeight
+        height: root.horizontal ? implicitHeight : implicitWidth
 
         Behavior on opacity {
             Anim {

--- a/modules/bar/components/Clock.qml
+++ b/modules/bar/components/Clock.qml
@@ -9,24 +9,27 @@ import qs.services
 StyledRect {
     id: root
 
+    required property bool horizontal
     readonly property color colour: Colours.palette.m3tertiary
     readonly property int padding: Config.bar.clock.background ? Tokens.padding.medium : Tokens.padding.extraSmall
     readonly property var font: Tokens.font.body.builders.small.scale(1.1)
 
-    implicitWidth: Tokens.sizes.bar.innerWidth
-    implicitHeight: layout.implicitHeight + root.padding * 2
+    implicitWidth: horizontal ? layout.implicitWidth + root.padding * 2 : Tokens.sizes.bar.innerWidth
+    implicitHeight: horizontal ? Tokens.sizes.bar.innerWidth : layout.implicitHeight + root.padding * 2
 
     color: Qt.alpha(Colours.tPalette.m3surfaceContainer, Config.bar.clock.background ? Colours.tPalette.m3surfaceContainer.a : 0)
     radius: Tokens.rounding.full
 
-    ColumnLayout {
+    GridLayout {
         id: layout
 
         anchors.centerIn: parent
-        spacing: Tokens.spacing.extraSmall
+        columns: root.horizontal ? -1 : 1
+        rowSpacing: Tokens.spacing.extraSmall
+        columnSpacing: Tokens.spacing.extraSmall
 
         Loader {
-            Layout.alignment: Qt.AlignHCenter
+            Layout.alignment: root.horizontal ? Qt.AlignVCenter : Qt.AlignHCenter
             asynchronous: true
             active: Config.bar.clock.showIcon
             visible: active
@@ -38,42 +41,46 @@ StyledRect {
         }
 
         Loader {
-            Layout.alignment: Qt.AlignHCenter
+            Layout.alignment: root.horizontal ? Qt.AlignVCenter : Qt.AlignHCenter
             asynchronous: true
             active: Config.bar.clock.showDate
             visible: active
 
-            sourceComponent: ColumnLayout {
-                spacing: layout.spacing - 4
+            sourceComponent: GridLayout {
+                columns: root.horizontal ? -1 : 1
+                rowSpacing: layout.rowSpacing - 4
+                columnSpacing: layout.columnSpacing - 4
 
                 StyledText {
-                    Layout.alignment: Qt.AlignHCenter
+                    Layout.alignment: root.horizontal ? Qt.AlignVCenter : Qt.AlignHCenter
                     text: Time.format("ddd")
                     font: Tokens.font.body.builders.small.scale(0.9).build()
                     color: root.colour
                 }
 
                 StyledText {
-                    Layout.alignment: Qt.AlignHCenter
+                    Layout.alignment: root.horizontal ? Qt.AlignVCenter : Qt.AlignHCenter
                     text: Time.format("d")
                     font: root.font.scale(1.1).build()
                     color: root.colour
                 }
 
                 StyledRect {
-                    Layout.fillWidth: true
-                    Layout.leftMargin: -Tokens.padding.extraSmall
-                    Layout.rightMargin: -Tokens.padding.extraSmall
-                    Layout.topMargin: 4
-                    Layout.bottomMargin: Tokens.padding.extraSmall / 2
-                    implicitHeight: 1
+                    Layout.fillWidth: !root.horizontal
+                    Layout.fillHeight: root.horizontal
+                    Layout.leftMargin: root.horizontal ? 4 : -Tokens.padding.extraSmall
+                    Layout.rightMargin: root.horizontal ? Tokens.padding.extraSmall / 2 : -Tokens.padding.extraSmall
+                    Layout.topMargin: root.horizontal ? -Tokens.padding.extraSmall : 4
+                    Layout.bottomMargin: root.horizontal ? -Tokens.padding.extraSmall : Tokens.padding.extraSmall / 2
+                    implicitWidth: root.horizontal ? 1 : 0
+                    implicitHeight: root.horizontal ? 0 : 1
                     color: Colours.palette.m3outlineVariant
                 }
             }
         }
 
         StyledText {
-            Layout.alignment: Qt.AlignHCenter
+            Layout.alignment: root.horizontal ? Qt.AlignVCenter : Qt.AlignHCenter
             text: Time.hourStr
             font: {
                 const scale = text === "11" ? 1.15 : Math.min(1.05, Math.max(hourMetrics.width, minMetrics.width) / hourMetrics.width);
@@ -90,8 +97,8 @@ StyledRect {
         }
 
         StyledText {
-            Layout.topMargin: -parent.spacing - 4
-            Layout.alignment: Qt.AlignHCenter
+            Layout.topMargin: root.horizontal ? 0 : -parent.rowSpacing - 4
+            Layout.alignment: root.horizontal ? Qt.AlignVCenter : Qt.AlignHCenter
             text: Time.minuteStr
             font: {
                 const scale = text === "11" ? 1.15 : Math.min(1.05, Math.max(hourMetrics.width, minMetrics.width) / minMetrics.width);
@@ -108,8 +115,8 @@ StyledRect {
         }
 
         Loader {
-            Layout.topMargin: -parent.spacing - 4
-            Layout.alignment: Qt.AlignHCenter
+            Layout.topMargin: root.horizontal ? 0 : -parent.rowSpacing - 4
+            Layout.alignment: root.horizontal ? Qt.AlignVCenter : Qt.AlignHCenter
             asynchronous: true
             active: GlobalConfig.services.useTwelveHourClock
             visible: active

--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -13,6 +13,7 @@ import qs.utils
 StyledRect {
     id: root
 
+    required property bool horizontal
     property color colour: Colours.palette.m3secondary
     readonly property alias items: iconColumn
 
@@ -20,30 +21,39 @@ StyledRect {
     radius: Tokens.rounding.full
 
     clip: true
-    implicitWidth: Tokens.sizes.bar.innerWidth
-    implicitHeight: iconColumn.implicitHeight + Tokens.padding.medium * 2 - (Config.bar.status.showLockStatus && !Hypr.capsLock && !Hypr.numLock ? iconColumn.spacing : 0)
+    implicitWidth: horizontal ? iconColumn.implicitWidth + Tokens.padding.medium * 2 - (Config.bar.status.showLockStatus && !Hypr.capsLock && !Hypr.numLock ? iconColumn.columnSpacing : 0) : Tokens.sizes.bar.innerWidth
+    implicitHeight: horizontal ? Tokens.sizes.bar.innerWidth : iconColumn.implicitHeight + Tokens.padding.medium * 2 - (Config.bar.status.showLockStatus && !Hypr.capsLock && !Hypr.numLock ? iconColumn.rowSpacing : 0)
 
-    ColumnLayout {
+    GridLayout {
         id: iconColumn
 
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: Tokens.padding.medium
+        // Only one orientation's anchors resolve, the others are undefined
+        // qmllint disable Quick.anchor-combinations
+        anchors.left: root.horizontal ? undefined : parent.left
+        anchors.right: root.horizontal ? undefined : parent.right
+        anchors.bottom: root.horizontal ? undefined : parent.bottom
+        anchors.horizontalCenter: root.horizontal ? parent.horizontalCenter : undefined
+        anchors.verticalCenter: root.horizontal ? parent.verticalCenter : undefined
+        anchors.bottomMargin: root.horizontal ? 0 : Tokens.padding.medium
+        // qmllint enable Quick.anchor-combinations
 
-        spacing: Tokens.spacing.medium / 2
+        columns: root.horizontal ? -1 : 1
+        rowSpacing: Tokens.spacing.medium / 2
+        columnSpacing: Tokens.spacing.medium / 2
 
         // Lock keys status
         WrappedLoader {
             name: "lockstatus"
             active: Config.bar.status.showLockStatus
 
-            sourceComponent: ColumnLayout {
-                spacing: 0
+            sourceComponent: GridLayout {
+                columns: root.horizontal ? -1 : 1
+                rowSpacing: 0
+                columnSpacing: 0
 
                 Item {
-                    implicitWidth: capslockIcon.implicitWidth
-                    implicitHeight: Hypr.capsLock ? capslockIcon.implicitHeight : 0
+                    implicitWidth: root.horizontal ? (Hypr.capsLock ? capslockIcon.implicitWidth : 0) : capslockIcon.implicitWidth
+                    implicitHeight: root.horizontal ? capslockIcon.implicitHeight : (Hypr.capsLock ? capslockIcon.implicitHeight : 0)
 
                     MaterialIcon {
                         id: capslockIcon
@@ -70,13 +80,18 @@ StyledRect {
                     Behavior on implicitHeight {
                         Anim {}
                     }
+
+                    Behavior on implicitWidth {
+                        Anim {}
+                    }
                 }
 
                 Item {
-                    Layout.topMargin: Hypr.capsLock && Hypr.numLock ? iconColumn.spacing : 0
+                    Layout.leftMargin: root.horizontal && Hypr.capsLock && Hypr.numLock ? iconColumn.columnSpacing : 0
+                    Layout.topMargin: !root.horizontal && Hypr.capsLock && Hypr.numLock ? iconColumn.rowSpacing : 0
 
-                    implicitWidth: numlockIcon.implicitWidth
-                    implicitHeight: Hypr.numLock ? numlockIcon.implicitHeight : 0
+                    implicitWidth: root.horizontal ? (Hypr.numLock ? numlockIcon.implicitWidth : 0) : numlockIcon.implicitWidth
+                    implicitHeight: root.horizontal ? numlockIcon.implicitHeight : (Hypr.numLock ? numlockIcon.implicitHeight : 0)
 
                     MaterialIcon {
                         id: numlockIcon
@@ -101,6 +116,10 @@ StyledRect {
                     }
 
                     Behavior on implicitHeight {
+                        Anim {}
+                    }
+
+                    Behavior on implicitWidth {
                         Anim {}
                     }
                 }
@@ -170,13 +189,16 @@ StyledRect {
 
         // Bluetooth section
         WrappedLoader {
-            Layout.preferredHeight: implicitHeight
+            Layout.preferredWidth: root.horizontal ? implicitWidth : -1
+            Layout.preferredHeight: root.horizontal ? -1 : implicitHeight
 
             name: "bluetooth"
             active: Config.bar.status.showBluetooth
 
-            sourceComponent: ColumnLayout {
-                spacing: Tokens.spacing.medium / 2
+            sourceComponent: GridLayout {
+                columns: root.horizontal ? -1 : 1
+                rowSpacing: Tokens.spacing.medium / 2
+                columnSpacing: Tokens.spacing.medium / 2
 
                 // Bluetooth icon
                 MaterialIcon {
@@ -232,6 +254,10 @@ StyledRect {
             Behavior on Layout.preferredHeight {
                 Anim {}
             }
+
+            Behavior on Layout.preferredWidth {
+                Anim {}
+            }
         }
 
         // Battery icon
@@ -261,7 +287,7 @@ StyledRect {
         required property string name
 
         asynchronous: true
-        Layout.alignment: Qt.AlignHCenter
+        Layout.alignment: root.horizontal ? Qt.AlignVCenter : Qt.AlignHCenter
         visible: active
     }
 }

--- a/modules/bar/components/Tray.qml
+++ b/modules/bar/components/Tray.qml
@@ -10,6 +10,7 @@ import qs.services
 StyledRect {
     id: root
 
+    required property bool horizontal
     readonly property alias layout: layout
     readonly property alias items: items
     readonly property alias expandIcon: expandIcon
@@ -19,7 +20,19 @@ StyledRect {
 
     property bool expanded
 
+    readonly property real nonAnimWidth: {
+        if (!horizontal)
+            return Tokens.sizes.bar.innerWidth;
+        if (!Config.bar.tray.compact)
+            return layout.implicitWidth + padding * 2;
+        const pad = (Config.bar.tray.background ? Tokens.padding.extraSmall : 0) + padding;
+        if (expanded)
+            return expandIcon.implicitWidth + layout.implicitWidth + spacing + pad;
+        return Math.max(Config.bar.tray.background ? height : 0, expandIcon.implicitWidth + pad);
+    }
     readonly property real nonAnimHeight: {
+        if (horizontal)
+            return Tokens.sizes.bar.innerWidth;
         if (!Config.bar.tray.compact)
             return layout.implicitHeight + padding * 2;
         const pad = (Config.bar.tray.background ? Tokens.padding.extraSmall : 0) + padding;
@@ -29,20 +42,24 @@ StyledRect {
     }
 
     clip: true
-    visible: height > 0
+    visible: horizontal ? width > 0 : height > 0
 
-    implicitWidth: Tokens.sizes.bar.innerWidth
-    implicitHeight: nonAnimHeight
+    implicitWidth: horizontal ? nonAnimWidth : Tokens.sizes.bar.innerWidth
+    implicitHeight: horizontal ? Tokens.sizes.bar.innerWidth : nonAnimHeight
 
     color: Qt.alpha(Colours.tPalette.m3surfaceContainer, (Config.bar.tray.background && items.count > 0) ? Colours.tPalette.m3surfaceContainer.a : 0)
     radius: Tokens.rounding.full
 
-    Column {
+    Grid {
         id: layout
 
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.top: parent.top
-        anchors.topMargin: root.padding
+        anchors.horizontalCenter: root.horizontal ? undefined : parent.horizontalCenter
+        anchors.verticalCenter: root.horizontal ? parent.verticalCenter : undefined
+        anchors.top: root.horizontal ? undefined : parent.top
+        anchors.left: root.horizontal ? parent.left : undefined
+        anchors.topMargin: root.horizontal ? 0 : root.padding
+        anchors.leftMargin: root.horizontal ? root.padding : 0
+        columns: root.horizontal ? Math.max(1, items.count) : 1
         spacing: Tokens.spacing.small
 
         opacity: root.expanded || !Config.bar.tray.compact ? 1 : 0
@@ -89,25 +106,30 @@ StyledRect {
 
         asynchronous: true
 
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.bottom: parent.bottom
+        anchors.horizontalCenter: root.horizontal ? undefined : parent.horizontalCenter
+        anchors.verticalCenter: root.horizontal ? parent.verticalCenter : undefined
+        anchors.right: root.horizontal ? parent.right : undefined
+        anchors.bottom: root.horizontal ? undefined : parent.bottom
 
         active: Config.bar.tray.compact && items.count > 0
 
         sourceComponent: Item {
-            implicitWidth: expandIconInner.implicitWidth
-            implicitHeight: expandIconInner.implicitHeight - Tokens.padding.small
+            implicitWidth: root.horizontal ? expandIconInner.implicitWidth - Tokens.padding.small : expandIconInner.implicitWidth
+            implicitHeight: root.horizontal ? expandIconInner.implicitHeight : expandIconInner.implicitHeight - Tokens.padding.small
 
             MaterialIcon {
                 id: expandIconInner
 
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.bottom: parent.bottom
-                anchors.bottomMargin: Config.bar.tray.background ? Tokens.padding.extraSmall : -Tokens.padding.small
+                anchors.horizontalCenter: root.horizontal ? undefined : parent.horizontalCenter
+                anchors.verticalCenter: root.horizontal ? parent.verticalCenter : undefined
+                anchors.right: root.horizontal ? parent.right : undefined
+                anchors.bottom: root.horizontal ? undefined : parent.bottom
+                anchors.rightMargin: root.horizontal ? (Config.bar.tray.background ? Tokens.padding.extraSmall : -Tokens.padding.small) : 0
+                anchors.bottomMargin: root.horizontal ? 0 : Config.bar.tray.background ? Tokens.padding.extraSmall : -Tokens.padding.small
                 text: "expand_less"
                 color: Colours.palette.m3onSurfaceVariant
                 fontStyle: Tokens.font.icon.medium
-                rotation: root.expanded ? 180 : 0
+                rotation: (root.horizontal ? 270 : 0) + (root.expanded ? 180 : 0)
 
                 Behavior on rotation {
                     Anim {}
@@ -116,11 +138,21 @@ StyledRect {
                 Behavior on anchors.bottomMargin {
                     Anim {}
                 }
+
+                Behavior on anchors.rightMargin {
+                    Anim {}
+                }
             }
         }
     }
 
     Behavior on implicitHeight {
+        Anim {}
+    }
+
+    Behavior on implicitWidth {
+        enabled: root.horizontal
+
         Anim {}
     }
 }

--- a/modules/bar/components/workspaces/ActiveIndicator.qml
+++ b/modules/bar/components/workspaces/ActiveIndicator.qml
@@ -13,6 +13,7 @@ StyledRect {
     required property Repeater workspaces
     required property Item mask
     required property bool fullscreen
+    required property bool horizontal
 
     readonly property int currentWsIdx: {
         let i = activeWsId - 1;
@@ -21,15 +22,15 @@ StyledRect {
         return i % Config.bar.workspaces.shown;
     }
 
-    property real leading: workspaces.count > 0 ? workspaces.itemAt(currentWsIdx)?.y ?? 0 : 0
-    property real trailing: workspaces.count > 0 ? workspaces.itemAt(currentWsIdx)?.y ?? 0 : 0
+    property real leading: workspaces.count > 0 ? (horizontal ? workspaces.itemAt(currentWsIdx)?.x : workspaces.itemAt(currentWsIdx)?.y) ?? 0 : 0
+    property real trailing: workspaces.count > 0 ? (horizontal ? workspaces.itemAt(currentWsIdx)?.x : workspaces.itemAt(currentWsIdx)?.y) ?? 0 : 0
     property real currentSize: workspaces.count > 0 ? (workspaces.itemAt(currentWsIdx) as Workspace)?.size ?? 0 : 0
     property real offset: Math.min(leading, trailing)
     property real size: {
         const s = Math.abs(leading - trailing) + currentSize;
         if (Config.bar.workspaces.activeTrail && lastWs > currentWsIdx) {
             const ws = workspaces.itemAt(lastWs) as Workspace;
-            return ws ? Math.min(ws.y + ws.size - offset, s) : 0;
+            return ws ? Math.min((horizontal ? ws.x : ws.y) + ws.size - offset, s) : 0;
         }
         return s;
     }
@@ -43,9 +44,10 @@ StyledRect {
     }
 
     clip: true
-    y: offset + mask.y
-    implicitWidth: Tokens.sizes.bar.innerWidth - Tokens.padding.small
-    implicitHeight: size
+    x: horizontal ? offset + mask.x : 0
+    y: horizontal ? 0 : offset + mask.y
+    implicitWidth: horizontal ? size : Tokens.sizes.bar.innerWidth - Tokens.padding.small
+    implicitHeight: horizontal ? Tokens.sizes.bar.innerWidth - Tokens.padding.small : size
     radius: Tokens.rounding.full
     color: Colours.palette.m3primary
 
@@ -54,12 +56,13 @@ StyledRect {
         sourceColor: Colours.palette.m3onSurface
         colorizationColor: Colours.palette.m3onPrimary
 
-        x: 0
-        y: -parent.offset
+        x: root.horizontal ? -parent.offset : 0
+        y: root.horizontal ? 0 : -parent.offset
         implicitWidth: root.mask.implicitWidth
         implicitHeight: root.mask.implicitHeight
 
-        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.horizontalCenter: root.horizontal ? undefined : parent.horizontalCenter
+        anchors.verticalCenter: root.horizontal ? parent.verticalCenter : undefined
     }
 
     Behavior on leading {

--- a/modules/bar/components/workspaces/OccupiedBg.qml
+++ b/modules/bar/components/workspaces/OccupiedBg.qml
@@ -12,6 +12,7 @@ Item {
     required property Repeater workspaces
     required property var occupied
     required property int groupOffset
+    required property bool horizontal
 
     property list<var> pills: []
 
@@ -62,11 +63,13 @@ Item {
                 return i % Config.bar.workspaces.shown;
             }
 
-            anchors.horizontalCenter: root.horizontalCenter
+            anchors.horizontalCenter: root.horizontal ? undefined : root.horizontalCenter
+            anchors.verticalCenter: root.horizontal ? root.verticalCenter : undefined
 
-            y: (start?.y ?? 0) - 1
-            implicitWidth: Tokens.sizes.bar.innerWidth - Tokens.padding.small + 2
-            implicitHeight: start && end ? end.y + end.size - start.y + 2 : 0
+            x: root.horizontal ? (start?.x ?? 0) - 1 : 0
+            y: root.horizontal ? 0 : (start?.y ?? 0) - 1
+            implicitWidth: root.horizontal ? (start && end ? end.x + end.size - start.x + 2 : 0) : Tokens.sizes.bar.innerWidth - Tokens.padding.small + 2
+            implicitHeight: root.horizontal ? Tokens.sizes.bar.innerWidth - Tokens.padding.small + 2 : (start && end ? end.y + end.size - start.y + 2 : 0)
 
             color: Colours.layer(Colours.palette.m3surfaceContainerHigh, 2)
             radius: Tokens.rounding.full
@@ -81,10 +84,26 @@ Item {
             }
 
             Behavior on y {
+                enabled: !root.horizontal
+
+                Anim {}
+            }
+
+            Behavior on x {
+                enabled: root.horizontal
+
                 Anim {}
             }
 
             Behavior on implicitHeight {
+                enabled: !root.horizontal
+
+                Anim {}
+            }
+
+            Behavior on implicitWidth {
+                enabled: root.horizontal
+
                 Anim {}
             }
         }

--- a/modules/bar/components/workspaces/SpecialWorkspaces.qml
+++ b/modules/bar/components/workspaces/SpecialWorkspaces.qml
@@ -14,6 +14,7 @@ Item {
     id: root
 
     required property ShellScreen screen
+    required property bool horizontal
     readonly property HyprlandMonitor monitor: Hypr.monitorFor(screen)
     readonly property string activeSpecial: (GlobalConfig.bar.workspaces.perMonitorWorkspaces ? monitor : Hypr.focusedMonitor)?.lastIpcObject.specialWorkspace?.name ?? ""
 
@@ -34,7 +35,7 @@ Item {
             radius: Tokens.rounding.full
 
             gradient: Gradient {
-                orientation: Gradient.Vertical
+                orientation: root.horizontal ? Gradient.Horizontal : Gradient.Vertical
 
                 GradientStop {
                     position: 0
@@ -57,12 +58,14 @@ Item {
 
         Rectangle {
             anchors.top: parent.top
+            anchors.bottom: root.horizontal ? parent.bottom : undefined
             anchors.left: parent.left
-            anchors.right: parent.right
+            anchors.right: root.horizontal ? undefined : parent.right
 
             radius: Tokens.rounding.full
-            implicitHeight: parent.height / 2
-            opacity: view.contentY > 0 ? 0 : 1
+            implicitWidth: root.horizontal ? parent.width / 2 : 0
+            implicitHeight: root.horizontal ? 0 : parent.height / 2
+            opacity: (root.horizontal ? view.contentX : view.contentY) > 0 ? 0 : 1
 
             Behavior on opacity {
                 Anim {
@@ -72,13 +75,15 @@ Item {
         }
 
         Rectangle {
+            anchors.top: root.horizontal ? parent.top : undefined
             anchors.bottom: parent.bottom
-            anchors.left: parent.left
+            anchors.left: root.horizontal ? undefined : parent.left
             anchors.right: parent.right
 
             radius: Tokens.rounding.full
-            implicitHeight: parent.height / 2
-            opacity: view.contentY < view.contentHeight - parent.height + Tokens.padding.extraSmall ? 0 : 1
+            implicitWidth: root.horizontal ? parent.width / 2 : 0
+            implicitHeight: root.horizontal ? 0 : parent.height / 2
+            opacity: (root.horizontal ? view.contentX < view.contentWidth - parent.width + Tokens.padding.extraSmall : view.contentY < view.contentHeight - parent.height + Tokens.padding.extraSmall) ? 0 : 1
 
             Behavior on opacity {
                 Anim {
@@ -94,6 +99,7 @@ Item {
         anchors.fill: parent
         spacing: Tokens.spacing.medium
         interactive: false
+        orientation: root.horizontal ? ListView.Horizontal : ListView.Vertical
 
         currentIndex: model.values.findIndex(w => w.name === root.activeSpecial)
         onCurrentIndexChanged: currentIndex = Qt.binding(() => model.values.findIndex(w => w.name === root.activeSpecial))
@@ -103,13 +109,19 @@ Item {
         }
 
         preferredHighlightBegin: 0
-        preferredHighlightEnd: height
+        preferredHighlightEnd: root.horizontal ? width : height
         highlightRangeMode: ListView.StrictlyEnforceRange
 
         highlightFollowsCurrentItem: false
         highlight: Item {
-            y: view.currentItem?.y ?? 0
-            implicitHeight: (view.currentItem as SpecialWsDelegate)?.size ?? 0
+            x: root.horizontal ? view.currentItem?.x ?? 0 : 0
+            y: root.horizontal ? 0 : view.currentItem?.y ?? 0
+            implicitWidth: root.horizontal ? (view.currentItem as SpecialWsDelegate)?.size ?? 0 : 0
+            implicitHeight: root.horizontal ? 0 : (view.currentItem as SpecialWsDelegate)?.size ?? 0
+
+            Behavior on x {
+                Anim {}
+            }
 
             Behavior on y {
                 Anim {}
@@ -172,11 +184,15 @@ Item {
             StyledClippingRect {
                 id: indicator
 
-                anchors.left: parent.left
-                anchors.right: parent.right
+                anchors.top: root.horizontal ? parent.top : undefined
+                anchors.bottom: root.horizontal ? parent.bottom : undefined
+                anchors.left: root.horizontal ? undefined : parent.left
+                anchors.right: root.horizontal ? undefined : parent.right
 
-                y: (view.currentItem?.y ?? 0) - view.contentY
-                implicitHeight: (view.currentItem as SpecialWsDelegate)?.size ?? 0
+                x: root.horizontal ? (view.currentItem?.x ?? 0) - view.contentX : 0
+                y: root.horizontal ? 0 : (view.currentItem?.y ?? 0) - view.contentY
+                implicitWidth: root.horizontal ? (view.currentItem as SpecialWsDelegate)?.size ?? 0 : 0
+                implicitHeight: root.horizontal ? 0 : (view.currentItem as SpecialWsDelegate)?.size ?? 0
 
                 color: Colours.palette.m3tertiary
                 radius: Tokens.rounding.full
@@ -186,15 +202,28 @@ Item {
                     sourceColor: Colours.palette.m3onSurface
                     colorizationColor: Colours.palette.m3onTertiary
 
-                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.horizontalCenter: root.horizontal ? undefined : parent.horizontalCenter
+                    anchors.verticalCenter: root.horizontal ? parent.verticalCenter : undefined
 
-                    x: 0
-                    y: -indicator.y
+                    x: root.horizontal ? -indicator.x : 0
+                    y: root.horizontal ? 0 : -indicator.y
                     implicitWidth: view.width
                     implicitHeight: view.height
                 }
 
+                Behavior on x {
+                    Anim {
+                        type: Anim.Emphasized
+                    }
+                }
+
                 Behavior on y {
+                    Anim {
+                        type: Anim.Emphasized
+                    }
+                }
+
+                Behavior on implicitWidth {
                     Anim {
                         type: Anim.Emphasized
                     }
@@ -210,19 +239,25 @@ Item {
     }
 
     MouseArea {
+        property real startX
         property real startY
 
         anchors.fill: view
 
         drag.target: view.contentItem
-        drag.axis: Drag.YAxis
+        drag.axis: root.horizontal ? Drag.XAxis : Drag.YAxis
+        drag.maximumX: 0
+        drag.minimumX: Math.min(0, view.width - view.contentWidth - Tokens.padding.extraSmall)
         drag.maximumY: 0
         drag.minimumY: Math.min(0, view.height - view.contentHeight - Tokens.padding.extraSmall)
 
-        onPressed: event => startY = event.y
+        onPressed: event => {
+            startX = event.x;
+            startY = event.y;
+        }
 
         onClicked: event => {
-            if (Math.abs(event.y - startY) > drag.threshold)
+            if (Math.abs((root.horizontal ? event.x - startX : event.y - startY)) > drag.threshold)
                 return;
 
             const ws = view.itemAt(event.x, event.y) as SpecialWsDelegate;
@@ -233,19 +268,23 @@ Item {
         }
     }
 
-    component SpecialWsDelegate: ColumnLayout {
+    component SpecialWsDelegate: GridLayout {
         id: ws
 
         required property HyprlandWorkspace modelData
-        readonly property int size: label.Layout.preferredHeight + (hasWindows ? windows.implicitHeight + Tokens.padding.extraSmall : 0)
+        readonly property int size: (root.horizontal ? label.Layout.preferredWidth : label.Layout.preferredHeight) + (hasWindows ? (root.horizontal ? windows.implicitWidth : windows.implicitHeight) + Tokens.padding.extraSmall : 0)
         property int wsId
         property string icon
         property bool hasWindows
 
-        anchors.left: view.contentItem.left
-        anchors.right: view.contentItem.right
+        anchors.top: root.horizontal ? view.contentItem.top : undefined
+        anchors.bottom: root.horizontal ? view.contentItem.bottom : undefined
+        anchors.left: root.horizontal ? undefined : view.contentItem.left
+        anchors.right: root.horizontal ? undefined : view.contentItem.right
 
-        spacing: 0
+        columns: root.horizontal ? -1 : 1
+        rowSpacing: 0
+        columnSpacing: 0
 
         Component.onCompleted: {
             wsId = modelData.id;
@@ -287,8 +326,9 @@ Item {
 
             asynchronous: true
 
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
-            Layout.preferredHeight: Tokens.sizes.bar.innerWidth - Tokens.padding.small
+            Layout.alignment: root.horizontal ? Qt.AlignVCenter | Qt.AlignLeft : Qt.AlignHCenter | Qt.AlignTop
+            Layout.preferredWidth: root.horizontal ? Tokens.sizes.bar.innerWidth - Tokens.padding.small : -1
+            Layout.preferredHeight: root.horizontal ? -1 : Tokens.sizes.bar.innerWidth - Tokens.padding.small
 
             sourceComponent: ws.icon.length === 1 ? letterComp : iconComp
 
@@ -317,14 +357,17 @@ Item {
 
             asynchronous: true
 
-            Layout.alignment: Qt.AlignHCenter
-            Layout.fillHeight: true
-            Layout.preferredHeight: implicitHeight
+            Layout.alignment: root.horizontal ? Qt.AlignVCenter : Qt.AlignHCenter
+            Layout.fillWidth: root.horizontal
+            Layout.fillHeight: !root.horizontal
+            Layout.preferredWidth: root.horizontal ? implicitWidth : -1
+            Layout.preferredHeight: root.horizontal ? -1 : implicitHeight
 
             visible: active
             active: ws.hasWindows
 
-            sourceComponent: Column {
+            sourceComponent: Grid {
+                columns: root.horizontal ? items.count : 1
                 spacing: 0
 
                 add: Transition {
@@ -348,6 +391,8 @@ Item {
                 }
 
                 Repeater {
+                    id: items
+
                     model: ScriptModel {
                         values: {
                             const windows = Hypr.toplevels.values.filter(c => c.workspace?.id === ws.wsId);
@@ -367,6 +412,10 @@ Item {
             }
 
             Behavior on Layout.preferredHeight {
+                Anim {}
+            }
+
+            Behavior on Layout.preferredWidth {
                 Anim {}
             }
         }

--- a/modules/bar/components/workspaces/Workspace.qml
+++ b/modules/bar/components/workspaces/Workspace.qml
@@ -8,32 +8,37 @@ import qs.components
 import qs.services
 import qs.utils
 
-ColumnLayout {
+GridLayout {
     id: root
 
     required property int index
     required property int activeWsId
     required property var occupied
     required property int groupOffset
+    required property bool horizontal
 
     readonly property bool isWorkspace: true // Flag for finding workspace children
     // Unanimated prop for others to use as reference
-    readonly property int size: implicitHeight + (hasWindows ? Tokens.padding.extraSmall : 0)
+    readonly property int size: (horizontal ? implicitWidth : implicitHeight) + (hasWindows ? Tokens.padding.extraSmall : 0)
 
     readonly property int ws: groupOffset + index + 1
     readonly property bool isOccupied: occupied[ws] ?? false
     readonly property bool hasWindows: isOccupied && Config.bar.workspaces.showWindows
 
-    Layout.alignment: Qt.AlignHCenter
-    Layout.preferredHeight: size
+    Layout.alignment: horizontal ? Qt.AlignVCenter : Qt.AlignHCenter
+    Layout.preferredWidth: horizontal ? size : -1
+    Layout.preferredHeight: horizontal ? -1 : size
 
-    spacing: 0
+    columns: horizontal ? -1 : 1
+    rowSpacing: 0
+    columnSpacing: 0
 
     StyledText {
         id: indicator
 
-        Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
-        Layout.preferredHeight: Tokens.sizes.bar.innerWidth - Tokens.padding.small
+        Layout.alignment: root.horizontal ? Qt.AlignVCenter | Qt.AlignLeft : Qt.AlignHCenter | Qt.AlignTop
+        Layout.preferredWidth: root.horizontal ? Tokens.sizes.bar.innerWidth - Tokens.padding.small : -1
+        Layout.preferredHeight: root.horizontal ? -1 : Tokens.sizes.bar.innerWidth - Tokens.padding.small
 
         animate: true
         text: {
@@ -60,14 +65,17 @@ ColumnLayout {
 
         asynchronous: true
 
-        Layout.alignment: Qt.AlignHCenter
-        Layout.fillHeight: true
-        Layout.topMargin: -Tokens.sizes.bar.innerWidth / 10
+        Layout.alignment: root.horizontal ? Qt.AlignVCenter : Qt.AlignHCenter
+        Layout.fillWidth: root.horizontal
+        Layout.fillHeight: !root.horizontal
+        Layout.leftMargin: root.horizontal ? -Tokens.sizes.bar.innerWidth / 10 : 0
+        Layout.topMargin: root.horizontal ? 0 : -Tokens.sizes.bar.innerWidth / 10
 
         visible: active
         active: root.hasWindows
 
-        sourceComponent: Column {
+        sourceComponent: Grid {
+            columns: root.horizontal ? Math.max(1, items.count) : 1
             spacing: 0
 
             add: Transition {
@@ -91,6 +99,8 @@ ColumnLayout {
             }
 
             Repeater {
+                id: items
+
                 model: ScriptModel {
                     values: {
                         const ws = root.ws;
@@ -112,6 +122,10 @@ ColumnLayout {
     }
 
     Behavior on Layout.preferredHeight {
+        Anim {}
+    }
+
+    Behavior on Layout.preferredWidth {
         Anim {}
     }
 }

--- a/modules/bar/components/workspaces/Workspaces.qml
+++ b/modules/bar/components/workspaces/Workspaces.qml
@@ -13,6 +13,7 @@ StyledClippingRect {
 
     required property ShellScreen screen
     required property bool fullscreen
+    required property bool horizontal
 
     readonly property bool onSpecial: (GlobalConfig.bar.workspaces.perMonitorWorkspaces ? Hypr.monitorFor(screen) : Hypr.focusedMonitor)?.lastIpcObject.specialWorkspace?.name !== ""
     readonly property int activeWsId: GlobalConfig.bar.workspaces.perMonitorWorkspaces ? (Hypr.monitorFor(screen).activeWorkspace?.id ?? 1) : Hypr.activeWsId
@@ -27,8 +28,8 @@ StyledClippingRect {
 
     property real blur: onSpecial ? 1 : 0
 
-    implicitWidth: Tokens.sizes.bar.innerWidth
-    implicitHeight: layout.implicitHeight + Tokens.padding.small
+    implicitWidth: horizontal ? layout.implicitWidth + Tokens.padding.small : Tokens.sizes.bar.innerWidth
+    implicitHeight: horizontal ? Tokens.sizes.bar.innerWidth : layout.implicitHeight + Tokens.padding.small
 
     color: Colours.tPalette.m3surfaceContainer
     radius: Tokens.rounding.full
@@ -57,14 +58,17 @@ StyledClippingRect {
                 workspaces: workspaces
                 occupied: root.occupied
                 groupOffset: root.groupOffset
+                horizontal: root.horizontal
             }
         }
 
-        ColumnLayout {
+        GridLayout {
             id: layout
 
             anchors.centerIn: parent
-            spacing: Math.floor(Tokens.spacing.extraSmall)
+            columns: root.horizontal ? -1 : 1
+            rowSpacing: Math.floor(Tokens.spacing.extraSmall)
+            columnSpacing: Math.floor(Tokens.spacing.extraSmall)
 
             Repeater {
                 id: workspaces
@@ -75,13 +79,15 @@ StyledClippingRect {
                     activeWsId: root.activeWsId
                     occupied: root.occupied
                     groupOffset: root.groupOffset
+                    horizontal: root.horizontal
                 }
             }
         }
 
         Loader {
             asynchronous: true
-            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.horizontalCenter: root.horizontal ? undefined : parent.horizontalCenter
+            anchors.verticalCenter: root.horizontal ? parent.verticalCenter : undefined
             active: Config.bar.workspaces.activeIndicator
 
             sourceComponent: ActiveIndicator {
@@ -89,6 +95,7 @@ StyledClippingRect {
                 workspaces: workspaces
                 mask: layout
                 fullscreen: root.fullscreen
+                horizontal: root.horizontal
             }
         }
 
@@ -131,6 +138,7 @@ StyledClippingRect {
 
         sourceComponent: SpecialWorkspaces {
             screen: root.screen
+            horizontal: root.horizontal
         }
 
         Behavior on scale {

--- a/modules/bar/popouts/ClipWrapper.qml
+++ b/modules/bar/popouts/ClipWrapper.qml
@@ -9,21 +9,47 @@ Item {
     id: root
 
     required property ShellScreen screen
+    required property string position
     required property real borderThickness
 
     readonly property alias content: content
-    property real offsetScale: x > 0 || content.hasCurrent ? 0 : 1
+    readonly property bool horizontal: position !== "left"
+    property real offsetScale: {
+        if (content.hasCurrent)
+            return 0;
+        if (position === "top")
+            return y > 0 ? 0 : 1;
+        if (position === "bottom")
+            return content.isDetached ? 0 : 1;
+        return x > 0 ? 0 : 1;
+    }
+
+    // Anchored, not y-bound: a Behavior-lagged y would dip the clip area into the bar while height animates
+    anchors.bottom: position === "bottom" && !content.isDetached ? parent.bottom : undefined
 
     visible: width > 0 && height > 0
     clip: true
 
-    implicitWidth: content.implicitWidth * (1 - offsetScale)
-    implicitHeight: content.implicitHeight
+    implicitWidth: horizontal ? content.implicitWidth : content.implicitWidth * (1 - offsetScale)
+    implicitHeight: horizontal ? content.implicitHeight * (1 - offsetScale) : content.implicitHeight
 
-    x: content.isDetached ? (parent.width - content.nonAnimWidth) / 2 : 0
+    x: {
+        if (content.isDetached)
+            return (parent.width - content.nonAnimWidth) / 2;
+        if (!horizontal)
+            return 0;
+
+        const off = content.currentCenter - borderThickness - content.nonAnimWidth / 2;
+        const diff = parent.width - Math.floor(off + content.nonAnimWidth);
+        if (diff < 0)
+            return off + diff;
+        return Math.max(off, 0);
+    }
     y: {
         if (content.isDetached)
             return (parent.height - content.nonAnimHeight) / 2;
+        if (horizontal)
+            return 0;
 
         const off = content.currentCenter - borderThickness - content.nonAnimHeight / 2;
         const diff = parent.height - Math.floor(off + content.nonAnimHeight);
@@ -37,6 +63,8 @@ Item {
     }
 
     Behavior on x {
+        enabled: !root.horizontal || root.offsetScale < 1
+
         Anim {
             duration: content.animLength
             easing: content.animCurve
@@ -44,7 +72,7 @@ Item {
     }
 
     Behavior on y {
-        enabled: root.offsetScale < 1
+        enabled: root.horizontal || root.offsetScale < 1
 
         Anim {
             duration: content.animLength
@@ -58,8 +86,16 @@ Item {
         screen: root.screen
         offsetScale: root.offsetScale
 
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.left: parent.left
+        // Only the anchors for the current bar edge resolve, the others are undefined
+        // qmllint disable Quick.anchor-combinations
+        anchors.verticalCenter: root.horizontal ? undefined : parent.verticalCenter
+        anchors.horizontalCenter: root.horizontal ? parent.horizontalCenter : undefined
+        anchors.left: root.horizontal ? undefined : parent.left
+        anchors.top: root.position === "top" ? parent.top : undefined
+        anchors.bottom: root.position === "bottom" ? parent.bottom : undefined
+        // qmllint enable Quick.anchor-combinations
         anchors.leftMargin: (-implicitWidth - 5) * root.offsetScale
+        anchors.topMargin: (-implicitHeight - 5) * root.offsetScale
+        anchors.bottomMargin: (-implicitHeight - 5) * root.offsetScale
     }
 }

--- a/modules/dashboard/Wrapper.qml
+++ b/modules/dashboard/Wrapper.qml
@@ -12,6 +12,7 @@ Item {
     id: root
 
     required property ScreenState screenState
+    required property bool onLeft
     readonly property FileDialog facePicker: FileDialog {
         title: qsTr("Select a profile picture")
         filterLabel: qsTr("Image files")
@@ -29,7 +30,8 @@ Item {
     property real offsetScale: shouldBeActive ? 0 : 1
 
     visible: offsetScale < 1
-    anchors.topMargin: (-implicitHeight - 5) * offsetScale
+    anchors.topMargin: onLeft ? 0 : (-implicitHeight - 5) * offsetScale
+    anchors.leftMargin: onLeft ? (-implicitWidth - 5) * offsetScale : 0
     implicitHeight: content.implicitHeight
     implicitWidth: content.implicitWidth || 854 // Hard coded fallback for first open
     opacity: 1 - offsetScale
@@ -41,8 +43,10 @@ Item {
     Loader {
         id: content
 
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.bottom: parent.bottom
+        anchors.horizontalCenter: root.onLeft ? undefined : parent.horizontalCenter
+        anchors.verticalCenter: root.onLeft ? parent.verticalCenter : undefined
+        anchors.bottom: root.onLeft ? undefined : parent.bottom
+        anchors.right: root.onLeft ? parent.right : undefined
 
         active: root.shouldBeActive || root.visible
 

--- a/modules/drawers/ContentWindow.qml
+++ b/modules/drawers/ContentWindow.qml
@@ -92,6 +92,7 @@ StyledWindow {
         bar: bar
         win: root
         configPosition: root.contentItem.Config.bar.position
+        configDashboardPosition: root.contentItem.Config.dashboard.position
     }
 
     Region {

--- a/modules/drawers/ContentWindow.qml
+++ b/modules/drawers/ContentWindow.qml
@@ -18,6 +18,7 @@ StyledWindow {
 
     readonly property alias bar: bar
     readonly property alias interactionWrapper: interactions
+    readonly property alias geometry: geometry
 
     readonly property ScreenState screenState: ShellState.forScreen(screen)
 
@@ -85,11 +86,19 @@ StyledWindow {
         CAnim {}
     }
 
+    EdgeGeometry {
+        id: geometry
+
+        bar: bar
+        win: root
+        configPosition: root.contentItem.Config.bar.position
+    }
+
     Region {
         id: emptyRegion
 
-        x: panels.notifications.x + bar.implicitWidth
-        y: panels.notifications.y + root.borderThickness
+        x: panels.notifications.x + geometry.insetLeft(root.borderThickness)
+        y: panels.notifications.y + geometry.insetTop(root.borderThickness)
         width: panels.notifications.width
         height: panels.notifications.height
 
@@ -104,7 +113,7 @@ StyledWindow {
     Regions {
         id: regions
 
-        bar: bar
+        geometry: geometry
         panels: panels
         win: root
     }
@@ -168,10 +177,10 @@ StyledWindow {
             anchors.margins: -50 // Make border thicker to smooth out bulge from closed drawers
             group: blobGroup
             radius: root.borderRounding
-            borderLeft: bar.implicitWidth - anchors.margins - root.sdfBorderOffset
+            borderLeft: geometry.insetLeft(root.borderThickness) - anchors.margins - root.sdfBorderOffset
             borderRight: root.borderThickness - anchors.margins - root.sdfBorderOffset
-            borderTop: root.borderThickness - anchors.margins - root.sdfBorderOffset
-            borderBottom: root.borderThickness - anchors.margins - root.sdfBorderOffset
+            borderTop: geometry.insetTop(root.borderThickness) - anchors.margins - root.sdfBorderOffset
+            borderBottom: geometry.insetBottom(root.borderThickness) - anchors.margins - root.sdfBorderOffset
         }
 
         PanelBg {
@@ -193,7 +202,7 @@ StyledWindow {
 
             panel: panels.sessionWrapper
             deformAmount: 0.2
-            x: panels.sessionWrapper.x + panels.session.x + bar.implicitWidth
+            x: panels.sessionWrapper.x + panels.session.x + geometry.insetLeft(root.borderThickness)
             implicitWidth: panels.session.width
         }
 
@@ -212,7 +221,7 @@ StyledWindow {
 
             panel: panels.osdWrapper
             deformAmount: 0.25
-            x: panels.osdWrapper.x + panels.osd.x + bar.implicitWidth
+            x: panels.osdWrapper.x + panels.osd.x + geometry.insetLeft(root.borderThickness)
             implicitWidth: panels.osd.width
         }
 
@@ -239,7 +248,7 @@ StyledWindow {
 
             panel: panels.popoutsWrapper
             deformAmount: panels.popouts.isDetached ? 0.05 : panels.popouts.hasCurrent ? 0.15 : 0.1
-            x: panels.popoutsWrapper.x + panels.popouts.x + bar.implicitWidth - panels.popouts.width * extraWidth
+            x: panels.popoutsWrapper.x + panels.popouts.x + geometry.insetLeft(root.borderThickness) - panels.popouts.width * extraWidth
             implicitWidth: panels.popouts.width * (1 + extraWidth)
 
             Behavior on extraWidth {
@@ -256,6 +265,7 @@ StyledWindow {
         screenState: root.screenState
         panels: panels
         bar: bar
+        geometry: geometry
         borderThickness: root.borderLayoutThickness
         fullscreen: root.hasFullscreen
 
@@ -265,6 +275,7 @@ StyledWindow {
             screen: root.screen
             screenState: root.screenState
             bar: bar
+            geometry: geometry
             borderThickness: root.borderThickness
 
             utilities.horizontalStretch: (sidebarBg.rawDeformMatrix.m11 - 1) / 2 + 1
@@ -339,8 +350,8 @@ StyledWindow {
         property real deformAmount: 0.15
 
         group: blobGroup
-        x: panel.x + bar.implicitWidth
-        y: panel.y + root.borderThickness
+        x: panel.x + geometry.insetLeft(root.borderThickness)
+        y: panel.y + geometry.insetTop(root.borderThickness)
         implicitWidth: panel.width
         implicitHeight: panel.height
         radius: Tokens.rounding.extraLarge

--- a/modules/drawers/ContentWindow.qml
+++ b/modules/drawers/ContentWindow.qml
@@ -243,15 +243,17 @@ StyledWindow {
         PanelBg {
             id: popoutBg
 
-            // Extra width to prevent vertical movement deformation partially detaching panel from bar
-            property real extraWidth: panels.popouts.isDetached ? 0 : 0.2
+            // Extra extent to prevent axis movement deformation partially detaching panel from bar
+            property real extraExtent: panels.popouts.isDetached ? 0 : 0.2
 
             panel: panels.popoutsWrapper
             deformAmount: panels.popouts.isDetached ? 0.05 : panels.popouts.hasCurrent ? 0.15 : 0.1
-            x: panels.popoutsWrapper.x + panels.popouts.x + geometry.insetLeft(root.borderThickness) - panels.popouts.width * extraWidth
-            implicitWidth: panels.popouts.width * (1 + extraWidth)
+            x: panels.popoutsWrapper.x + panels.popouts.x + geometry.insetLeft(root.borderThickness) - (geometry.horizontal ? 0 : panels.popouts.width * extraExtent)
+            y: panels.popoutsWrapper.y + panels.popouts.y + geometry.insetTop(root.borderThickness) - (geometry.barOnTop ? panels.popouts.height * extraExtent : 0)
+            implicitWidth: panels.popouts.width * (geometry.horizontal ? 1 : 1 + extraExtent)
+            implicitHeight: panels.popouts.height * (geometry.horizontal ? 1 + extraExtent : 1)
 
-            Behavior on extraWidth {
+            Behavior on extraExtent {
                 Anim {}
             }
         }
@@ -310,12 +312,19 @@ StyledWindow {
         BarWrapper {
             id: bar
 
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
+            // Anchored on one corner and sized by binding: an opposing pair of anchors sizes the
+            // item instead, and keeps that size once the pair is dropped
+            anchors.left: parent.left
+            anchors.top: geometry.barOnBottom ? undefined : parent.top
+            anchors.bottom: geometry.barOnBottom ? parent.bottom : undefined
+
+            width: geometry.horizontal ? parent.width : implicitWidth
+            height: geometry.horizontal ? implicitHeight : parent.height
 
             screen: root.screen
             screenState: root.screenState
             popouts: panels.popouts
+            position: geometry.position
 
             fullscreen: root.hasFullscreen
         }

--- a/modules/drawers/Drawers.qml
+++ b/modules/drawers/Drawers.qml
@@ -15,6 +15,7 @@ Variants {
         Exclusions {
             screen: scope.modelData
             bar: content.bar
+            geometry: content.geometry
         }
 
         ContentWindow {

--- a/modules/drawers/Drawers.qml
+++ b/modules/drawers/Drawers.qml
@@ -12,8 +12,46 @@ Variants {
 
         required property ShellScreen modelData
 
+        // The bar's orientation is baked into the layouts, loaders and running animations of every
+        // drawer, so a live position change rebuilds the screen's windows instead of converting them
+        // in place, which leaves half of them still facing the old edge.
+        function rebuild(): void {
+            loader.active = false;
+            loader.active = true;
+        }
+
+        LazyLoader {
+            id: loader
+
+            active: true
+
+            Drawer {
+                screen: scope.modelData
+            }
+        }
+
+        Connections {
+            function onConfigPositionChanged(): void {
+                Qt.callLater(scope.rebuild);
+            }
+
+            function onConfigDashboardPositionChanged(): void {
+                Qt.callLater(scope.rebuild);
+            }
+
+            target: (loader.item as Drawer)?.geometry ?? null
+        }
+    }
+
+    component Drawer: Scope {
+        id: drawer
+
+        required property ShellScreen screen
+
+        readonly property alias geometry: content.geometry
+
         Exclusions {
-            screen: scope.modelData
+            screen: drawer.screen
             bar: content.bar
             geometry: content.geometry
         }
@@ -21,7 +59,7 @@ Variants {
         ContentWindow {
             id: content
 
-            screen: scope.modelData
+            screen: drawer.screen
         }
     }
 }

--- a/modules/drawers/EdgeGeometry.qml
+++ b/modules/drawers/EdgeGeometry.qml
@@ -14,8 +14,8 @@ QtObject {
     readonly property bool barOnTop: position === "top"
     readonly property bool barOnBottom: position === "bottom"
 
-    readonly property real barExtent: bar.implicitWidth
-    readonly property real barClamped: bar.clampedWidth
+    readonly property real barExtent: bar.extent
+    readonly property real barClamped: bar.clampedExtent
 
     function insetLeft(border: real, clamped = false): real {
         return barOnLeft ? (clamped ? barClamped : barExtent) : border;

--- a/modules/drawers/EdgeGeometry.qml
+++ b/modules/drawers/EdgeGeometry.qml
@@ -7,12 +7,17 @@ QtObject {
     required property Bar.BarWrapper bar
     required property var win
     required property string configPosition
+    required property string configDashboardPosition
 
     readonly property string position: configPosition === "top" || configPosition === "bottom" ? configPosition : "left"
     readonly property bool horizontal: position !== "left"
     readonly property bool barOnLeft: position === "left"
     readonly property bool barOnTop: position === "top"
     readonly property bool barOnBottom: position === "bottom"
+    // A dashboard on the bar's own edge can never be revealed: closed, its hover zone is exactly
+    // the strip the bar occupies, and hovering the bar has to open popouts instead. Use the other
+    // edge when the two would collide.
+    readonly property bool dashboardOnLeft: configDashboardPosition === "left" ? !barOnLeft : barOnTop
 
     readonly property real barExtent: bar.extent
     readonly property real barClamped: bar.clampedExtent

--- a/modules/drawers/EdgeGeometry.qml
+++ b/modules/drawers/EdgeGeometry.qml
@@ -1,0 +1,57 @@
+import QtQuick
+import qs.modules.bar as Bar
+
+QtObject {
+    id: root
+
+    required property Bar.BarWrapper bar
+    required property var win
+    required property string configPosition
+
+    readonly property string position: configPosition === "top" || configPosition === "bottom" ? configPosition : "left"
+    readonly property bool horizontal: position !== "left"
+    readonly property bool barOnLeft: position === "left"
+    readonly property bool barOnTop: position === "top"
+    readonly property bool barOnBottom: position === "bottom"
+
+    readonly property real barExtent: bar.implicitWidth
+    readonly property real barClamped: bar.clampedWidth
+
+    function insetLeft(border: real, clamped = false): real {
+        return barOnLeft ? (clamped ? barClamped : barExtent) : border;
+    }
+
+    function insetTop(border: real, clamped = false): real {
+        return barOnTop ? (clamped ? barClamped : barExtent) : border;
+    }
+
+    function insetBottom(border: real, clamped = false): real {
+        return barOnBottom ? (clamped ? barClamped : barExtent) : border;
+    }
+
+    function barContains(x: real, y: real, clamped = false): bool {
+        const extent = clamped ? barClamped : barExtent;
+        if (barOnTop)
+            return y < extent;
+        if (barOnBottom)
+            return y > win.height - extent;
+        return x < extent;
+    }
+
+    function inwardDrag(dragX: real, dragY: real): real {
+        if (barOnTop)
+            return dragY;
+        if (barOnBottom)
+            return -dragY;
+        return dragX;
+    }
+
+    function axisPos(x: real, y: real): real {
+        return horizontal ? x : y;
+    }
+
+    onConfigPositionChanged: {
+        if (!["left", "top", "bottom"].includes(configPosition))
+            console.warn(`Invalid bar position '${configPosition}', falling back to left`);
+    }
+}

--- a/modules/drawers/Exclusions.qml
+++ b/modules/drawers/Exclusions.qml
@@ -11,14 +11,16 @@ Scope {
 
     required property ShellScreen screen
     required property Bar.BarWrapper bar
+    required property EdgeGeometry geometry
 
     ExclusionZone {
         anchors.left: true
-        exclusiveZone: root.bar.exclusiveZone
+        hasBar: root.geometry.barOnLeft
     }
 
     ExclusionZone {
         anchors.top: true
+        hasBar: root.geometry.barOnTop
     }
 
     ExclusionZone {
@@ -27,12 +29,15 @@ Scope {
 
     ExclusionZone {
         anchors.bottom: true
+        hasBar: root.geometry.barOnBottom
     }
 
     component ExclusionZone: StyledWindow {
+        property bool hasBar
+
         screen: root.screen
         name: "border-exclusion"
-        exclusiveZone: contentItem.Config.border.thickness
+        exclusiveZone: hasBar ? root.bar.exclusiveZone : contentItem.Config.border.thickness
         mask: Region {}
         implicitWidth: 1
         implicitHeight: 1

--- a/modules/drawers/Interactions.qml
+++ b/modules/drawers/Interactions.qml
@@ -15,6 +15,7 @@ CustomMouseArea {
     required property ScreenState screenState
     required property Panels panels
     required property Bar.BarWrapper bar
+    required property EdgeGeometry geometry
     required property real borderThickness
     required property bool fullscreen
 
@@ -24,21 +25,21 @@ CustomMouseArea {
     property bool utilitiesShortcutActive
 
     function withinPanelHeight(panel: Item, x: real, y: real): bool {
-        const panelY = root.borderThickness + panel.y;
+        const panelY = geometry.insetTop(borderThickness) + panel.y;
         return y >= panelY - Config.border.rounding && y <= panelY + panel.height + Config.border.rounding;
     }
 
     function withinPanelWidth(panel: Item, x: real, y: real): bool {
-        const panelX = bar.implicitWidth + panel.x;
+        const panelX = geometry.insetLeft(borderThickness) + panel.x;
         return x >= panelX - Config.border.rounding && x <= panelX + panel.width + Config.border.rounding;
     }
 
     function inLeftPanel(panel: Item, x: real, y: real): bool {
-        return x < bar.implicitWidth + panel.x + panel.width && withinPanelHeight(panel, x, y);
+        return x < geometry.insetLeft(borderThickness) + panel.x + panel.width && withinPanelHeight(panel, x, y);
     }
 
     function inRightPanel(panel: Item, x: real, y: real): bool {
-        return x > Math.min(width - Config.border.minThickness, bar.implicitWidth + panel.x) && withinPanelHeight(panel, x, y);
+        return x > Math.min(width - Config.border.minThickness, geometry.insetLeft(borderThickness) + panel.x) && withinPanelHeight(panel, x, y);
     }
 
     function inTopPanel(panel: Item, x: real, y: real): bool {
@@ -54,8 +55,8 @@ CustomMouseArea {
     function onWheel(event: WheelEvent): void {
         if (fullscreen)
             return;
-        if (event.x < bar.implicitWidth) {
-            bar.handleWheel(event.y, event.angleDelta);
+        if (geometry.barContains(event.x, event.y)) {
+            bar.handleWheel(geometry.axisPos(event.x, event.y), event.angleDelta);
         }
     }
 
@@ -106,14 +107,15 @@ CustomMouseArea {
         }
 
         // Show bar in non-exclusive mode on hover
-        if (!screenState.bar && Config.bar.showOnHover && x < bar.clampedWidth)
+        if (!screenState.bar && Config.bar.showOnHover && geometry.barContains(x, y, true))
             bar.isHovered = true;
 
         // Show/hide bar on drag
-        if (pressed && dragStart.x < bar.clampedWidth) {
-            if (dragX > Config.bar.dragThreshold)
+        if (pressed && geometry.barContains(dragStart.x, dragStart.y, true)) {
+            const barDrag = geometry.inwardDrag(dragX, dragY);
+            if (barDrag > Config.bar.dragThreshold)
                 screenState.bar = true;
-            else if (dragX < -Config.bar.dragThreshold)
+            else if (barDrag < -Config.bar.dragThreshold)
                 screenState.bar = false;
         }
 
@@ -131,12 +133,12 @@ CustomMouseArea {
                 root.panels.osd.hovered = true;
             }
 
-            const showSidebar = pressed && dragStart.x > Math.min(width - Config.border.minThickness, bar.implicitWidth + panels.sidebar.x);
+            const showSidebar = pressed && dragStart.x > Math.min(width - Config.border.minThickness, geometry.insetLeft(borderThickness) + panels.sidebar.x);
 
             // Show sidebar on hover (top-right corner, bounded by notification panel height)
             if (Config.sidebar.showOnHover) {
                 const sidebarTriggerY = Math.max(Config.sidebar.minHoverThreshold, panels.notifications.y + panels.notifications.height + borderThickness);
-                const showSidebarHover = x > Math.min(width - Config.border.minThickness, bar.implicitWidth + panels.sidebar.x) && y <= sidebarTriggerY;
+                const showSidebarHover = x > Math.min(width - Config.border.minThickness, geometry.insetLeft(borderThickness) + panels.sidebar.x) && y <= sidebarTriggerY;
                 if (showSidebarHover && !screenState.sidebar)
                     screenState.sidebar = true;
             }
@@ -181,7 +183,7 @@ CustomMouseArea {
             // Show/hide sidebar on hover
             if (Config.sidebar.showOnHover && !pressed) {
                 const sidebarTriggerY = Math.max(Config.sidebar.minHoverThreshold, panels.notifications.y + panels.notifications.height + borderThickness);
-                const showSidebarHover = x > Math.min(width - Config.border.minThickness, bar.implicitWidth + panels.sidebar.x) && y <= sidebarTriggerY;
+                const showSidebarHover = x > Math.min(width - Config.border.minThickness, geometry.insetLeft(borderThickness) + panels.sidebar.x) && y <= sidebarTriggerY;
                 if (showSidebarHover && !screenState.sidebar) {
                     screenState.sidebar = true;
                 } else {
@@ -238,8 +240,8 @@ CustomMouseArea {
         }
 
         // Show popouts on hover
-        if (x < bar.implicitWidth) {
-            bar.checkPopout(y);
+        if (geometry.barContains(x, y)) {
+            bar.checkPopout(geometry.axisPos(x, y));
         } else if ((!popouts.currentName.startsWith("traymenu") || ((popouts.current as StackView)?.depth ?? 0) <= 1) && !inLeftPanel(panels.popoutsWrapper, x, y)) {
             popouts.hasCurrent = false;
             bar.closeTray();

--- a/modules/drawers/Interactions.qml
+++ b/modules/drawers/Interactions.qml
@@ -38,18 +38,27 @@ CustomMouseArea {
         return x < geometry.insetLeft(borderThickness) + panel.x + panel.width && withinPanelHeight(panel, x, y);
     }
 
+    // A left bar's popout starts at the screen edge, so a one-sided bound is enough for it. A
+    // horizontal bar's is centred on the hovered entry, so it needs bounding on both sides.
+    function inPopoutArea(x: real, y: real): bool {
+        const panel = panels.popoutsWrapper;
+        if (!geometry.horizontal)
+            return inLeftPanel(panel, x, y);
+        return withinPanelWidth(panel, x, y) && withinPanelHeight(panel, x, y);
+    }
+
     function inRightPanel(panel: Item, x: real, y: real): bool {
         return x > Math.min(width - Config.border.minThickness, geometry.insetLeft(borderThickness) + panel.x) && withinPanelHeight(panel, x, y);
     }
 
     function inTopPanel(panel: Item, x: real, y: real): bool {
         const panelHeight = panel.height * (1 - (panel.offsetScale ?? 0)); // qmllint disable missing-property
-        return y < Math.max(Config.border.minThickness, Config.border.thickness + panelHeight) && withinPanelWidth(panel, x, y);
+        return y < Math.max(Config.border.minThickness, geometry.insetTop(Config.border.thickness) + panelHeight) && withinPanelWidth(panel, x, y);
     }
 
     function inBottomPanel(panel: Item, x: real, y: real, isCorner = false): bool {
         const panelHeight = panel.height * (1 - (panel.offsetScale ?? 0)); // qmllint disable missing-property
-        return y > height - Math.max(Config.border.minThickness, Config.border.thickness + panelHeight) - (isCorner ? Config.border.rounding : 0) && withinPanelWidth(panel, x, y);
+        return y > height - Math.max(Config.border.minThickness, geometry.insetBottom(Config.border.thickness) + panelHeight) - (isCorner ? Config.border.rounding : 0) && withinPanelWidth(panel, x, y);
     }
 
     function onWheel(event: WheelEvent): void {
@@ -200,9 +209,9 @@ CustomMouseArea {
 
         // Show launcher on hover, or show/hide on drag if hover is disabled
         if (Config.launcher.showOnHover) {
-            if (!screenState.launcher && inBottomPanel(panels.launcher, x, y))
+            if (!screenState.launcher && inBottomPanel(panels.launcher, x, y) && !(geometry.barOnBottom && geometry.barContains(x, y)))
                 screenState.launcher = true;
-        } else if (pressed && inBottomPanel(panels.launcher, dragStart.x, dragStart.y) && withinPanelWidth(panels.launcher, x, y)) {
+        } else if (pressed && inBottomPanel(panels.launcher, dragStart.x, dragStart.y) && !(geometry.barOnBottom && geometry.barContains(dragStart.x, dragStart.y)) && withinPanelWidth(panels.launcher, x, y)) {
             if (dragY < -Config.launcher.dragThreshold)
                 screenState.launcher = true;
             else if (dragY > Config.launcher.dragThreshold)
@@ -210,7 +219,7 @@ CustomMouseArea {
         }
 
         // Show dashboard on hover
-        const showDashboard = Config.dashboard.showOnHover && inTopPanel(panels.dashboard, x, y);
+        const showDashboard = Config.dashboard.showOnHover && inTopPanel(panels.dashboard, x, y) && !(geometry.barOnTop && geometry.barContains(x, y));
 
         // Always update visibility based on hover if not in shortcut mode
         if (!dashboardShortcutActive) {
@@ -221,15 +230,21 @@ CustomMouseArea {
         }
 
         // Show/hide dashboard on drag (for touchscreen devices)
-        if (pressed && inTopPanel(panels.dashboard, dragStart.x, dragStart.y) && withinPanelWidth(panels.dashboard, x, y)) {
+        if (pressed && inTopPanel(panels.dashboard, dragStart.x, dragStart.y) && !(geometry.barOnTop && geometry.barContains(dragStart.x, dragStart.y)) && withinPanelWidth(panels.dashboard, x, y)) {
             if (dragY > Config.dashboard.dragThreshold)
                 screenState.dashboard = true;
             else if (dragY < -Config.dashboard.dragThreshold)
                 screenState.dashboard = false;
         }
 
-        // Show utilities on hover
-        const showUtilities = inBottomPanel(panels.utilities, x, y, true);
+        // Show utilities on hover; on a bottom bar it rides the power entry instead of an edge zone
+        let showUtilities;
+        if (geometry.barOnBottom) {
+            const entry = geometry.barContains(x, y) ? bar.entryAt(geometry.axisPos(x, y)) : "";
+            showUtilities = entry === "power" || (screenState.utilities && !entry && inBottomPanel(panels.utilities, x, y, true));
+        } else {
+            showUtilities = inBottomPanel(panels.utilities, x, y, true);
+        }
 
         // Always update visibility based on hover if not in shortcut mode
         if (!utilitiesShortcutActive) {
@@ -242,7 +257,7 @@ CustomMouseArea {
         // Show popouts on hover
         if (geometry.barContains(x, y)) {
             bar.checkPopout(geometry.axisPos(x, y));
-        } else if ((!popouts.currentName.startsWith("traymenu") || ((popouts.current as StackView)?.depth ?? 0) <= 1) && !inLeftPanel(panels.popoutsWrapper, x, y)) {
+        } else if ((!popouts.currentName.startsWith("traymenu") || ((popouts.current as StackView)?.depth ?? 0) <= 1) && !inPopoutArea(x, y)) {
             popouts.hasCurrent = false;
             bar.closeTray();
         }

--- a/modules/drawers/Interactions.qml
+++ b/modules/drawers/Interactions.qml
@@ -62,10 +62,14 @@ CustomMouseArea {
     }
 
     function inDashboardArea(x: real, y: real): bool {
-        if (geometry.horizontal) {
+        if (geometry.dashboardOnLeft) {
+            if (geometry.barOnLeft && geometry.barContains(x, y))
+                return false;
             const panelWidth = panels.dashboard.width * (1 - panels.dashboard.offsetScale);
             return x < Math.max(Config.border.minThickness, geometry.insetLeft(Config.border.thickness) + panelWidth) && withinPanelHeight(panels.dashboard, x, y);
         }
+        if (geometry.barOnTop && geometry.barContains(x, y))
+            return false;
         return inTopPanel(panels.dashboard, x, y);
     }
 
@@ -238,8 +242,8 @@ CustomMouseArea {
         }
 
         // Show/hide dashboard on drag (for touchscreen devices)
-        if (pressed && inDashboardArea(dragStart.x, dragStart.y) && (geometry.horizontal ? withinPanelHeight(panels.dashboard, x, y) : withinPanelWidth(panels.dashboard, x, y))) {
-            const dashDrag = geometry.horizontal ? dragX : dragY;
+        if (pressed && inDashboardArea(dragStart.x, dragStart.y) && (geometry.dashboardOnLeft ? withinPanelHeight(panels.dashboard, x, y) : withinPanelWidth(panels.dashboard, x, y))) {
+            const dashDrag = geometry.dashboardOnLeft ? dragX : dragY;
             if (dashDrag > Config.dashboard.dragThreshold)
                 screenState.dashboard = true;
             else if (dashDrag < -Config.dashboard.dragThreshold)

--- a/modules/drawers/Interactions.qml
+++ b/modules/drawers/Interactions.qml
@@ -61,6 +61,14 @@ CustomMouseArea {
         return y > height - Math.max(Config.border.minThickness, geometry.insetBottom(Config.border.thickness) + panelHeight) - (isCorner ? Config.border.rounding : 0) && withinPanelWidth(panel, x, y);
     }
 
+    function inDashboardArea(x: real, y: real): bool {
+        if (geometry.horizontal) {
+            const panelWidth = panels.dashboard.width * (1 - panels.dashboard.offsetScale);
+            return x < Math.max(Config.border.minThickness, geometry.insetLeft(Config.border.thickness) + panelWidth) && withinPanelHeight(panels.dashboard, x, y);
+        }
+        return inTopPanel(panels.dashboard, x, y);
+    }
+
     function onWheel(event: WheelEvent): void {
         if (fullscreen)
             return;
@@ -219,7 +227,7 @@ CustomMouseArea {
         }
 
         // Show dashboard on hover
-        const showDashboard = Config.dashboard.showOnHover && inTopPanel(panels.dashboard, x, y) && !(geometry.barOnTop && geometry.barContains(x, y));
+        const showDashboard = Config.dashboard.showOnHover && inDashboardArea(x, y);
 
         // Always update visibility based on hover if not in shortcut mode
         if (!dashboardShortcutActive) {
@@ -230,10 +238,11 @@ CustomMouseArea {
         }
 
         // Show/hide dashboard on drag (for touchscreen devices)
-        if (pressed && inTopPanel(panels.dashboard, dragStart.x, dragStart.y) && !(geometry.barOnTop && geometry.barContains(dragStart.x, dragStart.y)) && withinPanelWidth(panels.dashboard, x, y)) {
-            if (dragY > Config.dashboard.dragThreshold)
+        if (pressed && inDashboardArea(dragStart.x, dragStart.y) && (geometry.horizontal ? withinPanelHeight(panels.dashboard, x, y) : withinPanelWidth(panels.dashboard, x, y))) {
+            const dashDrag = geometry.horizontal ? dragX : dragY;
+            if (dashDrag > Config.dashboard.dragThreshold)
                 screenState.dashboard = true;
-            else if (dragY < -Config.dashboard.dragThreshold)
+            else if (dashDrag < -Config.dashboard.dragThreshold)
                 screenState.dashboard = false;
         }
 
@@ -273,7 +282,7 @@ CustomMouseArea {
                 root.utilitiesShortcutActive = false;
 
                 // Also hide dashboard and OSD if they're not being hovered
-                const inDashboardArea = root.inTopPanel(root.panels.dashboard, root.mouseX, root.mouseY);
+                const inDashboardArea = root.inDashboardArea(root.mouseX, root.mouseY);
                 const inOsdArea = root.inRightPanel(root.panels.osdWrapper, root.mouseX, root.mouseY);
 
                 if (!inDashboardArea) {
@@ -289,7 +298,7 @@ CustomMouseArea {
         function onDashboardChanged() {
             if (root.screenState.dashboard) {
                 // Dashboard became visible, immediately check if this should be shortcut mode
-                const inDashboardArea = root.inTopPanel(root.panels.dashboard, root.mouseX, root.mouseY);
+                const inDashboardArea = root.inDashboardArea(root.mouseX, root.mouseY);
                 if (!inDashboardArea) {
                     root.dashboardShortcutActive = true;
                 }

--- a/modules/drawers/Panels.qml
+++ b/modules/drawers/Panels.qml
@@ -123,6 +123,7 @@ Item {
         id: popoutsWrapper
 
         screen: root.screen
+        position: root.geometry.position
         borderThickness: root.borderThickness
     }
 

--- a/modules/drawers/Panels.qml
+++ b/modules/drawers/Panels.qml
@@ -19,6 +19,7 @@ Item {
     required property ShellScreen screen
     required property ScreenState screenState
     required property Bar.BarWrapper bar
+    required property EdgeGeometry geometry
     required property real borderThickness
 
     readonly property alias osd: osd
@@ -36,7 +37,9 @@ Item {
 
     anchors.fill: parent
     anchors.margins: borderThickness
-    anchors.leftMargin: bar.implicitWidth
+    anchors.leftMargin: geometry.insetLeft(borderThickness)
+    anchors.topMargin: geometry.insetTop(borderThickness)
+    anchors.bottomMargin: geometry.insetBottom(borderThickness)
 
     Item {
         id: osdWrapper

--- a/modules/drawers/Panels.qml
+++ b/modules/drawers/Panels.qml
@@ -114,12 +114,12 @@ Item {
         id: dashboard
 
         screenState: root.screenState
-        onLeft: root.geometry.horizontal
+        onLeft: root.geometry.dashboardOnLeft
 
-        anchors.horizontalCenter: root.geometry.horizontal ? undefined : parent.horizontalCenter
-        anchors.top: root.geometry.horizontal ? undefined : parent.top
-        anchors.verticalCenter: root.geometry.horizontal ? parent.verticalCenter : undefined
-        anchors.left: root.geometry.horizontal ? parent.left : undefined
+        anchors.horizontalCenter: root.geometry.dashboardOnLeft ? undefined : parent.horizontalCenter
+        anchors.top: root.geometry.dashboardOnLeft ? undefined : parent.top
+        anchors.verticalCenter: root.geometry.dashboardOnLeft ? parent.verticalCenter : undefined
+        anchors.left: root.geometry.dashboardOnLeft ? parent.left : undefined
     }
 
     BarPopouts.ClipWrapper {

--- a/modules/drawers/Panels.qml
+++ b/modules/drawers/Panels.qml
@@ -114,9 +114,12 @@ Item {
         id: dashboard
 
         screenState: root.screenState
+        onLeft: root.geometry.horizontal
 
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.top: parent.top
+        anchors.horizontalCenter: root.geometry.horizontal ? undefined : parent.horizontalCenter
+        anchors.top: root.geometry.horizontal ? undefined : parent.top
+        anchors.verticalCenter: root.geometry.horizontal ? parent.verticalCenter : undefined
+        anchors.left: root.geometry.horizontal ? parent.left : undefined
     }
 
     BarPopouts.ClipWrapper {

--- a/modules/drawers/Regions.qml
+++ b/modules/drawers/Regions.qml
@@ -22,10 +22,10 @@ Region {
 
     R {
         panel: root.panels.dashboard
-        x: root.geometry.horizontal ? 0 : panel.x + root.geometry.insetLeft(root.borderThickness)
-        y: root.geometry.horizontal ? panel.y + root.geometry.insetTop(root.borderThickness) : 0
-        width: root.geometry.horizontal ? panel.width * (1 - root.panels.dashboard.offsetScale) + root.geometry.insetLeft(root.borderThickness) : panel.width
-        height: root.geometry.horizontal ? panel.height : panel.height * (1 - root.panels.dashboard.offsetScale) + root.geometry.insetTop(root.borderThickness)
+        x: root.geometry.dashboardOnLeft ? 0 : panel.x + root.geometry.insetLeft(root.borderThickness)
+        y: root.geometry.dashboardOnLeft ? panel.y + root.geometry.insetTop(root.borderThickness) : 0
+        width: root.geometry.dashboardOnLeft ? panel.width * (1 - root.panels.dashboard.offsetScale) + root.geometry.insetLeft(root.borderThickness) : panel.width
+        height: root.geometry.dashboardOnLeft ? panel.height : panel.height * (1 - root.panels.dashboard.offsetScale) + root.geometry.insetTop(root.borderThickness)
     }
 
     R {

--- a/modules/drawers/Regions.qml
+++ b/modules/drawers/Regions.qml
@@ -3,22 +3,21 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import Quickshell
 import Caelestia.Config
-import qs.modules.bar as Bar
 
 Region {
     id: root
 
-    required property Bar.BarWrapper bar
+    required property EdgeGeometry geometry
     required property Panels panels
     required property var win
 
     readonly property real borderThickness: win.contentItem.Config.border.thickness
     readonly property real clampedThickness: win.contentItem.Config.border.clampedThickness
 
-    x: bar.clampedWidth + win.dragMaskPadding
-    y: clampedThickness + win.dragMaskPadding
-    width: win.width - bar.clampedWidth - clampedThickness - win.dragMaskPadding * 2
-    height: win.height - clampedThickness * 2 - win.dragMaskPadding * 2
+    x: geometry.insetLeft(clampedThickness, true) + win.dragMaskPadding
+    y: geometry.insetTop(clampedThickness, true) + win.dragMaskPadding
+    width: win.width - geometry.insetLeft(clampedThickness, true) - clampedThickness - win.dragMaskPadding * 2
+    height: win.height - geometry.insetTop(clampedThickness, true) - geometry.insetBottom(clampedThickness, true) - win.dragMaskPadding * 2
     intersection: Intersection.Xor
 
     R {
@@ -75,8 +74,8 @@ Region {
     component R: Region {
         required property Item panel
 
-        x: panel.x + root.bar.implicitWidth
-        y: panel.y + root.borderThickness
+        x: panel.x + root.geometry.insetLeft(root.borderThickness)
+        y: panel.y + root.geometry.insetTop(root.borderThickness)
         width: panel.width
         height: panel.height
         intersection: Intersection.Subtract

--- a/modules/drawers/Regions.qml
+++ b/modules/drawers/Regions.qml
@@ -23,13 +23,13 @@ Region {
     R {
         panel: root.panels.dashboard
         y: 0
-        height: panel.height * (1 - root.panels.dashboard.offsetScale) + root.borderThickness
+        height: panel.height * (1 - root.panels.dashboard.offsetScale) + root.geometry.insetTop(root.borderThickness)
     }
 
     R {
         panel: root.panels.launcher
         y: root.win.height - height
-        height: panel.height * (1 - root.panels.launcher.offsetScale) + root.borderThickness
+        height: panel.height * (1 - root.panels.launcher.offsetScale) + root.geometry.insetBottom(root.borderThickness)
     }
 
     R {
@@ -57,18 +57,19 @@ Region {
     R {
         panel: root.panels.notifications
         y: 0
-        height: panel.height + root.borderThickness
+        height: panel.height + root.geometry.insetTop(root.borderThickness)
     }
 
     R {
         panel: root.panels.utilities
         y: root.win.height - height
-        height: panel.height * (1 - root.panels.utilities.offsetScale) + root.borderThickness
+        height: panel.height * (1 - root.panels.utilities.offsetScale) + root.geometry.insetBottom(root.borderThickness)
     }
 
     R {
         panel: root.panels.popoutsWrapper
-        width: panel.width * (1 - root.panels.popoutsWrapper.offsetScale)
+        width: root.geometry.horizontal ? panel.width : panel.width * (1 - root.panels.popoutsWrapper.offsetScale)
+        height: root.geometry.horizontal ? panel.height * (1 - root.panels.popoutsWrapper.offsetScale) : panel.height
     }
 
     component R: Region {

--- a/modules/drawers/Regions.qml
+++ b/modules/drawers/Regions.qml
@@ -22,8 +22,10 @@ Region {
 
     R {
         panel: root.panels.dashboard
-        y: 0
-        height: panel.height * (1 - root.panels.dashboard.offsetScale) + root.geometry.insetTop(root.borderThickness)
+        x: root.geometry.horizontal ? 0 : panel.x + root.geometry.insetLeft(root.borderThickness)
+        y: root.geometry.horizontal ? panel.y + root.geometry.insetTop(root.borderThickness) : 0
+        width: root.geometry.horizontal ? panel.width * (1 - root.panels.dashboard.offsetScale) + root.geometry.insetLeft(root.borderThickness) : panel.width
+        height: root.geometry.horizontal ? panel.height : panel.height * (1 - root.panels.dashboard.offsetScale) + root.geometry.insetTop(root.borderThickness)
     }
 
     R {

--- a/modules/launcher/WallpaperList.qml
+++ b/modules/launcher/WallpaperList.qml
@@ -23,9 +23,9 @@ PathView {
             return 0;
 
         // Screen width - 4x outer rounding - 2x max side thickness (cause centered)
-        const barMargins = Math.max(Config.border.thickness, panels.bar.implicitWidth);
+        const barMargins = panels.geometry.insetLeft(Config.border.thickness);
         let outerMargins = 0;
-        if (panels.popouts.hasCurrent && panels.popouts.currentCenter + panels.popouts.nonAnimHeight / 2 > screen.height - content.implicitHeight - Config.border.thickness * 2)
+        if (panels.popouts.hasCurrent && (panels.geometry.horizontal || panels.popouts.currentCenter + panels.popouts.nonAnimHeight / 2 > screen.height - content.implicitHeight - Config.border.thickness * 2))
             outerMargins = panels.popouts.nonAnimWidth;
         if ((screenState.utilities || screenState.sidebar) && panels.utilities.implicitWidth > outerMargins)
             outerMargins = panels.utilities.implicitWidth;

--- a/modules/nexus/pages/panels/TaskbarPanel.qml
+++ b/modules/nexus/pages/panels/TaskbarPanel.qml
@@ -1,11 +1,38 @@
 pragma ComponentBehavior: Bound
 
+import QtQuick
 import QtQuick.Layouts
 import Caelestia.Config
+import qs.components.controls
 import qs.modules.nexus.common
 
 PageBase {
     id: root
+
+    // Bar edges + the config value each maps to
+    readonly property list<MenuItem> positionItems: [
+        MenuItem {
+            text: qsTr("Left")
+        },
+        MenuItem {
+            text: qsTr("Top")
+        },
+        MenuItem {
+            text: qsTr("Bottom")
+        }
+    ]
+    readonly property var positionValues: ["left", "top", "bottom"]
+
+    // Dashboard edges + the config value each maps to
+    readonly property list<MenuItem> dashboardItems: [
+        MenuItem {
+            text: qsTr("Top")
+        },
+        MenuItem {
+            text: qsTr("Left")
+        }
+    ]
+    readonly property var dashboardValues: ["top", "left"]
 
     title: qsTr("Taskbar")
     isSubPage: true
@@ -16,9 +43,32 @@ PageBase {
         width: root.cappedWidth
         spacing: Tokens.spacing.extraSmall / 2
 
-        // Behaviour
+        // Layout
         SectionHeader {
             first: true
+            text: qsTr("Layout")
+        }
+
+        SelectRow {
+            first: true
+            label: qsTr("Position")
+            subtext: qsTr("Which screen edge the bar sits on")
+            menuItems: root.positionItems
+            active: root.positionItems[Math.max(0, root.positionValues.indexOf(Config.bar.position))]
+            onSelected: item => GlobalConfig.bar.position = root.positionValues[root.positionItems.indexOf(item)]
+        }
+
+        SelectRow {
+            last: true
+            label: qsTr("Dashboard")
+            subtext: qsTr("Which edge the dashboard opens from")
+            menuItems: root.dashboardItems
+            active: root.dashboardItems[Math.max(0, root.dashboardValues.indexOf(Config.dashboard.position))]
+            onSelected: item => GlobalConfig.dashboard.position = root.dashboardValues[root.dashboardItems.indexOf(item)]
+        }
+
+        // Behaviour
+        SectionHeader {
             text: qsTr("Behaviour")
         }
 

--- a/plugin/src/Caelestia/Config/barconfig.hpp
+++ b/plugin/src/Caelestia/Config/barconfig.hpp
@@ -127,6 +127,7 @@ class BarConfig : public ConfigObject {
     Q_OBJECT
     QML_ANONYMOUS
 
+    CONFIG_PROPERTY(QString, position, u"left"_s)
     CONFIG_PROPERTY(bool, persistent, true)
     CONFIG_PROPERTY(bool, showOnHover, true)
     CONFIG_PROPERTY(int, dragThreshold, 20)

--- a/plugin/src/Caelestia/Config/dashboardconfig.hpp
+++ b/plugin/src/Caelestia/Config/dashboardconfig.hpp
@@ -2,7 +2,11 @@
 
 #include "configobject.hpp"
 
+#include <qstring.h>
+
 namespace caelestia::config {
+
+using Qt::StringLiterals::operator""_s;
 
 class DashboardPerformance : public ConfigObject {
     Q_OBJECT
@@ -24,6 +28,7 @@ class DashboardConfig : public ConfigObject {
     Q_OBJECT
     QML_ANONYMOUS
 
+    CONFIG_PROPERTY(QString, position, u"top"_s)
     CONFIG_PROPERTY(bool, enabled, true)
     CONFIG_PROPERTY(bool, showOnHover, true)
     CONFIG_PROPERTY(bool, showDashboard, true)


### PR DESCRIPTION
Adds `bar.position` (`left` default, `top`, `bottom`) and `dashboard.position` (`top` default,
`left`). Both are per-monitor. Closes #1182; #1148 and #573 were closed as needing an entire
rework, so this is that rework.

The drawer geometry assumed a left bar: `bar.implicitWidth` for the left inset and
`border.thickness` for the other three edges, spread across ContentWindow, Panels, Regions,
Interactions and Exclusions. The first commit pulls that into `modules/drawers/EdgeGeometry.qml`,
a per-screen object that answers how far in each edge sits and whether a point is on the bar, then
threads it through. With `position: "left"` every expression it replaces evaluates to what it did
before, so that commit changes nothing at runtime.

The second adds the two horizontal positions: the bar lays out as a row, its components morph
(workspaces row, unrotated window title, tray and status as rows), popouts flip axis and clamp
along X, the blob border and SDF offsets follow whichever edge the bar is on, and the launcher and
dashboard hover zones stop firing on the edge the bar now occupies. On a bottom bar the utilities
panel rides the `power` entry, since its corner zone is under the bar, and the launcher's edge
gesture is unavailable for the same reason. Orientation is baked into the drawers' layouts,
loaders and running animations, so `Drawers.qml` rebuilds a screen's windows when the position
changes rather than converting them in place.

The next two move the dashboard to the left edge, because a top dashboard and a horizontal bar
want the same screen edge, then make the edge configurable. A dashboard configured onto the bar's
own edge opens from the other one instead, since otherwise its hover zone is exactly the strip the
bar covers and it could never be revealed. The last adds both selectors to the taskbar page in
Nexus and documents the defaults.

### Testing

Daily driven on a bottom bar:

- All three positions render correctly from a cold start.
- Switching position live between all three, no restart, from the Nexus selectors.
- Bottom bar: every popout opens and stays open while the pointer is on it, utilities from the
  `power` entry, dashboard from the left edge.

`qmlformat`, `scripts/qml-lint-conventions.py`, `qmllint` and the cmake build are clean.

### Screenshots

`bar.position: "left"` 
<img width="2560" height="1440" alt="bar-left" src="https://github.com/user-attachments/assets/6de93605-199f-429f-816b-292c0ae56aa7" />

`bar.position: "top"`
<img width="2560" height="1440" alt="bar-top" src="https://github.com/user-attachments/assets/710cf429-13a8-4f3f-a3bb-c884c1c4180c" />

`bar.position: "bottom"`
<img width="2560" height="1440" alt="bar-bottom" src="https://github.com/user-attachments/assets/784d9c8e-bb74-4ebb-8a14-2b21427f364c" />

`bar.position: "bottom"` with `dashboard.position: "left"`
<img width="2560" height="1440" alt="dashboard-left" src="https://github.com/user-attachments/assets/e67ef1a3-4065-442d-a6dc-6d7cf119766a" />



