### PR TITLE
fix: nominatim compliance

### DIFF
--- a/services/Weather.qml
+++ b/services/Weather.qml
@@ -161,23 +161,21 @@ Singleton {
         const [lat, lon] = coords.split(",").map(s => s.trim());
         const lang = Qt.locale().name.split("_")[0] || "en";
 
-        const fallbackToBigDataCloud = () => {
-            const fallbackUrl = `https://api.bigdatacloud.net/data/reverse-geocode-client?latitude=${lat}&longitude=${lon}&localityLanguage=${lang}`;
-            Requests.get(fallbackUrl, text => {
-                const geo = JSON.parse(text);
-                const geoCity = geo.city || geo.locality;
-                if (geoCity) {
-                    city = fixCityName(geoCity);
-                    cachedCities.set(coords, city);
-                } else {
-                    city = "Unknown City";
-                }
-            });
+        const nominatimUrl = `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lon}&format=geocodejson&accept-language=${lang}`;
+        const nominatimHeaders = {
+            "User-Agent": `caelestia-shell/${CUtils.version} (+https://github.com/caelestia-dots/shell)`
         };
 
-        const nominatimUrl = `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lon}&format=geocodejson&accept-language=${lang}`;
         Requests.get(nominatimUrl, text => {
-            const geo = JSON.parse(text).features?.[0]?.properties.geocoding;
+            let geo;
+            try {
+                geo = JSON.parse(text).features?.[0]?.properties.geocoding;
+            } catch (error) {
+                console.warn(lc, `Unable to parse response from nominatim: ${error}`);
+                city = qsTr("Unknown City");
+                return;
+            }
+
             if (geo) {
                 const geoCity = geo.type === "city" ? geo.name : geo.city;
                 if (geoCity) {
@@ -186,8 +184,13 @@ Singleton {
                     return;
                 }
             }
-            fallbackToBigDataCloud();
-        }, fallbackToBigDataCloud);
+
+            console.warn(lc, "No locality in nominatim response");
+            city = qsTr("Unknown City");
+        }, error => {
+            console.warn(lc, `Nominatim request failed: ${error}`);
+            city = qsTr("Unknown City");
+        }, nominatimHeaders);
     }
 
     function fetchCoordsFromCity(cityName: string): void {

--- a/services/Weather.qml
+++ b/services/Weather.qml
@@ -2,6 +2,7 @@ pragma Singleton
 
 import QtQuick
 import Quickshell
+import Quickshell.Io
 import Caelestia
 import Caelestia.Config
 import qs.utils
@@ -17,6 +18,7 @@ Singleton {
 
     property bool ipApiRequestPending: false
     property double ipApiBlockedUntil: 0
+    property bool citiesLoaded: false
 
     readonly property string icon: cc ? Icons.getWeatherIcon(cc.weatherCode) : "cloud_alert"
     readonly property string description: cc?.weatherDesc ?? qsTr("No weather")
@@ -152,6 +154,11 @@ Singleton {
         return mapping[cityName] || cityName;
     }
 
+    function cacheCity(coords: string, cityName: string): void {
+        cachedCities.set(coords, cityName);
+        citiesSaveTimer.restart();
+    }
+
     function fetchCityFromCoords(coords: string): void {
         if (cachedCities.has(coords)) {
             city = cachedCities.get(coords);
@@ -180,7 +187,7 @@ Singleton {
                 const geoCity = geo.type === "city" ? geo.name : geo.city;
                 if (geoCity) {
                     city = fixCityName(geoCity);
-                    cachedCities.set(coords, city);
+                    cacheCity(coords, city);
                     return;
                 }
             }
@@ -347,8 +354,48 @@ Singleton {
         }
     }
 
+    Timer {
+        id: citiesSaveTimer
+
+        interval: 1000
+        onTriggered: {
+            if (!root.citiesLoaded)
+                return;
+
+            const data = {};
+            root.cachedCities.forEach((cityName, coords) => data[coords] = cityName);
+            citiesStorage.setText(JSON.stringify(data));
+        }
+    }
+
     ElapsedTimer {
         id: timer
+    }
+
+    FileView {
+        id: citiesStorage
+
+        printErrors: false
+        path: `${Paths.cache}/cities.json`
+        onLoaded: {
+            try {
+                const data = JSON.parse(text());
+                for (const [coords, cityName] of Object.entries(data))
+                    if (!root.cachedCities.has(coords))
+                        root.cachedCities.set(coords, cityName);
+            } catch (error) {
+                console.warn(lc, `Unable to parse cached cities: ${error}`);
+            }
+
+            root.citiesLoaded = true;
+        }
+        onLoadFailed: err => {
+            root.citiesLoaded = true;
+            if (err === FileViewError.FileNotFound)
+                Qt.callLater(() => setText("{}"));
+            else
+                console.warn(lc, `Unable to load cached cities: ${err}`);
+        }
     }
 
     LoggingCategory {

--- a/services/Weather.qml
+++ b/services/Weather.qml
@@ -19,6 +19,7 @@ Singleton {
     property bool ipApiRequestPending: false
     property double ipApiBlockedUntil: 0
     property bool citiesLoaded: false
+    property string pendingCoords
 
     readonly property string icon: cc ? Icons.getWeatherIcon(cc.weatherCode) : "cloud_alert"
     readonly property string description: cc?.weatherDesc ?? qsTr("No weather")
@@ -162,6 +163,12 @@ Singleton {
     function fetchCityFromCoords(coords: string): void {
         if (cachedCities.has(coords)) {
             city = cachedCities.get(coords);
+            return;
+        }
+
+        // Defer until cache is loaded
+        if (!citiesLoaded) {
+            pendingCoords = coords;
             return;
         }
 
@@ -321,6 +328,14 @@ Singleton {
     }
 
     onLocChanged: fetchWeatherData()
+    onCitiesLoadedChanged: {
+        if (!citiesLoaded || !pendingCoords)
+            return;
+
+        const coords = pendingCoords;
+        pendingCoords = "";
+        fetchCityFromCoords(coords);
+    }
 
     Connections {
         function onWeatherLocationChanged(): void {


### PR DESCRIPTION
Set the `User-Agent` header for the nominatim request to comply with their TOS, and cache cities to disk to reduce the number of requests. This is also to comply with their TOS. We have in-memory caching currently, but that doesn't apply across reloads or restarts.

This is for the weather service lat,long coordinates -> city conversion.