### PR TITLE
fix: use GNUInstallDirs for install dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ string(REGEX REPLACE "^v" "" VERSION "${VERSION}")
 
 project(caelestia-shell VERSION ${VERSION} LANGUAGES CXX)
 
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -35,9 +37,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 
 set(DISTRIBUTOR "Unset" CACHE STRING "Distributor")
 set(ENABLE_MODULES "extras;plugin;shell;m3shapes" CACHE STRING "Modules to build/install")
-set(INSTALL_LIBDIR "usr/lib/caelestia" CACHE STRING "Library install dir")
-set(INSTALL_QMLDIR "usr/lib/qt6/qml" CACHE STRING "QML install dir")
-set(INSTALL_QSCONFDIR "etc/xdg/quickshell/caelestia" CACHE STRING "Quickshell config install dir")
+set(INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/caelestia" CACHE STRING "Library install dir")
+set(INSTALL_QMLDIR "${CMAKE_INSTALL_LIBDIR}/qt6/qml" CACHE STRING "QML install dir")
+set(INSTALL_QSCONFDIR "${CMAKE_INSTALL_SYSCONFDIR}/xdg/quickshell/caelestia" CACHE STRING "Quickshell config install dir")
 
 add_compile_options(
     -Wall -Wextra -Wpedantic -Wshadow -Wconversion

--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -6,4 +6,4 @@ target_compile_definitions(version PRIVATE
     GIT_REVISION="${GIT_REVISION}"
     DISTRIBUTOR="${DISTRIBUTOR}"
 )
-install(TARGETS version DESTINATION ${INSTALL_LIBDIR})
+install(TARGETS version DESTINATION "${INSTALL_LIBDIR}")


### PR DESCRIPTION
To support distros with different lib paths (e.g. fedora/gentoo use lib64 instead of lib)