### PR TITLE
feat(bar): add option for hiding empty + inactive workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ For example, to automatically hide the bar on the monitor named `DP-1`:
             "shown": 5,
             "activeIndicator": true,
             "occupiedBg": false,
+            "showUnoccupied": true,
             "showWindows": true,
             "showWindowsOnSpecialWorkspaces": true,
             "maxWindowIcons": 5,

--- a/modules/bar/components/workspaces/ActiveIndicator.qml
+++ b/modules/bar/components/workspaces/ActiveIndicator.qml
@@ -13,33 +13,66 @@ StyledRect {
     required property Repeater workspaces
     required property Item mask
     required property bool fullscreen
+    required property bool layoutTransitionRunning
 
-    readonly property int currentWsIdx: {
-        let i = activeWsId - 1;
-        while (i < 0)
-            i += Config.bar.workspaces.shown;
-        return i % Config.bar.workspaces.shown;
-    }
+    property int currentWsIdx: -1
+    property int lastWs: -1
 
-    property real leading: workspaces.count > 0 ? workspaces.itemAt(currentWsIdx)?.y ?? 0 : 0
-    property real trailing: workspaces.count > 0 ? workspaces.itemAt(currentWsIdx)?.y ?? 0 : 0
-    property real currentSize: workspaces.count > 0 ? (workspaces.itemAt(currentWsIdx) as Workspace)?.size ?? 0 : 0
+    property real leading: workspaceOffset(currentWsIdx)
+    property real trailing: workspaceOffset(currentWsIdx)
+    property real currentSize: (workspaces.itemAt(currentWsIdx) as Workspace)?.size ?? 0
     property real offset: Math.min(leading, trailing)
     property real size: {
         const s = Math.abs(leading - trailing) + currentSize;
         if (Config.bar.workspaces.activeTrail && lastWs > currentWsIdx) {
             const ws = workspaces.itemAt(lastWs) as Workspace;
-            return ws ? Math.min(ws.y + ws.size - offset, s) : 0;
+            return ws ? Math.min(workspaceOffset(lastWs) + ws.size - offset, s) : 0;
         }
         return s;
     }
 
-    property int cWs
-    property int lastWs
+    property bool ready: false
+    property bool workspaceSwitchRunning: false
+    readonly property bool geometryAnimationEnabled: ready && (!layoutTransitionRunning || workspaceSwitchRunning)
 
-    onCurrentWsIdxChanged: {
-        lastWs = cWs;
-        cWs = currentWsIdx;
+    function workspaceIndex(id: int): int {
+        let index = id - 1;
+
+        while (index < 0)
+            index += Config.bar.workspaces.shown;
+
+        return index % Config.bar.workspaces.shown;
+    }
+
+    function workspaceOffset(index: int): real {
+        if (index < 0)
+            return 0;
+
+        const ws = workspaces.itemAt(index) as Workspace;
+        return ws ? (workspaceSwitchRunning ? ws.targetY : ws.y) : 0;
+    }
+
+    function updateCurrentWorkspace(withAnimation: bool): void {
+        const nextIndex = workspaceIndex(activeWsId);
+        if (nextIndex === currentWsIdx)
+            return;
+
+        if (withAnimation) {
+            workspaceSwitchRunning = true;
+            lastWs = currentWsIdx;
+        } else {
+            lastWs = nextIndex;
+        }
+
+        currentWsIdx = nextIndex;
+
+        if (withAnimation)
+            workspaceSwitchTimer.restart();
+    }
+
+    onActiveWsIdChanged: {
+        if (ready)
+            updateCurrentWorkspace(true);
     }
 
     clip: true
@@ -48,6 +81,11 @@ StyledRect {
     implicitHeight: size
     radius: Tokens.rounding.full
     color: Colours.palette.m3primary
+
+    Component.onCompleted: {
+        updateCurrentWorkspace(false);
+        ready = true;
+    }
 
     Colouriser {
         source: root.mask
@@ -63,13 +101,13 @@ StyledRect {
     }
 
     Behavior on leading {
-        enabled: root.Config.bar.workspaces.activeTrail
+        enabled: root.Config.bar.workspaces.activeTrail && root.geometryAnimationEnabled
 
         EAnim {}
     }
 
     Behavior on trailing {
-        enabled: root.Config.bar.workspaces.activeTrail
+        enabled: root.Config.bar.workspaces.activeTrail && root.geometryAnimationEnabled
 
         EAnim {
             duration: Tokens.anim.durations.normal * 2
@@ -77,21 +115,28 @@ StyledRect {
     }
 
     Behavior on currentSize {
-        enabled: root.Config.bar.workspaces.activeTrail
+        enabled: root.Config.bar.workspaces.activeTrail && root.geometryAnimationEnabled
 
         EAnim {}
     }
 
     Behavior on offset {
-        enabled: !root.Config.bar.workspaces.activeTrail
+        enabled: !root.Config.bar.workspaces.activeTrail && root.geometryAnimationEnabled
 
         EAnim {}
     }
 
     Behavior on size {
-        enabled: !root.Config.bar.workspaces.activeTrail
+        enabled: !root.Config.bar.workspaces.activeTrail && root.geometryAnimationEnabled
 
         EAnim {}
+    }
+
+    Timer {
+        id: workspaceSwitchTimer
+
+        interval: root.Config.bar.workspaces.activeTrail ? Tokens.anim.durations.normal * 2 : Tokens.anim.durations.normal
+        onTriggered: root.workspaceSwitchRunning = false
     }
 
     component EAnim: Anim {

--- a/modules/bar/components/workspaces/ActiveIndicator.qml
+++ b/modules/bar/components/workspaces/ActiveIndicator.qml
@@ -18,9 +18,10 @@ StyledRect {
 
     property int currentWsId: -1
     readonly property int currentWsIdx: currentWsId < 0 ? -1 : workspaceIndex(currentWsId)
+    property int switchWsIdx: -1
 
-    property real leading: workspaceOffset(currentWsIdx)
-    property real trailing: workspaceOffset(currentWsIdx)
+    property real leading: workspaceOffset(switchWsIdx < 0 ? currentWsIdx : switchWsIdx)
+    property real trailing: workspaceOffset(switchWsIdx < 0 ? currentWsIdx : switchWsIdx)
     property real currentSize: {
         workspaces.count;
         return (workspaces.itemAt(currentWsIdx) as Workspace)?.size ?? 0;
@@ -34,7 +35,12 @@ StyledRect {
         }
         return naturalSize;
     }
-    property real trailEnd: 0
+    property int trailWsIdx: -1
+    readonly property real trailEnd: {
+        workspaces.count;
+        const ws = workspaces.itemAt(trailWsIdx) as Workspace;
+        return ws ? ws.y + ws.height : 0;
+    }
     property bool clampTrailEnd: false
 
     property bool ready: false
@@ -48,7 +54,7 @@ StyledRect {
             return 0;
 
         const ws = workspaces.itemAt(index) as Workspace;
-        return ws ? (workspaceSwitchRunning ? ws.targetY : ws.y) : 0;
+        return ws ? (switchWsIdx >= 0 ? ws.targetY : ws.y) : 0;
     }
 
     function updateCurrentWorkspace(withAnimation: bool): void {
@@ -58,27 +64,25 @@ StyledRect {
         const nextIndex = workspaceIndex(activeWsId);
         const nextWorkspace = workspaces.itemAt(nextIndex) as Workspace;
 
-        const previousOffset = offset;
-        const previousEnd = previousOffset + size;
-
         if (withAnimation) {
-            trailEnd = previousEnd;
-            clampTrailEnd = Config.bar.workspaces.activeTrail && !!nextWorkspace && nextWorkspace.targetY < previousOffset;
+            trailWsIdx = currentWsIdx;
+            clampTrailEnd = !!nextWorkspace && nextWorkspace.targetY <= offset;
             workspaceSwitchRunning = true;
-        } else {
-            endWorkspaceSwitch();
-        }
+            switchWsIdx = nextIndex;
+            currentWsId = activeWsId;
 
-        currentWsId = activeWsId;
-
-        if (withAnimation)
             Qt.callLater(() => {
                 if (switchSettled)
                     endWorkspaceSwitch();
             });
+        } else {
+            endWorkspaceSwitch();
+            currentWsId = activeWsId;
+        }
     }
 
     function endWorkspaceSwitch(): void {
+        switchWsIdx = -1;
         workspaceSwitchRunning = false;
         clampTrailEnd = false;
     }

--- a/modules/bar/components/workspaces/ActiveIndicator.qml
+++ b/modules/bar/components/workspaces/ActiveIndicator.qml
@@ -35,6 +35,8 @@ StyledRect {
 
     property bool ready: false
     property bool workspaceSwitchRunning: false
+    readonly property bool switchAnimating: leadingAnim.running || trailingAnim.running || currentSizeAnim.running || offsetAnim.running || sizeAnim.running
+    readonly property bool switchSettled: !switchAnimating && !layoutTransitionRunning
     readonly property bool geometryAnimationEnabled: ready && (!layoutTransitionRunning || workspaceSwitchRunning)
 
     function workspaceIndex(id: int): int {
@@ -69,19 +71,31 @@ StyledRect {
             clampTrailEnd = Config.bar.workspaces.activeTrail && !!nextWorkspace && nextWorkspace.targetY < previousOffset;
             workspaceSwitchRunning = true;
         } else {
-            workspaceSwitchRunning = false;
-            clampTrailEnd = false;
+            endWorkspaceSwitch();
         }
 
         currentWsId = activeWsId;
 
         if (withAnimation)
-            workspaceSwitchTimer.restart();
+            Qt.callLater(() => {
+                if (switchSettled)
+                    endWorkspaceSwitch();
+            });
+    }
+
+    function endWorkspaceSwitch(): void {
+        workspaceSwitchRunning = false;
+        clampTrailEnd = false;
     }
 
     onActiveWsIdChanged: {
         if (ready)
             updateCurrentWorkspace(true);
+    }
+
+    onSwitchSettledChanged: {
+        if (switchSettled)
+            endWorkspaceSwitch();
     }
 
     clip: true
@@ -109,26 +123,20 @@ StyledRect {
         anchors.horizontalCenter: parent.horizontalCenter
     }
 
-    Timer {
-        id: workspaceSwitchTimer
-
-        interval: root.Config.bar.workspaces.activeTrail ? Tokens.anim.durations.normal * 2 : Tokens.anim.durations.normal
-        onTriggered: {
-            root.workspaceSwitchRunning = false;
-            root.clampTrailEnd = false;
-        }
-    }
-
     Behavior on leading {
         enabled: root.Config.bar.workspaces.activeTrail && root.geometryAnimationEnabled
 
-        EAnim {}
+        EAnim {
+            id: leadingAnim
+        }
     }
 
     Behavior on trailing {
         enabled: root.Config.bar.workspaces.activeTrail && root.geometryAnimationEnabled
 
         EAnim {
+            id: trailingAnim
+
             duration: Tokens.anim.durations.normal * 2
         }
     }
@@ -136,19 +144,25 @@ StyledRect {
     Behavior on currentSize {
         enabled: root.Config.bar.workspaces.activeTrail && root.geometryAnimationEnabled
 
-        EAnim {}
+        EAnim {
+            id: currentSizeAnim
+        }
     }
 
     Behavior on offset {
         enabled: !root.Config.bar.workspaces.activeTrail && root.geometryAnimationEnabled
 
-        EAnim {}
+        EAnim {
+            id: offsetAnim
+        }
     }
 
     Behavior on size {
         enabled: !root.Config.bar.workspaces.activeTrail && root.geometryAnimationEnabled
 
-        EAnim {}
+        EAnim {
+            id: sizeAnim
+        }
     }
 
     component EAnim: Anim {

--- a/modules/bar/components/workspaces/ActiveIndicator.qml
+++ b/modules/bar/components/workspaces/ActiveIndicator.qml
@@ -21,7 +21,10 @@ StyledRect {
 
     property real leading: workspaceOffset(currentWsIdx)
     property real trailing: workspaceOffset(currentWsIdx)
-    property real currentSize: (workspaces.itemAt(currentWsIdx) as Workspace)?.size ?? 0
+    property real currentSize: {
+        workspaces.count;
+        return (workspaces.itemAt(currentWsIdx) as Workspace)?.size ?? 0;
+    }
     property real offset: Math.min(leading, trailing)
     property real size: {
         const naturalSize = Math.abs(leading - trailing) + currentSize;

--- a/modules/bar/components/workspaces/ActiveIndicator.qml
+++ b/modules/bar/components/workspaces/ActiveIndicator.qml
@@ -15,21 +15,23 @@ StyledRect {
     required property bool fullscreen
     required property bool layoutTransitionRunning
 
-    property int currentWsIdx: -1
-    property int lastWs: -1
+    property int currentWsId: -1
+    readonly property int currentWsIdx: currentWsId < 0 ? -1 : workspaceIndex(currentWsId)
 
     property real leading: workspaceOffset(currentWsIdx)
     property real trailing: workspaceOffset(currentWsIdx)
     property real currentSize: (workspaces.itemAt(currentWsIdx) as Workspace)?.size ?? 0
     property real offset: Math.min(leading, trailing)
     property real size: {
-        const s = Math.abs(leading - trailing) + currentSize;
-        if (Config.bar.workspaces.activeTrail && lastWs > currentWsIdx) {
-            const ws = workspaces.itemAt(lastWs) as Workspace;
-            return ws ? Math.min(workspaceOffset(lastWs) + ws.size - offset, s) : 0;
+        const naturalSize = Math.abs(leading - trailing) + currentSize;
+        if (Config.bar.workspaces.activeTrail && clampTrailEnd) {
+            const clampedSize = Math.min(trailEnd - offset, naturalSize);
+            return Math.max(currentSize, clampedSize);
         }
-        return s;
+        return naturalSize;
     }
+    property real trailEnd: 0
+    property bool clampTrailEnd: false
 
     property bool ready: false
     property bool workspaceSwitchRunning: false
@@ -45,7 +47,7 @@ StyledRect {
     }
 
     function workspaceOffset(index: int): real {
-        if (index < 0)
+        if (index < 0 || index >= workspaces.count)
             return 0;
 
         const ws = workspaces.itemAt(index) as Workspace;
@@ -53,18 +55,25 @@ StyledRect {
     }
 
     function updateCurrentWorkspace(withAnimation: bool): void {
-        const nextIndex = workspaceIndex(activeWsId);
-        if (nextIndex === currentWsIdx)
+        if (activeWsId === currentWsId)
             return;
 
+        const nextIndex = workspaceIndex(activeWsId);
+        const nextWorkspace = workspaces.itemAt(nextIndex) as Workspace;
+
+        const previousOffset = offset;
+        const previousEnd = previousOffset + size;
+
         if (withAnimation) {
+            trailEnd = previousEnd;
+            clampTrailEnd = Config.bar.workspaces.activeTrail && !!nextWorkspace && nextWorkspace.targetY < previousOffset;
             workspaceSwitchRunning = true;
-            lastWs = currentWsIdx;
         } else {
-            lastWs = nextIndex;
+            workspaceSwitchRunning = false;
+            clampTrailEnd = false;
         }
 
-        currentWsIdx = nextIndex;
+        currentWsId = activeWsId;
 
         if (withAnimation)
             workspaceSwitchTimer.restart();
@@ -100,6 +109,16 @@ StyledRect {
         anchors.horizontalCenter: parent.horizontalCenter
     }
 
+    Timer {
+        id: workspaceSwitchTimer
+
+        interval: root.Config.bar.workspaces.activeTrail ? Tokens.anim.durations.normal * 2 : Tokens.anim.durations.normal
+        onTriggered: {
+            root.workspaceSwitchRunning = false;
+            root.clampTrailEnd = false;
+        }
+    }
+
     Behavior on leading {
         enabled: root.Config.bar.workspaces.activeTrail && root.geometryAnimationEnabled
 
@@ -130,13 +149,6 @@ StyledRect {
         enabled: !root.Config.bar.workspaces.activeTrail && root.geometryAnimationEnabled
 
         EAnim {}
-    }
-
-    Timer {
-        id: workspaceSwitchTimer
-
-        interval: root.Config.bar.workspaces.activeTrail ? Tokens.anim.durations.normal * 2 : Tokens.anim.durations.normal
-        onTriggered: root.workspaceSwitchRunning = false
     }
 
     component EAnim: Anim {

--- a/modules/bar/components/workspaces/ActiveIndicator.qml
+++ b/modules/bar/components/workspaces/ActiveIndicator.qml
@@ -14,6 +14,7 @@ StyledRect {
     required property Item mask
     required property bool fullscreen
     required property bool layoutTransitionRunning
+    required property var workspaceIndex
 
     property int currentWsId: -1
     readonly property int currentWsIdx: currentWsId < 0 ? -1 : workspaceIndex(currentWsId)
@@ -38,15 +39,6 @@ StyledRect {
     readonly property bool switchAnimating: leadingAnim.running || trailingAnim.running || currentSizeAnim.running || offsetAnim.running || sizeAnim.running
     readonly property bool switchSettled: !switchAnimating && !layoutTransitionRunning
     readonly property bool geometryAnimationEnabled: ready && (!layoutTransitionRunning || workspaceSwitchRunning)
-
-    function workspaceIndex(id: int): int {
-        let index = id - 1;
-
-        while (index < 0)
-            index += Config.bar.workspaces.shown;
-
-        return index % Config.bar.workspaces.shown;
-    }
 
     function workspaceOffset(index: int): real {
         if (index < 0 || index >= workspaces.count)

--- a/modules/bar/components/workspaces/OccupiedBg.qml
+++ b/modules/bar/components/workspaces/OccupiedBg.qml
@@ -12,6 +12,7 @@ Item {
     required property Repeater workspaces
     required property var occupied
     required property int groupOffset
+    required property bool layoutTransitionRunning
 
     property list<var> pills: []
 
@@ -81,10 +82,14 @@ Item {
             }
 
             Behavior on y {
+                enabled: !root.layoutTransitionRunning
+
                 Anim {}
             }
 
             Behavior on implicitHeight {
+                enabled: !root.layoutTransitionRunning
+
                 Anim {}
             }
         }

--- a/modules/bar/components/workspaces/OccupiedBg.qml
+++ b/modules/bar/components/workspaces/OccupiedBg.qml
@@ -54,8 +54,14 @@ Item {
 
             required property var modelData
 
-            readonly property Workspace start: root.workspaces.count > 0 ? root.workspaces.itemAt(root.workspaceIndex(modelData.start)) as Workspace ?? null : null
-            readonly property Workspace end: root.workspaces.count > 0 ? root.workspaces.itemAt(root.workspaceIndex(modelData.end)) as Workspace ?? null : null
+            readonly property Workspace start: {
+                root.workspaces.count;
+                return root.workspaces.itemAt(root.workspaceIndex(modelData.start)) as Workspace ?? null;
+            }
+            readonly property Workspace end: {
+                root.workspaces.count;
+                return root.workspaces.itemAt(root.workspaceIndex(modelData.end)) as Workspace ?? null;
+            }
 
             anchors.horizontalCenter: root.horizontalCenter
 

--- a/modules/bar/components/workspaces/OccupiedBg.qml
+++ b/modules/bar/components/workspaces/OccupiedBg.qml
@@ -13,6 +13,7 @@ Item {
     required property var occupied
     required property int groupOffset
     required property bool layoutTransitionRunning
+    required property var workspaceIndex
 
     property list<var> pills: []
 
@@ -53,15 +54,8 @@ Item {
 
             required property var modelData
 
-            readonly property Workspace start: root.workspaces.count > 0 ? root.workspaces.itemAt(getWsIdx(modelData.start)) ?? null : null // qmllint disable incompatible-type
-            readonly property Workspace end: root.workspaces.count > 0 ? root.workspaces.itemAt(getWsIdx(modelData.end)) ?? null : null // qmllint disable incompatible-type
-
-            function getWsIdx(ws: int): int {
-                let i = ws - 1;
-                while (i < 0)
-                    i += Config.bar.workspaces.shown;
-                return i % Config.bar.workspaces.shown;
-            }
+            readonly property Workspace start: root.workspaces.count > 0 ? root.workspaces.itemAt(root.workspaceIndex(modelData.start)) as Workspace ?? null : null
+            readonly property Workspace end: root.workspaces.count > 0 ? root.workspaces.itemAt(root.workspaceIndex(modelData.end)) as Workspace ?? null : null
 
             anchors.horizontalCenter: root.horizontalCenter
 

--- a/modules/bar/components/workspaces/Workspace.qml
+++ b/modules/bar/components/workspaces/Workspace.qml
@@ -18,6 +18,9 @@ ColumnLayout {
     required property int groupOffset
     required property bool shouldShow
 
+    required property Repeater workspaceRepeater
+    required property real layoutSpacing
+
     readonly property bool isWorkspace: true // Flag for finding workspace children
     // Unanimated prop for others to use as reference
     readonly property int size: implicitHeight + (hasWindows ? Tokens.padding.extraSmall : 0)
@@ -29,6 +32,29 @@ ColumnLayout {
     readonly property list<int> focusedShapeList: [MaterialShape.Slanted, MaterialShape.Oval, MaterialShape.Pill, MaterialShape.Triangle, MaterialShape.Arrow, MaterialShape.Diamond, MaterialShape.Pentagon, MaterialShape.Gem, MaterialShape.VerySunny, MaterialShape.Sunny, MaterialShape.Cookie4Sided, MaterialShape.Cookie6Sided, MaterialShape.Cookie7Sided, MaterialShape.Cookie9Sided, MaterialShape.Cookie12Sided, MaterialShape.Clover4Leaf, MaterialShape.SoftBurst, MaterialShape.Ghostish]
 
     readonly property real revealProgress: Math.max(0, Math.min(1, reveal))
+    readonly property bool revealTransitionRunning: revealAnimation.running
+    readonly property real precedingRevealProgress: {
+        let progress = 0;
+
+        for (let i = 0; i < index; ++i) {
+            const workspace = workspaceRepeater.itemAt(i) as Workspace;
+            if (workspace)
+                progress = Math.max(progress, workspace.revealProgress);
+        }
+
+        return progress;
+    }
+    readonly property real targetY: {
+        let offset = 0;
+
+        for (let i = 0; i < index; ++i) {
+            const workspace = workspaceRepeater.itemAt(i) as Workspace;
+            if (workspace?.shouldShow)
+                offset += workspace.size + layoutSpacing;
+        }
+
+        return offset;
+    }
 
     property real reveal: shouldShow ? 1 : 0
     property real animatedSize: size
@@ -46,6 +72,7 @@ ColumnLayout {
 
     Layout.alignment: Qt.AlignHCenter
     Layout.preferredHeight: animatedSize * revealProgress
+    Layout.topMargin: layoutSpacing * Math.min(revealProgress, precedingRevealProgress)
 
     visible: shouldShow || revealProgress > 0
     opacity: revealProgress
@@ -186,14 +213,10 @@ ColumnLayout {
     }
 
     Behavior on reveal {
-        SequentialAnimation {
-            PauseAnimation {
-                duration: (root.shouldShow ? root.index : (root.Config.bar.workspaces.shown - root.index - 1)) * 20
-            }
+        Anim {
+            id: revealAnimation
 
-            Anim {
-                type: root.shouldShow ? Anim.FastEffects : Anim.DefaultEffects
-            }
+            type: Anim.DefaultEffects
         }
     }
 }

--- a/modules/bar/components/workspaces/Workspace.qml
+++ b/modules/bar/components/workspaces/Workspace.qml
@@ -16,6 +16,7 @@ ColumnLayout {
     required property int activeWsId
     required property var occupied
     required property int groupOffset
+    required property bool shouldShow
 
     readonly property bool isWorkspace: true // Flag for finding workspace children
     // Unanimated prop for others to use as reference
@@ -26,6 +27,11 @@ ColumnLayout {
     readonly property bool hasWindows: isOccupied && Config.bar.workspaces.showWindows && (Config.bar.workspaces.maxWindowIcons > 0)
     readonly property bool focused: activeWsId === ws
     readonly property list<int> focusedShapeList: [MaterialShape.Slanted, MaterialShape.Oval, MaterialShape.Pill, MaterialShape.Triangle, MaterialShape.Arrow, MaterialShape.Diamond, MaterialShape.Pentagon, MaterialShape.Gem, MaterialShape.VerySunny, MaterialShape.Sunny, MaterialShape.Cookie4Sided, MaterialShape.Cookie6Sided, MaterialShape.Cookie7Sided, MaterialShape.Cookie9Sided, MaterialShape.Cookie12Sided, MaterialShape.Clover4Leaf, MaterialShape.SoftBurst, MaterialShape.Ghostish]
+
+    readonly property real revealProgress: Math.max(0, Math.min(1, reveal))
+
+    property real reveal: shouldShow ? 1 : 0
+    property real animatedSize: size
 
     function updateShape(): void {
         const shape = indicator.item as MaterialShape;
@@ -39,7 +45,11 @@ ColumnLayout {
     }
 
     Layout.alignment: Qt.AlignHCenter
-    Layout.preferredHeight: size
+    Layout.preferredHeight: animatedSize * revealProgress
+
+    visible: shouldShow || revealProgress > 0
+    opacity: revealProgress
+    clip: true
 
     spacing: 0
 
@@ -171,7 +181,19 @@ ColumnLayout {
         }
     }
 
-    Behavior on Layout.preferredHeight {
+    Behavior on animatedSize {
         Anim {}
+    }
+
+    Behavior on reveal {
+        SequentialAnimation {
+            PauseAnimation {
+                duration: (root.shouldShow ? root.index : (root.Config.bar.workspaces.shown - root.index - 1)) * 20
+            }
+
+            Anim {
+                type: root.shouldShow ? Anim.FastEffects : Anim.DefaultEffects
+            }
+        }
     }
 }

--- a/modules/bar/components/workspaces/Workspaces.qml
+++ b/modules/bar/components/workspaces/Workspaces.qml
@@ -57,14 +57,26 @@ StyledClippingRect {
                 workspaces: workspaces
                 occupied: root.occupied
                 groupOffset: root.groupOffset
+                layoutTransitionRunning: layout.revealTransitionRunning
             }
         }
 
         ColumnLayout {
             id: layout
 
+            readonly property real workspaceSpacing: Math.floor(Tokens.spacing.extraSmall)
+            readonly property bool revealTransitionRunning: {
+                for (let i = 0; i < workspaces.count; ++i) {
+                    const workspace = workspaces.itemAt(i) as Workspace;
+                    if (workspace?.revealTransitionRunning)
+                        return true;
+                }
+
+                return false;
+            }
+
             anchors.centerIn: parent
-            spacing: Math.floor(Tokens.spacing.extraSmall)
+            spacing: 0
 
             Repeater {
                 id: workspaces
@@ -76,6 +88,9 @@ StyledClippingRect {
                     occupied: root.occupied
                     groupOffset: root.groupOffset
                     shouldShow: Config.bar.workspaces.showUnoccupied || isOccupied || Hypr.monitors.values.some(m => m.activeWorkspace?.id === ws)
+
+                    workspaceRepeater: workspaces
+                    layoutSpacing: layout.workspaceSpacing
                 }
             }
         }
@@ -90,6 +105,7 @@ StyledClippingRect {
                 workspaces: workspaces
                 mask: layout
                 fullscreen: root.fullscreen
+                layoutTransitionRunning: layout.revealTransitionRunning
             }
         }
 

--- a/modules/bar/components/workspaces/Workspaces.qml
+++ b/modules/bar/components/workspaces/Workspaces.qml
@@ -75,6 +75,7 @@ StyledClippingRect {
                     activeWsId: root.activeWsId
                     occupied: root.occupied
                     groupOffset: root.groupOffset
+                    visible: Config.bar.workspaces.showUnoccupied || isOccupied || Hypr.monitors.values.some(m => m.activeWorkspace?.id === ws)
                 }
             }
         }

--- a/modules/bar/components/workspaces/Workspaces.qml
+++ b/modules/bar/components/workspaces/Workspaces.qml
@@ -75,7 +75,7 @@ StyledClippingRect {
                     activeWsId: root.activeWsId
                     occupied: root.occupied
                     groupOffset: root.groupOffset
-                    visible: Config.bar.workspaces.showUnoccupied || isOccupied || Hypr.monitors.values.some(m => m.activeWorkspace?.id === ws)
+                    shouldShow: Config.bar.workspaces.showUnoccupied || isOccupied || Hypr.monitors.values.some(m => m.activeWorkspace?.id === ws)
                 }
             }
         }

--- a/modules/bar/components/workspaces/Workspaces.qml
+++ b/modules/bar/components/workspaces/Workspaces.qml
@@ -37,6 +37,13 @@ StyledClippingRect {
 
     property real blur: onSpecial ? 1 : 0
 
+    function workspaceIndex(id: int): int {
+        let index = id - 1;
+        while (index < 0)
+            index += Config.bar.workspaces.shown;
+        return index % Config.bar.workspaces.shown;
+    }
+
     implicitWidth: Tokens.sizes.bar.innerWidth
     implicitHeight: layout.implicitHeight + Tokens.padding.small
 
@@ -68,6 +75,7 @@ StyledClippingRect {
                 occupied: root.occupied
                 groupOffset: root.groupOffset
                 layoutTransitionRunning: root.revealTransitionRunning
+                workspaceIndex: root.workspaceIndex
             }
         }
 
@@ -105,6 +113,7 @@ StyledClippingRect {
                 mask: layout
                 fullscreen: root.fullscreen
                 layoutTransitionRunning: root.revealTransitionRunning
+                workspaceIndex: root.workspaceIndex
             }
         }
 

--- a/modules/bar/components/workspaces/Workspaces.qml
+++ b/modules/bar/components/workspaces/Workspaces.qml
@@ -16,11 +16,14 @@ StyledClippingRect {
 
     readonly property bool onSpecial: (GlobalConfig.bar.workspaces.perMonitorWorkspaces ? Hypr.monitorFor(screen) : Hypr.focusedMonitor)?.lastIpcObject.specialWorkspace?.name !== ""
     readonly property int activeWsId: GlobalConfig.bar.workspaces.perMonitorWorkspaces ? (Hypr.monitorFor(screen).activeWorkspace?.id ?? 1) : Hypr.activeWsId
+    readonly property int monitorWsId: Hypr.monitorFor(screen)?.activeWorkspace?.id ?? -1
 
     readonly property var occupied: {
+        // Other monitors' workspaces count as unoccupied when hiding unoccupied
+        const mon = GlobalConfig.bar.workspaces.perMonitorWorkspaces && !Config.bar.workspaces.showUnoccupied ? Hypr.monitorFor(screen) : null;
         const occ = {};
         for (const ws of Hypr.workspaces.values)
-            occ[ws.id] = ws.lastIpcObject.windows > 0;
+            occ[ws.id] = ws.lastIpcObject.windows > 0 && (!mon || ws.monitor === mon);
         return occ;
     }
     readonly property int groupOffset: Math.floor((activeWsId - 1) / Config.bar.workspaces.shown) * Config.bar.workspaces.shown
@@ -94,7 +97,7 @@ StyledClippingRect {
                     activeWsId: root.activeWsId
                     occupied: root.occupied
                     groupOffset: root.groupOffset
-                    shouldShow: Config.bar.workspaces.showUnoccupied || isOccupied || Hypr.monitors.values.some(m => m.activeWorkspace?.id === ws)
+                    shouldShow: Config.bar.workspaces.showUnoccupied || isOccupied || ws === root.activeWsId || ws === root.monitorWsId
 
                     workspaceRepeater: workspaces
                     layoutSpacing: root.workspaceSpacing

--- a/modules/bar/components/workspaces/Workspaces.qml
+++ b/modules/bar/components/workspaces/Workspaces.qml
@@ -24,6 +24,16 @@ StyledClippingRect {
         return occ;
     }
     readonly property int groupOffset: Math.floor((activeWsId - 1) / Config.bar.workspaces.shown) * Config.bar.workspaces.shown
+    readonly property real workspaceSpacing: Math.floor(Tokens.spacing.extraSmall)
+    readonly property bool revealTransitionRunning: {
+        for (let i = 0; i < workspaces.count; ++i) {
+            const workspace = workspaces.itemAt(i) as Workspace;
+            if (workspace?.revealTransitionRunning)
+                return true;
+        }
+
+        return false;
+    }
 
     property real blur: onSpecial ? 1 : 0
 
@@ -57,23 +67,12 @@ StyledClippingRect {
                 workspaces: workspaces
                 occupied: root.occupied
                 groupOffset: root.groupOffset
-                layoutTransitionRunning: layout.revealTransitionRunning
+                layoutTransitionRunning: root.revealTransitionRunning
             }
         }
 
         ColumnLayout {
             id: layout
-
-            readonly property real workspaceSpacing: Math.floor(Tokens.spacing.extraSmall)
-            readonly property bool revealTransitionRunning: {
-                for (let i = 0; i < workspaces.count; ++i) {
-                    const workspace = workspaces.itemAt(i) as Workspace;
-                    if (workspace?.revealTransitionRunning)
-                        return true;
-                }
-
-                return false;
-            }
 
             anchors.centerIn: parent
             spacing: 0
@@ -90,7 +89,7 @@ StyledClippingRect {
                     shouldShow: Config.bar.workspaces.showUnoccupied || isOccupied || Hypr.monitors.values.some(m => m.activeWorkspace?.id === ws)
 
                     workspaceRepeater: workspaces
-                    layoutSpacing: layout.workspaceSpacing
+                    layoutSpacing: root.workspaceSpacing
                 }
             }
         }
@@ -105,7 +104,7 @@ StyledClippingRect {
                 workspaces: workspaces
                 mask: layout
                 fullscreen: root.fullscreen
-                layoutTransitionRunning: layout.revealTransitionRunning
+                layoutTransitionRunning: root.revealTransitionRunning
             }
         }
 

--- a/modules/nexus/pages/panels/taskbar/BarWorkspaces.qml
+++ b/modules/nexus/pages/panels/taskbar/BarWorkspaces.qml
@@ -55,6 +55,13 @@ PageBase {
         }
 
         ToggleRow {
+            text: Tr.tr("Show unoccupied")
+            subtext: Tr.tr("Show workspaces that are inactive and empty")
+            checked: Config.bar.workspaces.showUnoccupied
+            onToggled: GlobalConfig.bar.workspaces.showUnoccupied = checked
+        }
+
+        ToggleRow {
             text: Tr.tr("Windows on special workspaces")
             checked: Config.bar.workspaces.showWindowsOnSpecialWorkspaces
             onToggled: GlobalConfig.bar.workspaces.showWindowsOnSpecialWorkspaces = checked

--- a/plugin/src/Caelestia/Config/barconfig.hpp
+++ b/plugin/src/Caelestia/Config/barconfig.hpp
@@ -35,6 +35,7 @@ class BarWorkspaces : public settings::ObjectNode {
     CONFIG_PROPERTY(int, shown, 5)
     CONFIG_PROPERTY(bool, activeIndicator, true)
     CONFIG_PROPERTY(bool, occupiedBg, false)
+    CONFIG_PROPERTY(bool, showUnoccupied, true)
     CONFIG_PROPERTY(bool, showWindows, true)
     CONFIG_PROPERTY(bool, showWindowsOnSpecialWorkspaces, true)
     CONFIG_PROPERTY(int, maxWindowIcons, 5)


### PR DESCRIPTION
## Summary

Adds a `bar.workspaces.showUnoccupied` property to `shell.json` for hiding workspaces that are both inactive and empty. This allows users with a larger `bar.workspaces.shown` value to keep used workspaces visible without reserving space for ones that are unused.

Closes #694.

- defaults to `true`, preserving the existing behavior
- when disabled, hides workspaces with no windows and still keeps the active workspace on every monitor visible
- adds a toggle for the option to the workspaces panel in nexus
- retains the existing workspace model so things like active indicators and occupied backgrounds remain unchanged
- documents the new option in the example configuration of the `README.md`

## Testing

- Builds successfully
- Passed `qmlformat` and linting checks
- Verified that workspaces with no windows that are not active on any monitor are hidden
- Tested the toggle behavior of the option in nexus