### PR TITLE
feat(nexus): add field for action prefix in launcher panel

### DIFF
--- a/components/controls/StyledTextField.qml
+++ b/components/controls/StyledTextField.qml
@@ -19,7 +19,8 @@ TextFieldBase {
     property int smallFontSize: Tokens.font.label.small.pointSize
     readonly property real smallFontScale: smallFontSize / font.pointSize
 
-    readonly property int horizontalPadding: Tokens.padding.large
+    property int verticalPadding: Tokens.padding.large
+    property int horizontalPadding: Tokens.padding.large
     property int radius: Tokens.rounding.small
     readonly property int clampedRadius: Math.min(horizontalPadding, Math.min(width, height) / 2, radius)
 
@@ -41,8 +42,8 @@ TextFieldBase {
 
     leftPadding: horizontalPadding + leadingOffset
     rightPadding: horizontalPadding + trailingOffset
-    topPadding: Tokens.padding.large + filledOffset
-    bottomPadding: Tokens.padding.large + supportingTextOffset - filledOffset
+    topPadding: verticalPadding + filledOffset
+    bottomPadding: verticalPadding + supportingTextOffset - filledOffset
 
     onPressed: {
         if (!stateLayer.disabled)

--- a/modules/nexus/common/TextFieldRow.qml
+++ b/modules/nexus/common/TextFieldRow.qml
@@ -13,7 +13,7 @@ ConnectedRect {
 
     property alias label: label.text
     property string subtext
-    property alias value: input.text
+    property string value
     property alias placeholderText: input.placeholderText
     property string errorText
     property alias maximumLength: input.maximumLength
@@ -27,6 +27,11 @@ ConnectedRect {
 
     function clear(): void {
         input.clear();
+    }
+
+    Component.onDestruction: {
+        if (value !== input.text)
+            editingFinished(input.text);
     }
 
     Layout.fillWidth: true
@@ -72,6 +77,8 @@ ConnectedRect {
             Layout.maximumWidth: root.width / 2
             Layout.alignment: Qt.AlignVCenter
             verticalPadding: Tokens.padding.small
+
+            text: root.value
 
             onTextEdited: root.valueEdited(text)
             onEditingFinished: root.editingFinished(text)

--- a/modules/nexus/common/TextFieldRow.qml
+++ b/modules/nexus/common/TextFieldRow.qml
@@ -15,12 +15,11 @@ ConnectedRect {
     property string subtext
     property alias value: input.text
     property alias placeholderText: input.placeholderText
-    property alias errorText: input.errorText
+    property string errorText
     property alias maximumLength: input.maximumLength
     property alias validate: input.validate
     property alias validator: input.validator
-    property int fieldWidth: Tokens.sizes.nexus.textFieldWidth
-    property int fieldVerticalPadding: Tokens.padding.small
+    property bool smallField
     readonly property alias field: input
 
     signal valueEdited(value: string)
@@ -31,7 +30,7 @@ ConnectedRect {
     }
 
     Layout.fillWidth: true
-    implicitHeight: rowLayout.implicitHeight + Tokens.padding.medium + Math.max(0, Tokens.padding.large - fieldVerticalPadding) * 2
+    implicitHeight: rowLayout.implicitHeight + Tokens.padding.medium + Math.max(0, Tokens.padding.large - input.verticalPadding) * 2
 
     RowLayout {
         id: rowLayout
@@ -58,19 +57,21 @@ ConnectedRect {
             StyledText {
                 Layout.fillWidth: true
                 visible: root.subtext
-                text: root.subtext
-                color: Colours.palette.m3outline
+                text: input.isError && root.errorText ? root.errorText : root.subtext
+                color: input.isError && root.errorText ? Colours.palette.m3error : Colours.palette.m3outline
                 font: Tokens.font.label.small
                 elide: Text.ElideRight
+                animate: root.errorText
             }
         }
 
         StyledTextField {
             id: input
 
-            Layout.preferredWidth: root.fieldWidth
+            Layout.preferredWidth: root.smallField ? Tokens.sizes.nexus.smallTextFieldWidth : Tokens.sizes.nexus.textFieldWidth
+            Layout.maximumWidth: root.width / 2
             Layout.alignment: Qt.AlignVCenter
-            verticalPadding: root.fieldVerticalPadding
+            verticalPadding: Tokens.padding.small
 
             onTextEdited: root.valueEdited(text)
             onEditingFinished: root.editingFinished(text)

--- a/modules/nexus/common/TextFieldRow.qml
+++ b/modules/nexus/common/TextFieldRow.qml
@@ -18,6 +18,7 @@ ConnectedRect {
     property alias errorText: input.errorText
     property alias maximumLength: input.maximumLength
     property alias validate: input.validate
+    property alias validator: input.validator
     property int fieldWidth: Tokens.sizes.nexus.textFieldWidth
     property int fieldVerticalPadding: Tokens.padding.small
     readonly property alias field: input

--- a/modules/nexus/common/TextFieldRow.qml
+++ b/modules/nexus/common/TextFieldRow.qml
@@ -18,7 +18,7 @@ ConnectedRect {
     property alias errorText: input.errorText
     property alias maximumLength: input.maximumLength
     property alias validate: input.validate
-    property int fieldWidth: 200
+    property int fieldWidth: Tokens.sizes.nexus.textFieldWidth
     property int fieldVerticalPadding: Tokens.padding.small
     readonly property alias field: input
 

--- a/modules/nexus/common/TextFieldRow.qml
+++ b/modules/nexus/common/TextFieldRow.qml
@@ -40,7 +40,7 @@ ConnectedRect {
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
         anchors.leftMargin: Tokens.padding.largeIncreased
-        anchors.rightMargin: Tokens.padding.medium
+        anchors.rightMargin: Tokens.padding.largeIncreased
         spacing: Tokens.spacing.medium
 
         ColumnLayout {

--- a/modules/nexus/common/TextFieldRow.qml
+++ b/modules/nexus/common/TextFieldRow.qml
@@ -1,0 +1,78 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.modules.nexus.common
+
+ConnectedRect {
+    id: root
+
+    property alias label: label.text
+    property string subtext
+    property alias value: input.text
+    property alias placeholderText: input.placeholderText
+    property alias errorText: input.errorText
+    property alias maximumLength: input.maximumLength
+    property alias validate: input.validate
+    property int fieldWidth: 200
+    property int fieldVerticalPadding: Tokens.padding.small
+    readonly property alias field: input
+
+    signal valueEdited(value: string)
+    signal editingFinished(value: string)
+
+    function clear(): void {
+        input.clear();
+    }
+
+    Layout.fillWidth: true
+    implicitHeight: rowLayout.implicitHeight + Tokens.padding.medium + Math.max(0, Tokens.padding.large - fieldVerticalPadding) * 2
+
+    RowLayout {
+        id: rowLayout
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.leftMargin: Tokens.padding.largeIncreased
+        anchors.rightMargin: Tokens.padding.medium
+        spacing: Tokens.spacing.medium
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: 0
+
+            StyledText {
+                id: label
+
+                Layout.fillWidth: true
+                font: Tokens.font.body.small
+                elide: Text.ElideRight
+            }
+
+            StyledText {
+                Layout.fillWidth: true
+                visible: root.subtext
+                text: root.subtext
+                color: Colours.palette.m3outline
+                font: Tokens.font.label.small
+                elide: Text.ElideRight
+            }
+        }
+
+        StyledTextField {
+            id: input
+
+            Layout.preferredWidth: root.fieldWidth
+            Layout.alignment: Qt.AlignVCenter
+            verticalPadding: root.fieldVerticalPadding
+
+            onTextEdited: root.valueEdited(text)
+            onEditingFinished: root.editingFinished(text)
+        }
+    }
+}

--- a/modules/nexus/pages/panels/LauncherPanel.qml
+++ b/modules/nexus/pages/panels/LauncherPanel.qml
@@ -53,7 +53,6 @@ PageBase {
             fieldWidth: 70
             value: GlobalConfig.launcher.actionPrefix === ">" ? "" : GlobalConfig.launcher.actionPrefix
             placeholderText: ">"
-            errorText: qsTr("Cannot be alphanumeric")
             maximumLength: 1
             validator: RegularExpressionValidator {
                 regularExpression: /^[^a-zA-Z0-9\s]$/

--- a/modules/nexus/pages/panels/LauncherPanel.qml
+++ b/modules/nexus/pages/panels/LauncherPanel.qml
@@ -41,8 +41,9 @@ PageBase {
             id: prefixRow
 
             function saveActionPrefix(): void {
-                GlobalConfig.launcher.actionPrefix = value;
-                if (GlobalConfig.launcher.actionPrefix === ">")
+                const prefix = value || "";
+                GlobalConfig.launcher.actionPrefix = prefix;
+                if (prefix === ">")
                     clear();
             }
 
@@ -54,7 +55,9 @@ PageBase {
             placeholderText: ">"
             errorText: qsTr("Cannot be alphanumeric")
             maximumLength: 1
-            validate: /^[^a-zA-Z0-9\s]$/
+            validator: RegularExpressionValidator {
+                regularExpression: /^[^a-zA-Z0-9\s]$/
+            }
 
             onValueEdited: saveActionPrefix()
             onEditingFinished: saveActionPrefix()

--- a/modules/nexus/pages/panels/LauncherPanel.qml
+++ b/modules/nexus/pages/panels/LauncherPanel.qml
@@ -40,26 +40,23 @@ PageBase {
         TextFieldRow {
             id: prefixRow
 
-            function saveActionPrefix(): void {
-                const prefix = value || "";
-                GlobalConfig.launcher.actionPrefix = prefix;
-                if (prefix === ">")
-                    clear();
-            }
-
             last: true
             label: qsTr("Action prefix")
             subtext: qsTr("Prefix used to run actions in the launcher")
-            fieldWidth: 70
-            value: GlobalConfig.launcher.actionPrefix === ">" ? "" : GlobalConfig.launcher.actionPrefix
+            errorText: qsTr("Prefix must not be alphanumeric")
+            value: GlobalConfig.launcher.actionPrefix === ">" ? "" : GlobalConfig.launcher.actionPrefix // TODO: replace with empty only when not loaded once loaded state is exposed
             placeholderText: ">"
             maximumLength: 1
-            validator: RegularExpressionValidator {
-                regularExpression: /^[^a-zA-Z0-9\s]$/
+            smallField: true
+            validate: /^[^a-zA-Z0-9\s]$/
+            onEditingFinished: value => {
+                if (!field.valid)
+                    return;
+                /// TODO: replace with GlobalConfig.launcher.resetOption("actionPrefix") on empty commit when reset is fixed
+                GlobalConfig.launcher.actionPrefix = value || ">";
+                if (GlobalConfig.launcher.actionPrefix === ">")
+                    clear();
             }
-
-            onValueEdited: saveActionPrefix()
-            onEditingFinished: saveActionPrefix()
         }
 
         // Display

--- a/modules/nexus/pages/panels/LauncherPanel.qml
+++ b/modules/nexus/pages/panels/LauncherPanel.qml
@@ -3,10 +3,17 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
 import qs.modules.nexus.common
 
 PageBase {
     id: root
+
+    function normaliseActionPrefix(prefix: string): string {
+        return /^[^a-zA-Z0-9\s]$/.test(prefix) ? prefix : ">";
+    }
 
     title: qsTr("Launcher")
     isSubPage: true
@@ -31,11 +38,82 @@ PageBase {
         }
 
         ToggleRow {
-            last: true
             text: qsTr("Show on hover")
             subtext: qsTr("Reveal when the cursor reaches the screen edge")
             checked: Config.launcher.showOnHover
             onToggled: GlobalConfig.launcher.showOnHover = checked
+        }
+
+        Item {
+            Layout.fillWidth: true
+            Layout.preferredHeight: contentRow.implicitHeight + Tokens.padding.medium * 2
+
+            ConnectedRect {
+                id: bg
+
+                anchors.fill: parent
+                last: true
+            }
+
+            RowLayout {
+                id: contentRow
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.leftMargin: Tokens.padding.largeIncreased
+                anchors.rightMargin: Tokens.padding.medium
+                spacing: Tokens.spacing.medium
+
+                Column {
+                    Layout.fillWidth: true
+                    spacing: 0
+
+                    StyledText {
+                        text: qsTr("Action Prefix")
+                        font: Tokens.font.body.small
+                        elide: Text.ElideRight
+                    }
+
+                    StyledText {
+                        text: qsTr("Prefix used to run actions in the launcher")
+                        font: Tokens.font.label.small
+                        color: Colours.palette.m3outline
+                        elide: Text.ElideRight
+                    }
+                }
+
+                StyledTextField {
+                    id: prefixInput
+
+                    function saveActionPrefix(): void {
+                        const prefix = root.normaliseActionPrefix(text);
+                        GlobalConfig.launcher.actionPrefix = prefix;
+                        if (prefix === ">" && text)
+                            clear();
+                    }
+
+                    Layout.preferredWidth: 100
+                    Layout.alignment: Qt.AlignVCenter
+                    text: {
+                        const normalised = root.normaliseActionPrefix(GlobalConfig.launcher.actionPrefix);
+                        return normalised === ">" ? "" : normalised;
+                    }
+                    placeholderText: ">"
+                    maximumLength: 1
+                    validator: RegularExpressionValidator {
+                        regularExpression: /^$|^[^a-zA-Z0-9\s]$/
+                    }
+
+                    onTextEdited: saveActionPrefix()
+                    onEditingFinished: saveActionPrefix()
+                    Component.onCompleted: {
+                        const prefix = root.normaliseActionPrefix(GlobalConfig.launcher.actionPrefix);
+                        if (GlobalConfig.launcher.actionPrefix !== prefix)
+                            GlobalConfig.launcher.actionPrefix = prefix;
+                    }
+                }
+            }
         }
 
         // Display

--- a/modules/nexus/pages/panels/LauncherPanel.qml
+++ b/modules/nexus/pages/panels/LauncherPanel.qml
@@ -3,17 +3,10 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import Caelestia.Config
-import qs.components
-import qs.components.controls
-import qs.services
 import qs.modules.nexus.common
 
 PageBase {
     id: root
-
-    function normaliseActionPrefix(prefix: string): string {
-        return /^[^a-zA-Z0-9\s]$/.test(prefix) ? prefix : ">";
-    }
 
     title: qsTr("Launcher")
     isSubPage: true
@@ -44,75 +37,27 @@ PageBase {
             onToggled: GlobalConfig.launcher.showOnHover = checked
         }
 
-        Item {
-            Layout.fillWidth: true
-            Layout.preferredHeight: contentRow.implicitHeight + Tokens.padding.medium + (Tokens.padding.large - Tokens.padding.small) * 2
+        TextFieldRow {
+            id: prefixRow
 
-            ConnectedRect {
-                id: bg
-
-                anchors.fill: parent
-                last: true
+            function saveActionPrefix(): void {
+                GlobalConfig.launcher.actionPrefix = value;
+                if (GlobalConfig.launcher.actionPrefix === ">")
+                    clear();
             }
 
-            RowLayout {
-                id: contentRow
+            last: true
+            label: qsTr("Action Prefix")
+            subtext: qsTr("Prefix used to run actions in the launcher")
+            fieldWidth: 70
+            value: GlobalConfig.launcher.actionPrefix === ">" ? "" : GlobalConfig.launcher.actionPrefix
+            placeholderText: ">"
+            errorText: qsTr("Cannot be alphanumeric")
+            maximumLength: 1
+            validate: /^$|^[^a-zA-Z0-9\s]$/
 
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.verticalCenter: parent.verticalCenter
-                anchors.leftMargin: Tokens.padding.largeIncreased
-                anchors.rightMargin: Tokens.padding.medium
-                spacing: Tokens.spacing.medium
-
-                Column {
-                    Layout.fillWidth: true
-                    spacing: 0
-
-                    StyledText {
-                        text: qsTr("Action Prefix")
-                        font: Tokens.font.body.small
-                        elide: Text.ElideRight
-                    }
-
-                    StyledText {
-                        text: qsTr("Prefix used to run actions in the launcher")
-                        font: Tokens.font.label.small
-                        color: Colours.palette.m3outline
-                        elide: Text.ElideRight
-                    }
-                }
-
-                StyledTextField {
-                    id: prefixInput
-
-                    function saveActionPrefix(): void {
-                        const prefix = root.normaliseActionPrefix(text);
-                        GlobalConfig.launcher.actionPrefix = prefix;
-                        if (prefix === ">" && text)
-                            clear();
-                    }
-
-                    Layout.preferredWidth: 70
-                    Layout.alignment: Qt.AlignVCenter
-                    verticalPadding: Tokens.padding.small
-                    text: {
-                        const prefix = root.normaliseActionPrefix(GlobalConfig.launcher.actionPrefix);
-                        return prefix === ">" ? "" : prefix;
-                    }
-                    placeholderText: ">"
-                    maximumLength: 1
-                    validate: /^$|^[^a-zA-Z0-9\s]$/
-
-                    onTextEdited: saveActionPrefix()
-                    onEditingFinished: saveActionPrefix()
-                    Component.onCompleted: {
-                        const prefix = root.normaliseActionPrefix(GlobalConfig.launcher.actionPrefix);
-                        if (GlobalConfig.launcher.actionPrefix !== prefix)
-                            GlobalConfig.launcher.actionPrefix = prefix;
-                    }
-                }
-            }
+            onValueEdited: saveActionPrefix()
+            onEditingFinished: saveActionPrefix()
         }
 
         // Display

--- a/modules/nexus/pages/panels/LauncherPanel.qml
+++ b/modules/nexus/pages/panels/LauncherPanel.qml
@@ -47,14 +47,14 @@ PageBase {
             }
 
             last: true
-            label: qsTr("Action Prefix")
+            label: qsTr("Action prefix")
             subtext: qsTr("Prefix used to run actions in the launcher")
             fieldWidth: 70
             value: GlobalConfig.launcher.actionPrefix === ">" ? "" : GlobalConfig.launcher.actionPrefix
             placeholderText: ">"
             errorText: qsTr("Cannot be alphanumeric")
             maximumLength: 1
-            validate: /^$|^[^a-zA-Z0-9\s]$/
+            validate: /^[^a-zA-Z0-9\s]$/
 
             onValueEdited: saveActionPrefix()
             onEditingFinished: saveActionPrefix()

--- a/modules/nexus/pages/panels/LauncherPanel.qml
+++ b/modules/nexus/pages/panels/LauncherPanel.qml
@@ -46,7 +46,7 @@ PageBase {
 
         Item {
             Layout.fillWidth: true
-            Layout.preferredHeight: contentRow.implicitHeight + Tokens.padding.medium * 2
+            Layout.preferredHeight: contentRow.implicitHeight + Tokens.padding.medium + (Tokens.padding.large - Tokens.padding.small) * 2
 
             ConnectedRect {
                 id: bg
@@ -93,17 +93,16 @@ PageBase {
                             clear();
                     }
 
-                    Layout.preferredWidth: 100
+                    Layout.preferredWidth: 70
                     Layout.alignment: Qt.AlignVCenter
+                    verticalPadding: Tokens.padding.small
                     text: {
-                        const normalised = root.normaliseActionPrefix(GlobalConfig.launcher.actionPrefix);
-                        return normalised === ">" ? "" : normalised;
+                        const prefix = root.normaliseActionPrefix(GlobalConfig.launcher.actionPrefix);
+                        return prefix === ">" ? "" : prefix;
                     }
                     placeholderText: ">"
                     maximumLength: 1
-                    validator: RegularExpressionValidator {
-                        regularExpression: /^$|^[^a-zA-Z0-9\s]$/
-                    }
+                    validate: /^$|^[^a-zA-Z0-9\s]$/
 
                     onTextEdited: saveActionPrefix()
                     onEditingFinished: saveActionPrefix()

--- a/plugin/src/Caelestia/Config/tokens.hpp
+++ b/plugin/src/Caelestia/Config/tokens.hpp
@@ -328,7 +328,8 @@ class NexusTokens : public ConfigObject {
     CONFIG_PROPERTY(int, networkShowVpnDetailWidth, 620)
     CONFIG_PROPERTY(int, maxDialogWidth, 400)
     CONFIG_PROPERTY(int, maxDialogHeight, 600)
-    CONFIG_PROPERTY(int, textFieldWidth, 400)
+    CONFIG_PROPERTY(int, textFieldWidth, 250)
+    CONFIG_PROPERTY(int, smallTextFieldWidth, 100)
 
 public:
     explicit NexusTokens(QObject* parent = nullptr)

--- a/plugin/src/Caelestia/Config/tokens.hpp
+++ b/plugin/src/Caelestia/Config/tokens.hpp
@@ -328,6 +328,7 @@ class NexusTokens : public ConfigObject {
     CONFIG_PROPERTY(int, networkShowVpnDetailWidth, 620)
     CONFIG_PROPERTY(int, maxDialogWidth, 400)
     CONFIG_PROPERTY(int, maxDialogHeight, 600)
+    CONFIG_PROPERTY(int, textFieldWidth, 400)
 
 public:
     explicit NexusTokens(QObject* parent = nullptr)


### PR DESCRIPTION
## Summary

Adds a field in `LauncherPanel.qml` for configuring the `launcher.actionPrefix` property of `shell.json` inside nexus. This adds support for one of the few remaining launcher settings that are currently absent from nexus' launcher panel (the others being actions and `specialPrefix`).

Closes caelestia-dots/shell#1787.

- defaults to `>`
- limits input to one character, disallowing [a-zA-Z0-9\s]
- saves input when a valid symbol is entered, so changes persist even if nexus is closed without the field losing focus or pressing enter

**Note:** I haven't included a field for `specialPrefix` since I was unsure if it should be a part of the panel as well. If it should also be configurable in nexus, I can tack it on to this PR as well since it's nearly identical in implementation to `actionPrefix`.

## Testing

- Builds successfully
- Passed `qmlformat` and linting checks
- Ensured prefix is saved when nexus is closed while editing
- Verified changes persist to `shell.json`
- Tested manually inputting the default prefix, using a different prefix, and reverting changes as shown in recording

[Demo Video](https://cdn.dxnny.dev/imgs/9oBuLDxJzVOo.mp4)