### PR TITLE
fix(idle-inhibitor): use mapped 1x1 surface for keep awake

### DIFF
--- a/services/IdleInhibitor.qml
+++ b/services/IdleInhibitor.qml
@@ -27,10 +27,18 @@ Singleton {
     IdleInhibitor {
         enabled: props.enabled
         window: PanelWindow {
-            implicitWidth: 0
-            implicitHeight: 0
+            // 0x0 surfaces do not map on Hyprland, so idle inhibitors are ignored.
+            // Use a 1x1 corner surface instead (see #635).
+            screen: Quickshell.screens[0]
+            visible: props.enabled
+            anchors.top: true
+            anchors.left: true
+            implicitWidth: 1
+            implicitHeight: 1
             color: "transparent"
             mask: Region {}
+            WlrLayershell.namespace: "caelestia-idle-inhibitor"
+            WlrLayershell.exclusionMode: ExclusionMode.Ignore
         }
     }
 


### PR DESCRIPTION
The keep awake toggle created a 0x0 PanelWindow that never mapped on Hyprland, so ext-idle-notify timers still fired and the system slept after the configured idle timeout.

Use a transparent 1x1 layer-shell surface anchored to the top-left corner instead. This keeps the inhibitor invisible while allowing Hyprland to register the idle inhibitor.