### PR TITLE
feat: add config lists

### DIFF
--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -107,7 +107,7 @@ ColumnLayout {
         id: repeater
 
         model: ScriptModel {
-            values: root.Config.bar.entries.filter(e => e.enabled ?? true)
+            values: root.Config.bar.entries.values.filter(e => e.enabled)
         }
 
         DelegateChooser {

--- a/plugin/src/Caelestia/Config/CMakeLists.txt
+++ b/plugin/src/Caelestia/Config/CMakeLists.txt
@@ -3,6 +3,8 @@ qml_module(caelestia-config
     SOURCES
         config.cpp
         configattached.cpp
+        configlist.cpp
+        confignode.cpp
         configobject.cpp
         rootconfig.cpp
         appearanceconfig.cpp

--- a/plugin/src/Caelestia/Config/barconfig.hpp
+++ b/plugin/src/Caelestia/Config/barconfig.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include "configlist.hpp"
 #include "configobject.hpp"
 
+#include <qjsonarray.h>
+#include <qjsonobject.h>
 #include <qstring.h>
 #include <qstringlist.h>
 #include <qvariant.h>
@@ -9,6 +12,30 @@
 namespace caelestia::config {
 
 using Qt::StringLiterals::operator""_s;
+
+class BarEntry : public ConfigObject {
+    Q_OBJECT
+    QML_ANONYMOUS
+
+    CONFIG_PROPERTY(QString, id)
+    CONFIG_PROPERTY(bool, enabled, true)
+
+public:
+    explicit BarEntry(QObject* parent = nullptr)
+        : ConfigObject(parent) {}
+};
+
+CONFIG_LIST_TYPE(BarEntry, BarEntryList)
+
+inline QJsonArray defaultBarEntries() {
+    QJsonArray entries;
+
+    for (const auto& id : { u"logo"_s, u"workspaces"_s, u"spacer"_s, u"activeWindow"_s, u"spacer"_s, u"tray"_s,
+             u"clock"_s, u"statusIcons"_s, u"power"_s })
+        entries.append(QJsonObject{ { u"id"_s, id } });
+
+    return entries;
+}
 
 class BarScrollActions : public ConfigObject {
     Q_OBJECT
@@ -137,18 +164,7 @@ class BarConfig : public ConfigObject {
     CONFIG_SUBOBJECT(BarTray, tray)
     CONFIG_SUBOBJECT(BarStatus, status)
     CONFIG_SUBOBJECT(BarClock, clock)
-    CONFIG_PROPERTY(QVariantList, entries,
-        {
-            vmap({ { u"id"_s, u"logo"_s }, { u"enabled"_s, true } }),
-            vmap({ { u"id"_s, u"workspaces"_s }, { u"enabled"_s, true } }),
-            vmap({ { u"id"_s, u"spacer"_s }, { u"enabled"_s, true } }),
-            vmap({ { u"id"_s, u"activeWindow"_s }, { u"enabled"_s, true } }),
-            vmap({ { u"id"_s, u"spacer"_s }, { u"enabled"_s, true } }),
-            vmap({ { u"id"_s, u"tray"_s }, { u"enabled"_s, true } }),
-            vmap({ { u"id"_s, u"clock"_s }, { u"enabled"_s, true } }),
-            vmap({ { u"id"_s, u"statusIcons"_s }, { u"enabled"_s, true } }),
-            vmap({ { u"id"_s, u"power"_s }, { u"enabled"_s, true } }),
-        })
+    CONFIG_LIST(BarEntryList, entries)
     CONFIG_PROPERTY(QStringList, excludedScreens)
 
 public:
@@ -160,7 +176,8 @@ public:
         , m_activeWindow(new BarActiveWindow(this))
         , m_tray(new BarTray(this))
         , m_status(new BarStatus(this))
-        , m_clock(new BarClock(this)) {}
+        , m_clock(new BarClock(this))
+        , m_entries(new BarEntryList(this, defaultBarEntries())) {}
 };
 
 } // namespace caelestia::config

--- a/plugin/src/Caelestia/Config/barconfig.hpp
+++ b/plugin/src/Caelestia/Config/barconfig.hpp
@@ -3,8 +3,6 @@
 #include "configlist.hpp"
 #include "configobject.hpp"
 
-#include <qjsonarray.h>
-#include <qjsonobject.h>
 #include <qstring.h>
 #include <qstringlist.h>
 #include <qvariant.h>
@@ -26,16 +24,6 @@ public:
 };
 
 CONFIG_LIST_TYPE(BarEntry, BarEntryList)
-
-inline QJsonArray defaultBarEntries() {
-    QJsonArray entries;
-
-    for (const auto& id : { u"logo"_s, u"workspaces"_s, u"spacer"_s, u"activeWindow"_s, u"spacer"_s, u"tray"_s,
-             u"clock"_s, u"statusIcons"_s, u"power"_s })
-        entries.append(QJsonObject{ { u"id"_s, id } });
-
-    return entries;
-}
 
 class BarScrollActions : public ConfigObject {
     Q_OBJECT
@@ -164,7 +152,18 @@ class BarConfig : public ConfigObject {
     CONFIG_SUBOBJECT(BarTray, tray)
     CONFIG_SUBOBJECT(BarStatus, status)
     CONFIG_SUBOBJECT(BarClock, clock)
-    CONFIG_LIST(BarEntryList, entries)
+    CONFIG_LIST(BarEntryList, entries,
+        {
+            vmap({ { u"id"_s, u"logo"_s } }),
+            vmap({ { u"id"_s, u"workspaces"_s } }),
+            vmap({ { u"id"_s, u"spacer"_s } }),
+            vmap({ { u"id"_s, u"activeWindow"_s } }),
+            vmap({ { u"id"_s, u"spacer"_s } }),
+            vmap({ { u"id"_s, u"tray"_s } }),
+            vmap({ { u"id"_s, u"clock"_s } }),
+            vmap({ { u"id"_s, u"statusIcons"_s } }),
+            vmap({ { u"id"_s, u"power"_s } }),
+        })
     CONFIG_PROPERTY(QStringList, excludedScreens)
 
 public:
@@ -176,8 +175,7 @@ public:
         , m_activeWindow(new BarActiveWindow(this))
         , m_tray(new BarTray(this))
         , m_status(new BarStatus(this))
-        , m_clock(new BarClock(this))
-        , m_entries(new BarEntryList(this, defaultBarEntries())) {}
+        , m_clock(new BarClock(this)) {}
 };
 
 } // namespace caelestia::config

--- a/plugin/src/Caelestia/Config/configlist.cpp
+++ b/plugin/src/Caelestia/Config/configlist.cpp
@@ -148,6 +148,15 @@ void ConfigList::onGlobalPropertiesChanged(const QMap<QString, QVariant>&) {
     syncValuesFromGlobal();
 }
 
+QString ConfigList::childPath(const ConfigNode* child) const {
+    // Position is how an element is addressed, correct at the moment it is asked for
+    for (int i = 0; i < m_items.size(); ++i)
+        if (m_items.at(i) == child)
+            return u"[%1]"_s.arg(i);
+
+    return {};
+}
+
 void ConfigList::populate(const QJsonArray& arr) {
     destroyItems();
 

--- a/plugin/src/Caelestia/Config/configlist.cpp
+++ b/plugin/src/Caelestia/Config/configlist.cpp
@@ -145,7 +145,8 @@ QJsonArray ConfigList::elementsToJson() const {
 }
 
 void ConfigList::resetToDefaults() {
-    populate(m_defaults);
+    // Quiet, seeding defaults is not a change and would dirty the config before the file is read
+    loadFromJsonQuietly(m_defaults);
     m_loaded = false;
 }
 

--- a/plugin/src/Caelestia/Config/configlist.cpp
+++ b/plugin/src/Caelestia/Config/configlist.cpp
@@ -176,12 +176,30 @@ QString ConfigList::childPath(const ConfigNode* child) const {
 }
 
 void ConfigList::populate(const QJsonArray& arr) {
-    destroyItems();
+    // Every reload runs through here, so an edit elsewhere in the file must be a no-op
+    const auto current = elementsToJson();
+    if (current == arr)
+        return;
 
-    for (const auto& val : arr)
-        appendItem(val);
+    const auto old = m_items;
+    m_items.clear();
+    m_items.reserve(arr.size());
 
-    emit countChanged();
+    // Reuse elements that didn't change, recreating one resets the delegate bound to it
+    for (int i = 0; i < arr.size(); ++i) {
+        if (i < old.size() && current.at(i) == arr.at(i))
+            m_items.append(old.at(i));
+        else
+            appendItem(arr.at(i));
+    }
+
+    for (int i = 0; i < old.size(); ++i)
+        if (i >= arr.size() || current.at(i) != arr.at(i))
+            destroyItem(old.at(i));
+
+    if (m_items.size() != old.size())
+        emit countChanged();
+
     emit valuesChanged();
 
     // Persistence is gated on m_loaded, not on silence, so defaults still serialise to nothing

--- a/plugin/src/Caelestia/Config/configlist.cpp
+++ b/plugin/src/Caelestia/Config/configlist.cpp
@@ -78,6 +78,11 @@ void ConfigList::clear() {
 }
 
 void ConfigList::loadFromJson(const QJsonValue& json) {
+    if (!json.isArray()) {
+        qCWarning(lcConfig, "Option '%s' must be a list, ignoring", qUtf8Printable(propertyPath()));
+        return;
+    }
+
     populate(json.toArray());
     m_loaded = true;
 }

--- a/plugin/src/Caelestia/Config/configlist.cpp
+++ b/plugin/src/Caelestia/Config/configlist.cpp
@@ -168,9 +168,26 @@ void ConfigList::appendItem(const QJsonValue& json) {
     // Quiet so seeded defaults and synced values don't look like user edits
     item->loadFromJsonQuietly(json);
 
-    connect(item, &ConfigNode::propertiesChanged, this, &ConfigList::onItemChanged);
+    connectItem(item);
 
     m_items.append(item);
+}
+
+void ConfigList::connectItem(ConfigNode* node) {
+    // Whole subtree, an edit to a sub-object of an element must reach the save path
+    connect(node, &ConfigNode::propertiesChanged, this, &ConfigList::onItemChanged);
+
+    const auto children = node->childNodes();
+    for (auto* const child : children)
+        connectItem(child);
+}
+
+void ConfigList::disconnectItem(ConfigNode* node) {
+    node->disconnect(this);
+
+    const auto children = node->childNodes();
+    for (auto* const child : children)
+        disconnectItem(child);
 }
 
 void ConfigList::destroyItems() {
@@ -182,7 +199,7 @@ void ConfigList::destroyItems() {
 
 void ConfigList::destroyItem(ConfigObject* item) {
     // Disconnect first, a queued notification would otherwise mark the list loaded
-    item->disconnect(this);
+    disconnectItem(item);
     item->deleteLater();
 }
 

--- a/plugin/src/Caelestia/Config/configlist.cpp
+++ b/plugin/src/Caelestia/Config/configlist.cpp
@@ -80,23 +80,27 @@ void ConfigList::clear() {
 void ConfigList::loadFromJson(const QJsonValue& json) {
     if (!json.isArray()) {
         qCWarning(lcConfig, "Option '%s' must be a list, ignoring", qUtf8Printable(propertyPath()));
+        m_rejectedJson = json;
         return;
     }
 
+    m_rejectedJson = QJsonValue::Undefined;
     populate(json.toArray());
     m_loaded = true;
 }
 
 QJsonValue ConfigList::toJson() const {
-    if (!m_loaded)
-        return QJsonValue::Undefined;
+    // Checked first so editing a rejected list from QML replaces it
+    if (m_loaded)
+        return elementsToJson();
 
-    return elementsToJson();
+    return m_rejectedJson;
 }
 
 void ConfigList::clearLoadedKeys() {
     // Tracking only like ConfigObject, rebuilding here would drop an overlay to defaults
     m_loaded = false;
+    m_rejectedJson = QJsonValue::Undefined;
 }
 
 QStringList ConfigList::unknownKeys() const {

--- a/plugin/src/Caelestia/Config/configlist.cpp
+++ b/plugin/src/Caelestia/Config/configlist.cpp
@@ -174,12 +174,27 @@ void ConfigList::appendItem(const QJsonValue& json) {
     auto* const item = createItem();
     QQmlEngine::setObjectOwnership(item, QQmlEngine::CppOwnership);
 
+    if (m_items.isEmpty())
+        rejectGlobalOnlyElement(item);
+
     // Quiet so seeded defaults and synced values don't look like user edits
     item->loadFromJsonQuietly(json);
 
     connectItem(item);
 
     m_items.append(item);
+}
+
+void ConfigList::rejectGlobalOnlyElement(const ConfigObject* item) const {
+    // Elements are never overlays, so isGlobalOnly() is always false for them and the
+    // option would be silently persisted per monitor
+    const auto keys = item->globalOnlyKeys();
+    if (keys.isEmpty())
+        return;
+
+    qCCritical(lcConfig,
+        "%s declares global-only options (%s) which do not work inside a list, use CONFIG_GLOBAL_LIST on %s instead",
+        item->metaObject()->className(), qUtf8Printable(keys.join(u", "_s)), metaObject()->className());
 }
 
 void ConfigList::connectItem(ConfigNode* node) {

--- a/plugin/src/Caelestia/Config/configlist.cpp
+++ b/plugin/src/Caelestia/Config/configlist.cpp
@@ -33,7 +33,7 @@ void ConfigList::remove(int index) {
         return;
     }
 
-    delete m_items.takeAt(index);
+    destroyItem(m_items.takeAt(index));
 
     m_loaded = true;
     emit countChanged();
@@ -174,8 +174,16 @@ void ConfigList::appendItem(const QJsonValue& json) {
 }
 
 void ConfigList::destroyItems() {
-    qDeleteAll(m_items);
+    for (auto* const item : std::as_const(m_items))
+        destroyItem(item);
+
     m_items.clear();
+}
+
+void ConfigList::destroyItem(ConfigObject* item) {
+    // Disconnect first, a queued notification would otherwise mark the list loaded
+    item->disconnect(this);
+    item->deleteLater();
 }
 
 void ConfigList::onItemChanged() {

--- a/plugin/src/Caelestia/Config/configlist.cpp
+++ b/plugin/src/Caelestia/Config/configlist.cpp
@@ -8,9 +8,9 @@ namespace caelestia::config {
 
 using Qt::StringLiterals::operator""_s;
 
-ConfigList::ConfigList(QObject* parent, const QJsonArray& defaults)
+ConfigList::ConfigList(QObject* parent, const QVariantList& defaults)
     : ConfigNode(parent)
-    , m_defaults(defaults) {}
+    , m_defaults(QJsonArray::fromVariantList(defaults)) {}
 
 int ConfigList::count() const {
     return static_cast<int>(m_items.size());

--- a/plugin/src/Caelestia/Config/configlist.cpp
+++ b/plugin/src/Caelestia/Config/configlist.cpp
@@ -16,6 +16,14 @@ int ConfigList::count() const {
     return static_cast<int>(m_items.size());
 }
 
+QVariantList ConfigList::values() const {
+    QVariantList vals;
+    vals.reserve(m_items.size());
+    for (auto* const item : m_items)
+        vals.append(QVariant::fromValue(item));
+    return vals;
+}
+
 ConfigObject* ConfigList::itemAt(int index) const {
     if (index < 0 || index >= m_items.size())
         return nullptr;

--- a/plugin/src/Caelestia/Config/configlist.cpp
+++ b/plugin/src/Caelestia/Config/configlist.cpp
@@ -1,0 +1,190 @@
+#include "configlist.hpp"
+
+#include <qjsonobject.h>
+#include <qmetaobject.h>
+#include <qqmlengine.h>
+
+namespace caelestia::config {
+
+using Qt::StringLiterals::operator""_s;
+
+ConfigList::ConfigList(QObject* parent, const QJsonArray& defaults)
+    : ConfigNode(parent)
+    , m_defaults(defaults) {}
+
+int ConfigList::count() const {
+    return static_cast<int>(m_items.size());
+}
+
+ConfigObject* ConfigList::itemAt(int index) const {
+    if (index < 0 || index >= m_items.size())
+        return nullptr;
+
+    return m_items.at(index);
+}
+
+const QList<ConfigObject*>& ConfigList::items() const {
+    return m_items;
+}
+
+void ConfigList::remove(int index) {
+    if (index < 0 || index >= m_items.size()) {
+        qCWarning(lcConfig) << metaObject()->className() << "cannot remove index" << index << "of" << count();
+        return;
+    }
+
+    delete m_items.takeAt(index);
+
+    m_loaded = true;
+    emit countChanged();
+    emit valuesChanged();
+    notifyChanged();
+}
+
+void ConfigList::move(int from, int to) {
+    if (from < 0 || from >= m_items.size() || to < 0 || to >= m_items.size()) {
+        qCWarning(lcConfig) << metaObject()->className() << "cannot move" << from << "to" << to << "of" << count();
+        return;
+    }
+
+    if (from == to)
+        return;
+
+    m_items.move(from, to);
+
+    m_loaded = true;
+    emit valuesChanged();
+    notifyChanged();
+}
+
+void ConfigList::clear() {
+    if (m_items.isEmpty())
+        return;
+
+    destroyItems();
+
+    m_loaded = true;
+    emit countChanged();
+    emit valuesChanged();
+    notifyChanged();
+}
+
+void ConfigList::loadFromJson(const QJsonValue& json) {
+    populate(json.toArray());
+    m_loaded = true;
+}
+
+QJsonValue ConfigList::toJson() const {
+    if (!m_loaded)
+        return QJsonValue::Undefined;
+
+    return elementsToJson();
+}
+
+void ConfigList::clearLoadedKeys() {
+    // Tracking only like ConfigObject, rebuilding here would drop an overlay to defaults
+    m_loaded = false;
+}
+
+QStringList ConfigList::unknownKeys() const {
+    QStringList keys;
+
+    for (int i = 0; i < m_items.size(); ++i) {
+        const auto childKeys = m_items.at(i)->unknownKeys();
+        for (const auto& childKey : childKeys)
+            keys.append(joinPath(u"[%1]"_s.arg(i), childKey));
+    }
+
+    return keys;
+}
+
+void ConfigList::resyncFromGlobal() {
+    syncValuesFromGlobal();
+}
+
+ConfigObject* ConfigList::insertItem(const QVariantMap& props, int index) {
+    const auto pos = index < 0 || index > m_items.size() ? m_items.size() : index;
+
+    appendItem(QJsonObject::fromVariantMap(props));
+    m_items.move(m_items.size() - 1, pos);
+
+    auto* const item = m_items.at(pos);
+    const auto unknown = item->unknownKeys();
+    for (const auto& key : unknown)
+        qCWarning(lcConfig) << "Unknown option" << key << "for" << item->metaObject()->className();
+
+    m_loaded = true;
+    emit countChanged();
+    emit valuesChanged();
+    notifyChanged();
+
+    return item;
+}
+
+QJsonArray ConfigList::elementsToJson() const {
+    QJsonArray arr;
+
+    // Position is identity in a list, so every element is written even when empty
+    for (auto* const item : m_items)
+        arr.append(item->toJson().toObject());
+
+    return arr;
+}
+
+void ConfigList::resetToDefaults() {
+    populate(m_defaults);
+    m_loaded = false;
+}
+
+void ConfigList::syncValuesFromGlobal() {
+    if (m_loaded)
+        return;
+
+    if (auto* const global = qobject_cast<ConfigList*>(m_global))
+        populate(global->elementsToJson());
+}
+
+void ConfigList::onGlobalPropertiesChanged(const QMap<QString, QVariant>&) {
+    syncValuesFromGlobal();
+}
+
+void ConfigList::populate(const QJsonArray& arr) {
+    destroyItems();
+
+    for (const auto& val : arr)
+        appendItem(val);
+
+    emit countChanged();
+    emit valuesChanged();
+
+    // Persistence is gated on m_loaded, not on silence, so defaults still serialise to nothing
+    notifyChanged();
+}
+
+void ConfigList::appendItem(const QJsonValue& json) {
+    auto* const item = createItem();
+    QQmlEngine::setObjectOwnership(item, QQmlEngine::CppOwnership);
+
+    // Quiet so seeded defaults and synced values don't look like user edits
+    item->loadFromJsonQuietly(json);
+
+    connect(item, &ConfigNode::propertiesChanged, this, &ConfigList::onItemChanged);
+
+    m_items.append(item);
+}
+
+void ConfigList::destroyItems() {
+    qDeleteAll(m_items);
+    m_items.clear();
+}
+
+void ConfigList::onItemChanged() {
+    m_loaded = true;
+    notifyChanged();
+}
+
+void ConfigList::notifyChanged() {
+    notifyPropertyChanged(u"values"_s, count());
+}
+
+} // namespace caelestia::config

--- a/plugin/src/Caelestia/Config/configlist.hpp
+++ b/plugin/src/Caelestia/Config/configlist.hpp
@@ -15,7 +15,7 @@ class ConfigList : public ConfigNode {
     Q_PROPERTY(int count READ count NOTIFY countChanged)
 
 public:
-    explicit ConfigList(QObject* parent = nullptr, const QJsonArray& defaults = {});
+    explicit ConfigList(QObject* parent = nullptr, const QVariantList& defaults = {});
 
     [[nodiscard]] int count() const;
     [[nodiscard]] ConfigObject* itemAt(int index) const;
@@ -74,7 +74,7 @@ private:
         Q_PROPERTY(QList<caelestia::config::Element*> values READ values NOTIFY valuesChanged)                         \
                                                                                                                        \
     public:                                                                                                            \
-        explicit Name(QObject* parent = nullptr, const QJsonArray& defaults = {})                                      \
+        explicit Name(QObject* parent = nullptr, const QVariantList& defaults = {})                                    \
             : caelestia::config::ConfigList(parent, defaults) {                                                        \
             resetToDefaults();                                                                                         \
         }                                                                                                              \
@@ -100,5 +100,15 @@ private:
         }                                                                                                              \
     };
 
-// Declares a CONSTANT config list property. Initialize the member in the constructor.
-#define CONFIG_LIST(Type, name) CONFIG_SUBOBJECT(Type, name)
+// Declares a CONSTANT config list property, constructed inline with its defaults.
+// Passing `this` is safe here, bases are built before members and ConfigList only stores the parent.
+#define CONFIG_LIST(Type, name, ...)                                                                                   \
+    Q_PROPERTY(caelestia::config::Type* name READ name CONSTANT)                                                       \
+                                                                                                                       \
+public:                                                                                                                \
+    [[nodiscard]] Type* name() const {                                                                                 \
+        return m_##name;                                                                                               \
+    }                                                                                                                  \
+                                                                                                                       \
+private:                                                                                                               \
+    Type* m_##name = new Type(this __VA_OPT__(, __VA_ARGS__));

--- a/plugin/src/Caelestia/Config/configlist.hpp
+++ b/plugin/src/Caelestia/Config/configlist.hpp
@@ -11,6 +11,7 @@ namespace caelestia::config {
 // in CONFIG_LIST_TYPE since QML only sees what moc sees, and moc can't see templates.
 class ConfigList : public ConfigNode {
     Q_OBJECT
+    QML_ANONYMOUS
 
     Q_PROPERTY(int count READ count NOTIFY countChanged)
 

--- a/plugin/src/Caelestia/Config/configlist.hpp
+++ b/plugin/src/Caelestia/Config/configlist.hpp
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "configobject.hpp"
+
+#include <qjsonarray.h>
+#include <qqmlintegration.h>
+
+namespace caelestia::config {
+
+// A node whose state lives in an ordered list of elements. Element-typed members live
+// in CONFIG_LIST_TYPE since QML only sees what moc sees, and moc can't see templates.
+class ConfigList : public ConfigNode {
+    Q_OBJECT
+
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+
+public:
+    explicit ConfigList(QObject* parent = nullptr, const QJsonArray& defaults = {});
+
+    [[nodiscard]] int count() const;
+    [[nodiscard]] ConfigObject* itemAt(int index) const;
+    [[nodiscard]] const QList<ConfigObject*>& items() const;
+
+    Q_INVOKABLE void remove(int index);
+    Q_INVOKABLE void move(int from, int to);
+    Q_INVOKABLE void clear();
+
+    void loadFromJson(const QJsonValue& json) override;
+    [[nodiscard]] QJsonValue toJson() const override;
+    void clearLoadedKeys() override;
+    [[nodiscard]] QStringList unknownKeys() const override;
+    void resyncFromGlobal() override;
+
+signals:
+    void countChanged();
+    void valuesChanged();
+
+protected:
+    // Supplied by CONFIG_LIST_TYPE, not callable from a ConfigList ctor (vtable incomplete)
+    [[nodiscard]] virtual ConfigObject* createItem() = 0;
+
+    // Called by the generated subclass ctor, once createItem() is callable
+    void resetToDefaults();
+
+    ConfigObject* insertItem(const QVariantMap& props, int index);
+
+    // Elements regardless of loaded state, unlike toJson()
+    [[nodiscard]] QJsonArray elementsToJson() const;
+
+    void syncValuesFromGlobal() override;
+    void onGlobalPropertiesChanged(const QMap<QString, QVariant>& changed) override;
+
+private:
+    void populate(const QJsonArray& arr);
+    void appendItem(const QJsonValue& json);
+    void destroyItems();
+    void onItemChanged();
+    void notifyChanged();
+
+    QJsonArray m_defaults;
+    QList<ConfigObject*> m_items;
+    bool m_loaded = false;
+};
+
+} // namespace caelestia::config
+
+// Declares a ConfigList subclass for an element type. A macro, not a template, since
+// everything it adds carries the element type. Use at namespace scope after the element.
+#define CONFIG_LIST_TYPE(Element, Name)                                                                                \
+    class Name : public caelestia::config::ConfigList {                                                                \
+        Q_OBJECT                                                                                                       \
+        QML_ANONYMOUS                                                                                                  \
+                                                                                                                       \
+        Q_PROPERTY(QList<caelestia::config::Element*> values READ values NOTIFY valuesChanged)                         \
+                                                                                                                       \
+    public:                                                                                                            \
+        explicit Name(QObject* parent = nullptr, const QJsonArray& defaults = {})                                      \
+            : caelestia::config::ConfigList(parent, defaults) {                                                        \
+            resetToDefaults();                                                                                         \
+        }                                                                                                              \
+                                                                                                                       \
+        [[nodiscard]] QList<caelestia::config::Element*> values() const {                                              \
+            QList<caelestia::config::Element*> vals;                                                                   \
+            vals.reserve(items().size());                                                                              \
+            for (auto* const item : items())                                                                           \
+                vals.append(static_cast<caelestia::config::Element*>(item));                                           \
+            return vals;                                                                                               \
+        }                                                                                                              \
+                                                                                                                       \
+        Q_INVOKABLE caelestia::config::Element* at(int index) const {                                                  \
+            return static_cast<caelestia::config::Element*>(itemAt(index));                                            \
+        }                                                                                                              \
+        Q_INVOKABLE caelestia::config::Element* insert(const QVariantMap& props, int index = -1) {                     \
+            return static_cast<caelestia::config::Element*>(insertItem(props, index));                                 \
+        }                                                                                                              \
+                                                                                                                       \
+    protected:                                                                                                         \
+        [[nodiscard]] caelestia::config::ConfigObject* createItem() override {                                         \
+            return new caelestia::config::Element(this);                                                               \
+        }                                                                                                              \
+    };
+
+// Declares a CONSTANT config list property. Initialize the member in the constructor.
+#define CONFIG_LIST(Type, name) CONFIG_SUBOBJECT(Type, name)

--- a/plugin/src/Caelestia/Config/configlist.hpp
+++ b/plugin/src/Caelestia/Config/configlist.hpp
@@ -57,6 +57,7 @@ private:
     void appendItem(const QJsonValue& json);
     void destroyItems();
     void destroyItem(ConfigObject* item);
+    void rejectGlobalOnlyElement(const ConfigObject* item) const;
     void connectItem(ConfigNode* node);
     void disconnectItem(ConfigNode* node);
     void onItemChanged();
@@ -117,3 +118,23 @@ public:                                                                         
                                                                                                                        \
 private:                                                                                                               \
     Type* m_##name = new Type(this __VA_OPT__(, __VA_ARGS__));
+
+// Like CONFIG_LIST but warns on read when accessed on a per-monitor overlay.
+// Global-only belongs on the list, never on a property of its element type.
+#define CONFIG_GLOBAL_LIST(Type, name, ...)                                                                            \
+    Q_PROPERTY(caelestia::config::Type* name READ name CONSTANT)                                                       \
+                                                                                                                       \
+public:                                                                                                                \
+    [[nodiscard]] Type* name() const {                                                                                 \
+        if (isOverlay())                                                                                               \
+            qCWarning(caelestia::config::lcConfig, "Reading global-only option '%s' on per-monitor overlay",           \
+                qUtf8Printable(propertyPath(QStringLiteral(#name))));                                                  \
+        return m_##name;                                                                                               \
+    }                                                                                                                  \
+                                                                                                                       \
+private:                                                                                                               \
+    Type* m_##name = new Type(this __VA_OPT__(, __VA_ARGS__));                                                         \
+    const bool m_##name##_go = [this] {                                                                                \
+        markGlobalOnly(QStringLiteral(#name));                                                                         \
+        return true;                                                                                                   \
+    }();

--- a/plugin/src/Caelestia/Config/configlist.hpp
+++ b/plugin/src/Caelestia/Config/configlist.hpp
@@ -54,6 +54,7 @@ private:
     void populate(const QJsonArray& arr);
     void appendItem(const QJsonValue& json);
     void destroyItems();
+    void destroyItem(ConfigObject* item);
     void onItemChanged();
     void notifyChanged();
 

--- a/plugin/src/Caelestia/Config/configlist.hpp
+++ b/plugin/src/Caelestia/Config/configlist.hpp
@@ -56,6 +56,8 @@ private:
     void appendItem(const QJsonValue& json);
     void destroyItems();
     void destroyItem(ConfigObject* item);
+    void connectItem(ConfigNode* node);
+    void disconnectItem(ConfigNode* node);
     void onItemChanged();
     void notifyChanged();
 

--- a/plugin/src/Caelestia/Config/configlist.hpp
+++ b/plugin/src/Caelestia/Config/configlist.hpp
@@ -4,6 +4,7 @@
 
 #include <qjsonarray.h>
 #include <qqmlintegration.h>
+#include <qvariantlist.h>
 
 namespace caelestia::config {
 
@@ -14,11 +15,13 @@ class ConfigList : public ConfigNode {
     QML_ANONYMOUS
 
     Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(QVariantList values READ values NOTIFY valuesChanged)
 
 public:
     explicit ConfigList(QObject* parent = nullptr, const QVariantList& defaults = {});
 
     [[nodiscard]] int count() const;
+    [[nodiscard]] QVariantList values() const;
     [[nodiscard]] ConfigObject* itemAt(int index) const;
     [[nodiscard]] const QList<ConfigObject*>& items() const;
 
@@ -77,20 +80,10 @@ private:
         Q_OBJECT                                                                                                       \
         QML_ANONYMOUS                                                                                                  \
                                                                                                                        \
-        Q_PROPERTY(QList<caelestia::config::Element*> values READ values NOTIFY valuesChanged)                         \
-                                                                                                                       \
     public:                                                                                                            \
         explicit Name(QObject* parent = nullptr, const QVariantList& defaults = {})                                    \
             : caelestia::config::ConfigList(parent, defaults) {                                                        \
             resetToDefaults();                                                                                         \
-        }                                                                                                              \
-                                                                                                                       \
-        [[nodiscard]] QList<caelestia::config::Element*> values() const {                                              \
-            QList<caelestia::config::Element*> vals;                                                                   \
-            vals.reserve(items().size());                                                                              \
-            for (auto* const item : items())                                                                           \
-                vals.append(static_cast<caelestia::config::Element*>(item));                                           \
-            return vals;                                                                                               \
         }                                                                                                              \
                                                                                                                        \
         Q_INVOKABLE caelestia::config::Element* at(int index) const {                                                  \

--- a/plugin/src/Caelestia/Config/configlist.hpp
+++ b/plugin/src/Caelestia/Config/configlist.hpp
@@ -69,6 +69,9 @@ private:
     QJsonArray m_defaults;
     QList<ConfigObject*> m_items;
     bool m_loaded = false;
+    // A rejected non list value, kept verbatim so saving doesn't drop it from the file.
+    // Separate from ConfigObject::m_extras, which would report it as an unknown option.
+    QJsonValue m_rejectedJson = QJsonValue::Undefined;
 };
 
 } // namespace caelestia::config

--- a/plugin/src/Caelestia/Config/configlist.hpp
+++ b/plugin/src/Caelestia/Config/configlist.hpp
@@ -50,6 +50,7 @@ protected:
 
     void syncValuesFromGlobal() override;
     void onGlobalPropertiesChanged(const QMap<QString, QVariant>& changed) override;
+    [[nodiscard]] QString childPath(const ConfigNode* child) const override;
 
 private:
     void populate(const QJsonArray& arr);

--- a/plugin/src/Caelestia/Config/confignode.cpp
+++ b/plugin/src/Caelestia/Config/confignode.cpp
@@ -1,0 +1,107 @@
+#include "confignode.hpp"
+
+#include <qmetaobject.h>
+
+namespace caelestia::config {
+
+Q_LOGGING_CATEGORY(lcConfig, "caelestia.config", QtInfoMsg)
+
+ConfigNode::ConfigNode(QObject* parent)
+    : QObject(parent) {}
+
+void ConfigNode::loadFromJsonQuietly(const QJsonValue& json) {
+    m_suppressNotify = true;
+    loadFromJson(json);
+    m_suppressNotify = false;
+}
+
+QList<ConfigNode*> ConfigNode::childNodes() const {
+    return {};
+}
+
+void ConfigNode::syncFromGlobal(ConfigNode* global) {
+    m_global = global;
+
+    qCDebug(lcConfig) << "Syncing" << metaObject()->className() << "from global";
+
+    // Connect batched change signal (single connection per node pair)
+    connect(global, &ConfigNode::propertiesChanged, this, &ConfigNode::onGlobalPropertiesChanged);
+
+    syncValuesFromGlobal();
+}
+
+bool ConfigNode::isOverlay() const {
+    return m_global != nullptr;
+}
+
+QString ConfigNode::propertyPath(const QString& name) const {
+    QStringList parts;
+
+    if (!name.isEmpty())
+        parts.append(name);
+
+    const QObject* obj = this;
+    while (auto* parentObj = obj->parent()) {
+        const auto* parentNode = qobject_cast<const ConfigNode*>(parentObj);
+        if (!parentNode)
+            break;
+
+        // Find which property name this child is on the parent
+        const auto* meta = parentNode->metaObject();
+        bool found = false;
+        for (int i = basePropertyOffset(); i < meta->propertyCount(); ++i) {
+            const auto prop = meta->property(i);
+            if (prop.read(parentObj).value<QObject*>() == obj) {
+                parts.prepend(QString::fromUtf8(prop.name()));
+                found = true;
+                break;
+            }
+        }
+
+        if (!found)
+            break;
+
+        obj = parentObj;
+    }
+
+    return parts.join(QLatin1Char('.'));
+}
+
+int ConfigNode::basePropertyOffset() {
+    return ConfigNode::staticMetaObject.propertyCount();
+}
+
+void ConfigNode::notifyPropertyChanged(const QString& name, const QVariant& value) {
+    if (m_suppressNotify)
+        return;
+
+    m_pendingChanges.insert(name, value);
+
+    if (!m_batchTimer) {
+        m_batchTimer = new QTimer(this);
+        m_batchTimer->setSingleShot(true);
+        m_batchTimer->setInterval(0);
+        connect(m_batchTimer, &QTimer::timeout, this, &ConfigNode::emitBatchedChanges);
+    }
+
+    m_batchTimer->start();
+}
+
+QString ConfigNode::joinPath(const QString& parent, const QString& child) {
+    // List elements are addressed as parent[i], everything else as parent.child
+    if (child.startsWith(QLatin1Char('[')))
+        return parent + child;
+
+    return parent + QLatin1Char('.') + child;
+}
+
+void ConfigNode::emitBatchedChanges() {
+    if (m_pendingChanges.isEmpty())
+        return;
+
+    auto changes = std::move(m_pendingChanges);
+    m_pendingChanges.clear();
+    emit propertiesChanged(changes);
+}
+
+} // namespace caelestia::config

--- a/plugin/src/Caelestia/Config/confignode.cpp
+++ b/plugin/src/Caelestia/Config/confignode.cpp
@@ -44,36 +44,20 @@ bool ConfigNode::isOverlay() const {
 }
 
 QString ConfigNode::propertyPath(const QString& name) const {
-    QStringList parts;
+    auto path = name;
 
-    if (!name.isEmpty())
-        parts.append(name);
-
-    const QObject* obj = this;
-    while (auto* parentObj = obj->parent()) {
-        const auto* parentNode = qobject_cast<const ConfigNode*>(parentObj);
-        if (!parentNode)
+    // Each parent names its own children, so a list can report an index
+    const auto* node = this;
+    while (const auto* parent = qobject_cast<const ConfigNode*>(node->parent())) {
+        const auto childName = parent->childPath(node);
+        if (childName.isEmpty())
             break;
 
-        // Find which property name this child is on the parent
-        const auto* meta = parentNode->metaObject();
-        bool found = false;
-        for (int i = basePropertyOffset(); i < meta->propertyCount(); ++i) {
-            const auto prop = meta->property(i);
-            if (prop.read(parentObj).value<QObject*>() == obj) {
-                parts.prepend(QString::fromUtf8(prop.name()));
-                found = true;
-                break;
-            }
-        }
-
-        if (!found)
-            break;
-
-        obj = parentObj;
+        path = path.isEmpty() ? childName : joinPath(childName, path);
+        node = parent;
     }
 
-    return parts.join(QLatin1Char('.'));
+    return path;
 }
 
 int ConfigNode::basePropertyOffset() {

--- a/plugin/src/Caelestia/Config/confignode.cpp
+++ b/plugin/src/Caelestia/Config/confignode.cpp
@@ -10,9 +10,18 @@ ConfigNode::ConfigNode(QObject* parent)
     : QObject(parent) {}
 
 void ConfigNode::loadFromJsonQuietly(const QJsonValue& json) {
-    m_suppressNotify = true;
+    setNotifySuppressed(true);
     loadFromJson(json);
-    m_suppressNotify = false;
+    setNotifySuppressed(false);
+}
+
+void ConfigNode::setNotifySuppressed(bool suppressed) {
+    // Whole subtree, a child loaded during a quiet load must stay quiet too
+    m_suppressNotify = suppressed;
+
+    const auto children = childNodes();
+    for (auto* const child : children)
+        child->setNotifySuppressed(suppressed);
 }
 
 QList<ConfigNode*> ConfigNode::childNodes() const {

--- a/plugin/src/Caelestia/Config/confignode.hpp
+++ b/plugin/src/Caelestia/Config/confignode.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <qjsonvalue.h>
+#include <qloggingcategory.h>
+#include <qmap.h>
+#include <qobject.h>
+#include <qstringlist.h>
+#include <qtimer.h>
+#include <qvariant.h>
+
+namespace caelestia::config {
+
+Q_DECLARE_LOGGING_CATEGORY(lcConfig)
+
+// Common base for config tree nodes. Owns change batching, the overlay link and the
+// JSON contract, so a parent traverses children without caring which kind they are.
+class ConfigNode : public QObject {
+    Q_OBJECT
+
+public:
+    explicit ConfigNode(QObject* parent = nullptr);
+
+    virtual void loadFromJson(const QJsonValue& json) = 0;
+    // Loads without reporting a change, for defaults and values synced from global
+    void loadFromJsonQuietly(const QJsonValue& json);
+    // Returns Undefined when the node holds nothing worth writing.
+    [[nodiscard]] virtual QJsonValue toJson() const = 0;
+
+    virtual void clearLoadedKeys() = 0;
+
+    // Paths of loaded keys that matched no property, relative to this node.
+    [[nodiscard]] virtual QStringList unknownKeys() const = 0;
+    // Child nodes held as properties, a list has none since it reports element changes itself
+    [[nodiscard]] virtual QList<ConfigNode*> childNodes() const;
+
+    void syncFromGlobal(ConfigNode* global);
+    virtual void resyncFromGlobal() = 0;
+
+    [[nodiscard]] bool isOverlay() const;
+    [[nodiscard]] QString propertyPath(const QString& name = {}) const;
+
+    // First property index past QObject's own (objectName). Unlike propertyOffset(),
+    // this keeps properties inherited from intermediate config classes
+    [[nodiscard]] static int basePropertyOffset();
+
+signals:
+    void propertiesChanged(const QMap<QString, QVariant>& changed);
+
+protected:
+    virtual void syncValuesFromGlobal() = 0;
+    virtual void onGlobalPropertiesChanged(const QMap<QString, QVariant>& changed) = 0;
+
+    void notifyPropertyChanged(const QString& name, const QVariant& value);
+
+    [[nodiscard]] static QString joinPath(const QString& parent, const QString& child);
+
+    ConfigNode* m_global = nullptr;
+
+private:
+    void emitBatchedChanges();
+
+    QMap<QString, QVariant> m_pendingChanges;
+    QTimer* m_batchTimer = nullptr;
+    bool m_suppressNotify = false;
+};
+
+} // namespace caelestia::config

--- a/plugin/src/Caelestia/Config/confignode.hpp
+++ b/plugin/src/Caelestia/Config/confignode.hpp
@@ -50,6 +50,9 @@ protected:
     virtual void syncValuesFromGlobal() = 0;
     virtual void onGlobalPropertiesChanged(const QMap<QString, QVariant>& changed) = 0;
 
+    // Name this node gives the child, empty if it does not hold it
+    [[nodiscard]] virtual QString childPath(const ConfigNode* child) const = 0;
+
     void notifyPropertyChanged(const QString& name, const QVariant& value);
 
     [[nodiscard]] static QString joinPath(const QString& parent, const QString& child);

--- a/plugin/src/Caelestia/Config/confignode.hpp
+++ b/plugin/src/Caelestia/Config/confignode.hpp
@@ -57,6 +57,7 @@ protected:
     ConfigNode* m_global = nullptr;
 
 private:
+    void setNotifySuppressed(bool suppressed);
     void emitBatchedChanges();
 
     QMap<QString, QVariant> m_pendingChanges;

--- a/plugin/src/Caelestia/Config/configobject.cpp
+++ b/plugin/src/Caelestia/Config/configobject.cpp
@@ -289,6 +289,22 @@ void ConfigObject::onGlobalPropertiesChanged(const QMap<QString, QVariant>& chan
     }
 }
 
+QString ConfigObject::childPath(const ConfigNode* child) const {
+    const auto* meta = metaObject();
+    for (int i = basePropertyOffset(); i < meta->propertyCount(); ++i) {
+        const auto prop = meta->property(i);
+
+        // Never a node, and reading one on an overlay warns, which would recurse back here
+        if (isGlobalOnly(QString::fromUtf8(prop.name())))
+            continue;
+
+        if (prop.read(this).value<ConfigNode*>() == child)
+            return QString::fromUtf8(prop.name());
+    }
+
+    return {};
+}
+
 void ConfigObject::markPropertyLoaded(const QString& name) {
     m_loadedKeys.insert(name);
 }

--- a/plugin/src/Caelestia/Config/configobject.cpp
+++ b/plugin/src/Caelestia/Config/configobject.cpp
@@ -1,30 +1,29 @@
 #include "configobject.hpp"
 
 #include <qjsonarray.h>
-#include <qjsonvalue.h>
-#include <qloggingcategory.h>
 #include <qmetaobject.h>
 #include <qstringlist.h>
 #include <qvariant.h>
 
 namespace caelestia::config {
 
-Q_LOGGING_CATEGORY(lcConfig, "caelestia.config", QtInfoMsg)
-
-// ConfigObject
-
 ConfigObject::ConfigObject(QObject* parent)
-    : QObject(parent) {}
+    : ConfigNode(parent) {}
 
-void ConfigObject::loadFromJson(const QJsonObject& obj) {
+void ConfigObject::loadFromJson(const QJsonValue& json) {
+    const auto obj = json.toObject();
     const auto* meta = metaObject();
 
     qCDebug(lcConfig) << "Loading JSON into" << meta->className() << "with" << obj.keys().size()
                       << "keys:" << obj.keys();
 
+    QSet<QString> known;
+
     for (int i = basePropertyOffset(); i < meta->propertyCount(); ++i) {
         auto prop = meta->property(i);
         const auto key = QString::fromUtf8(prop.name());
+
+        known.insert(key);
 
         if (!obj.contains(key))
             continue;
@@ -35,13 +34,10 @@ void ConfigObject::loadFromJson(const QJsonObject& obj) {
 
         const auto jsonVal = obj.value(key);
 
-        // Recurse into sub-objects
-        auto current = prop.read(this);
-        auto* subObj = current.value<ConfigObject*>();
-
-        if (subObj) {
-            qCDebug(lcConfig) << "  Recursing into sub-object" << key;
-            subObj->loadFromJson(jsonVal.toObject());
+        // Recurse into child nodes (sub-objects and lists)
+        if (auto* const node = prop.read(this).value<ConfigNode*>()) {
+            qCDebug(lcConfig) << "  Recursing into" << key;
+            node->loadFromJson(jsonVal);
             continue;
         }
 
@@ -66,9 +62,17 @@ void ConfigObject::loadFromJson(const QJsonObject& obj) {
         m_loadedKeys.insert(key);
         qCDebug(lcConfig) << "  Loaded" << key << "=" << jsonVal.toVariant();
     }
+
+    m_extras = {};
+    for (auto it = obj.begin(); it != obj.end(); ++it) {
+        if (!known.contains(it.key())) {
+            m_extras.insert(it.key(), it.value());
+            qCDebug(lcConfig) << "  Keeping unknown key" << it.key();
+        }
+    }
 }
 
-QJsonObject ConfigObject::toJsonObject() const {
+QJsonValue ConfigObject::toJson() const {
     QJsonObject obj;
     const auto* meta = metaObject();
 
@@ -85,14 +89,11 @@ QJsonObject ConfigObject::toJsonObject() const {
 
         const auto value = prop.read(this);
 
-        // Recurse into sub-objects — include only if they have loaded keys
-        if (value.canView<ConfigObject*>()) {
-            auto* const subObj = value.value<ConfigObject*>();
-            if (subObj) {
-                auto subJson = subObj->toJsonObject();
-                if (!subJson.isEmpty())
-                    obj.insert(key, subJson);
-            }
+        // Recurse into child nodes, they decide if they hold anything worth writing
+        if (auto* const node = value.value<ConfigNode*>()) {
+            const auto childJson = node->toJson();
+            if (!childJson.isUndefined())
+                obj.insert(key, childJson);
             continue;
         }
 
@@ -120,34 +121,77 @@ QJsonObject ConfigObject::toJsonObject() const {
         obj.insert(key, QJsonValue::fromVariant(value));
     }
 
+    for (auto it = m_extras.begin(); it != m_extras.end(); ++it)
+        obj.insert(it.key(), it.value());
+
+    if (obj.isEmpty())
+        return QJsonValue::Undefined;
+
     return obj;
 }
 
 void ConfigObject::clearLoadedKeys() {
     m_loadedKeys.clear();
+    m_extras = {};
 
     const auto* meta = metaObject();
     for (int i = basePropertyOffset(); i < meta->propertyCount(); ++i) {
         auto prop = meta->property(i);
         if (isGlobalOnly(QString::fromUtf8(prop.name())))
             continue;
-        auto value = prop.read(this);
-        auto* subObj = value.value<ConfigObject*>();
-        if (subObj)
-            subObj->clearLoadedKeys();
+
+        if (auto* const node = prop.read(this).value<ConfigNode*>())
+            node->clearLoadedKeys();
     }
 }
 
-void ConfigObject::syncFromGlobal(ConfigObject* global) {
-    m_global = global;
+QStringList ConfigObject::unknownKeys() const {
+    auto keys = m_extras.keys();
 
     const auto* meta = metaObject();
-    qCDebug(lcConfig) << "Syncing" << meta->className() << "from global, loaded keys:" << m_loadedKeys;
+    for (int i = basePropertyOffset(); i < meta->propertyCount(); ++i) {
+        const auto prop = meta->property(i);
+        const auto key = QString::fromUtf8(prop.name());
 
-    // Connect batched change signal (single connection per ConfigObject pair)
-    connect(global, &ConfigObject::propertiesChanged, this, &ConfigObject::onGlobalPropertiesChanged);
+        // Never a node, and reading one on an overlay warns
+        if (isGlobalOnly(key))
+            continue;
 
-    // Initial sync: copy all non-loaded property values from global
+        auto* const node = prop.read(this).value<ConfigNode*>();
+        if (!node)
+            continue;
+
+        const auto childKeys = node->unknownKeys();
+        for (const auto& childKey : childKeys)
+            keys.append(joinPath(key, childKey));
+    }
+
+    return keys;
+}
+
+QList<ConfigNode*> ConfigObject::childNodes() const {
+    QList<ConfigNode*> nodes;
+
+    const auto* meta = metaObject();
+    for (int i = basePropertyOffset(); i < meta->propertyCount(); ++i) {
+        const auto prop = meta->property(i);
+
+        // Never a node, and reading one on an overlay warns
+        if (isGlobalOnly(QString::fromUtf8(prop.name())))
+            continue;
+
+        if (auto* const node = prop.read(this).value<ConfigNode*>())
+            nodes.append(node);
+    }
+
+    return nodes;
+}
+
+void ConfigObject::syncValuesFromGlobal() {
+    const auto* meta = metaObject();
+    qCDebug(lcConfig) << "  Loaded keys:" << m_loadedKeys;
+
+    // Copy all non-loaded property values from global
     for (int i = basePropertyOffset(); i < meta->propertyCount(); ++i) {
         auto prop = meta->property(i);
         const auto key = QString::fromUtf8(prop.name());
@@ -155,14 +199,9 @@ void ConfigObject::syncFromGlobal(ConfigObject* global) {
         if (isGlobalOnly(key))
             continue;
 
-        auto current = prop.read(this);
-        auto* subObj = current.value<ConfigObject*>();
-
-        if (subObj) {
-            auto globalVal = prop.read(global);
-            auto* globalSub = globalVal.value<ConfigObject*>();
-            if (globalSub)
-                subObj->syncFromGlobal(globalSub);
+        if (auto* const node = prop.read(this).value<ConfigNode*>()) {
+            if (auto* const globalNode = prop.read(m_global).value<ConfigNode*>())
+                node->syncFromGlobal(globalNode);
             continue;
         }
 
@@ -170,7 +209,7 @@ void ConfigObject::syncFromGlobal(ConfigObject* global) {
             continue;
 
         if (!m_loadedKeys.contains(key)) {
-            auto val = prop.read(global);
+            auto val = prop.read(m_global);
             prop.write(this, val);
             m_loadedKeys.remove(key); // setter added it — remove since this is a synced value
             qCDebug(lcConfig) << "  Synced" << key << "=" << val << "from global";
@@ -192,11 +231,8 @@ void ConfigObject::resyncFromGlobal() {
         if (isGlobalOnly(key))
             continue;
 
-        auto current = prop.read(this);
-        auto* subObj = current.value<ConfigObject*>();
-
-        if (subObj) {
-            subObj->resyncFromGlobal();
+        if (auto* const node = prop.read(this).value<ConfigNode*>()) {
+            node->resyncFromGlobal();
             continue;
         }
 
@@ -210,70 +246,32 @@ void ConfigObject::resyncFromGlobal() {
     }
 }
 
-int ConfigObject::basePropertyOffset() {
-    return ConfigObject::staticMetaObject.propertyCount();
-}
-
-QString ConfigObject::propertyPath(const QString& name) const {
-    QStringList parts;
-    parts.append(name);
-
-    const QObject* obj = this;
-    while (auto* parentObj = obj->parent()) {
-        auto* parentConfig = qobject_cast<const ConfigObject*>(parentObj);
-        if (!parentConfig)
-            break;
-
-        // Find which property name this child is on the parent
-        const auto* meta = parentConfig->metaObject();
-        bool found = false;
-        for (int i = basePropertyOffset(); i < meta->propertyCount(); ++i) {
-            auto prop = meta->property(i);
-            auto val = prop.read(parentObj);
-            if (val.value<QObject*>() == obj) {
-                parts.prepend(QString::fromUtf8(prop.name()));
-                found = true;
-                break;
-            }
-        }
-
-        if (!found)
-            break;
-
-        obj = parentObj;
-    }
-
-    return parts.join(QLatin1Char('.'));
-}
-
 bool ConfigObject::isPropertyLoaded(const QString& name) const {
     return m_loadedKeys.contains(name);
-}
-
-bool ConfigObject::isOverlay() const {
-    return m_global != nullptr;
 }
 
 bool ConfigObject::isGlobalOnly(const QString& name) const {
     return isOverlay() && m_globalOnlyKeys.contains(name);
 }
 
-void ConfigObject::markPropertyLoaded(const QString& name) {
-    m_loadedKeys.insert(name);
-}
-
 void ConfigObject::resetOption(const QString& name) {
     m_loadedKeys.remove(name);
 
-    // If synced from global, re-copy the global value
-    if (m_global) {
-        int idx = metaObject()->indexOfProperty(name.toUtf8().constData());
-        if (idx >= 0) {
-            auto prop = metaObject()->property(idx);
-            if (prop.isWritable())
-                prop.write(this, prop.read(m_global));
-        }
+    const int idx = metaObject()->indexOfProperty(name.toUtf8().constData());
+    if (idx < 0)
+        return;
+
+    const auto prop = metaObject()->property(idx);
+
+    if (auto* const node = prop.read(this).value<ConfigNode*>()) {
+        node->clearLoadedKeys();
+        node->resyncFromGlobal();
+        return;
     }
+
+    // If synced from global, re-copy the global value
+    if (m_global && prop.isWritable())
+        prop.write(this, prop.read(m_global));
 }
 
 void ConfigObject::onGlobalPropertiesChanged(const QMap<QString, QVariant>& changed) {
@@ -291,30 +289,12 @@ void ConfigObject::onGlobalPropertiesChanged(const QMap<QString, QVariant>& chan
     }
 }
 
+void ConfigObject::markPropertyLoaded(const QString& name) {
+    m_loadedKeys.insert(name);
+}
+
 void ConfigObject::markGlobalOnly(const QString& name) {
     m_globalOnlyKeys.insert(name);
-}
-
-void ConfigObject::notifyPropertyChanged(const QString& name, const QVariant& value) {
-    m_pendingChanges.insert(name, value);
-
-    if (!m_batchTimer) {
-        m_batchTimer = new QTimer(this);
-        m_batchTimer->setSingleShot(true);
-        m_batchTimer->setInterval(0);
-        connect(m_batchTimer, &QTimer::timeout, this, &ConfigObject::emitBatchedChanges);
-    }
-
-    m_batchTimer->start();
-}
-
-void ConfigObject::emitBatchedChanges() {
-    if (m_pendingChanges.isEmpty())
-        return;
-
-    auto changes = std::move(m_pendingChanges);
-    m_pendingChanges.clear();
-    emit propertiesChanged(changes);
 }
 
 } // namespace caelestia::config

--- a/plugin/src/Caelestia/Config/configobject.cpp
+++ b/plugin/src/Caelestia/Config/configobject.cpp
@@ -254,6 +254,10 @@ bool ConfigObject::isGlobalOnly(const QString& name) const {
     return isOverlay() && m_globalOnlyKeys.contains(name);
 }
 
+QStringList ConfigObject::globalOnlyKeys() const {
+    return { m_globalOnlyKeys.begin(), m_globalOnlyKeys.end() };
+}
+
 void ConfigObject::resetOption(const QString& name) {
     m_loadedKeys.remove(name);
 

--- a/plugin/src/Caelestia/Config/configobject.hpp
+++ b/plugin/src/Caelestia/Config/configobject.hpp
@@ -116,6 +116,7 @@ public:
 protected:
     void syncValuesFromGlobal() override;
     void onGlobalPropertiesChanged(const QMap<QString, QVariant>& changed) override;
+    [[nodiscard]] QString childPath(const ConfigNode* child) const override;
 
     void markPropertyLoaded(const QString& name);
     void markGlobalOnly(const QString& name);

--- a/plugin/src/Caelestia/Config/configobject.hpp
+++ b/plugin/src/Caelestia/Config/configobject.hpp
@@ -98,6 +98,8 @@ public:
     [[nodiscard]] bool isPropertyLoaded(const QString& name) const;
     // Returns true only on overlays — global singleton always returns false.
     [[nodiscard]] bool isGlobalOnly(const QString& name) const;
+    // Names marked global-only, regardless of overlay state
+    [[nodiscard]] QStringList globalOnlyKeys() const;
 
     Q_INVOKABLE void resetOption(const QString& name);
 

--- a/plugin/src/Caelestia/Config/configobject.hpp
+++ b/plugin/src/Caelestia/Config/configobject.hpp
@@ -1,13 +1,10 @@
 #pragma once
 
+#include "confignode.hpp"
+
 #include <qjsonobject.h>
-#include <qloggingcategory.h>
-#include <qmap.h>
-#include <qobject.h>
 #include <qqmlintegration.h>
 #include <qset.h>
-#include <qtimer.h>
-#include <qvariant.h>
 
 namespace caelestia::config {
 
@@ -84,31 +81,21 @@ private:                                                                        
 
 namespace caelestia::config {
 
-Q_DECLARE_LOGGING_CATEGORY(lcConfig)
-
-class ConfigObject : public QObject {
+// A node whose state lives in its declared properties.
+class ConfigObject : public ConfigNode {
     Q_OBJECT
 
 public:
     explicit ConfigObject(QObject* parent = nullptr);
 
-    void loadFromJson(const QJsonObject& obj);
-    [[nodiscard]] QJsonObject toJsonObject() const;
-
-    // Per-monitor overlay support (Qt Resolve Mask pattern).
-    void syncFromGlobal(ConfigObject* global);
-    void resyncFromGlobal();
-    void clearLoadedKeys();
+    void loadFromJson(const QJsonValue& json) override;
+    [[nodiscard]] QJsonValue toJson() const override;
+    void clearLoadedKeys() override;
+    [[nodiscard]] QStringList unknownKeys() const override;
+    [[nodiscard]] QList<ConfigNode*> childNodes() const override;
+    void resyncFromGlobal() override;
 
     [[nodiscard]] bool isPropertyLoaded(const QString& name) const;
-    [[nodiscard]] QString propertyPath(const QString& name) const;
-
-    // First property index past QObject's own (objectName). ConfigObject declares no
-    // properties, so this is where every subclass's config properties begin — including
-    // ones inherited from an intermediate config class (e.g. IconFontStyleConfig). Use
-    // this instead of metaObject()->propertyOffset(), which excludes inherited properties.
-    [[nodiscard]] static int basePropertyOffset();
-    [[nodiscard]] bool isOverlay() const;
     // Returns true only on overlays — global singleton always returns false.
     [[nodiscard]] bool isGlobalOnly(const QString& name) const;
 
@@ -126,24 +113,18 @@ public:
         return true;
     }
 
-signals:
-    void propertiesChanged(const QMap<QString, QVariant>& changed);
-
 protected:
+    void syncValuesFromGlobal() override;
+    void onGlobalPropertiesChanged(const QMap<QString, QVariant>& changed) override;
+
     void markPropertyLoaded(const QString& name);
     void markGlobalOnly(const QString& name);
-    void notifyPropertyChanged(const QString& name, const QVariant& value);
 
 private:
-    void onGlobalPropertiesChanged(const QMap<QString, QVariant>& changed);
-    void emitBatchedChanges();
-
-    // Per-monitor overlay state
-    ConfigObject* m_global = nullptr;
     QSet<QString> m_loadedKeys;
     QSet<QString> m_globalOnlyKeys;
-    QMap<QString, QVariant> m_pendingChanges;
-    QTimer* m_batchTimer = nullptr;
+    // Loaded keys matching no property, kept verbatim so a save does not drop them
+    QJsonObject m_extras;
 };
 
 } // namespace caelestia::config

--- a/plugin/src/Caelestia/Config/rootconfig.cpp
+++ b/plugin/src/Caelestia/Config/rootconfig.cpp
@@ -25,69 +25,6 @@ bool RootConfig::recentlySaved() const {
     return m_recentlySaved;
 }
 
-QStringList RootConfig::collectUnknownKeys(const ConfigObject* obj, const QJsonObject& json) {
-    QStringList unknown;
-    const auto* meta = obj->metaObject();
-
-    QSet<QString> known;
-    for (int i = ConfigObject::basePropertyOffset(); i < meta->propertyCount(); ++i)
-        known.insert(QString::fromUtf8(meta->property(i).name()));
-
-    for (auto it = json.begin(); it != json.end(); ++it) {
-        if (!known.contains(it.key())) {
-            unknown.append(it.key());
-        } else if (it.value().isObject()) {
-            int idx = meta->indexOfProperty(it.key().toUtf8().constData());
-            if (idx >= 0) {
-                auto prop = meta->property(idx);
-                auto value = prop.read(obj);
-                auto* subObj = value.value<ConfigObject*>();
-                if (subObj) {
-                    const auto subUnknown = collectUnknownKeys(subObj, it.value().toObject());
-                    for (const auto& subKey : subUnknown)
-                        unknown.append(it.key() + QStringLiteral(".") + subKey);
-                }
-            }
-        }
-    }
-
-    return unknown;
-}
-
-void RootConfig::mergeUnknownKeys(const ConfigObject* obj, const QJsonObject& source, QJsonObject& target) {
-    const auto* meta = obj->metaObject();
-
-    QSet<QString> known;
-    for (int i = ConfigObject::basePropertyOffset(); i < meta->propertyCount(); ++i)
-        known.insert(QString::fromUtf8(meta->property(i).name()));
-
-    for (auto it = source.begin(); it != source.end(); ++it) {
-        if (!known.contains(it.key())) {
-            if (!target.contains(it.key()))
-                target.insert(it.key(), it.value());
-            continue;
-        }
-
-        if (!it.value().isObject())
-            continue;
-
-        int idx = meta->indexOfProperty(it.key().toUtf8().constData());
-        if (idx < 0)
-            continue;
-
-        auto prop = meta->property(idx);
-        auto* subObj = prop.read(obj).value<ConfigObject*>();
-        if (!subObj)
-            continue;
-
-        auto childTarget = target.value(it.key()).toObject();
-        mergeUnknownKeys(subObj, it.value().toObject(), childTarget);
-
-        if (!childTarget.isEmpty())
-            target.insert(it.key(), childTarget);
-    }
-}
-
 void RootConfig::setupFileBackend(const QString& path, const QString& screen) {
     m_filePath = path;
     m_screen = screen;
@@ -114,8 +51,7 @@ void RootConfig::setupFileBackend(const QString& path, const QString& screen) {
             return;
         }
 
-        auto json = toJsonObject();
-        mergeUnknownKeys(this, m_lastLoadedJson, json);
+        const auto json = toJson().toObject();
         file.write(QJsonDocument(json).toJson(QJsonDocument::Indented));
         file.close();
 
@@ -155,21 +91,16 @@ void RootConfig::setupFileBackend(const QString& path, const QString& screen) {
     });
 }
 
-void RootConfig::connectAutoSave(ConfigObject* obj) {
-    connect(obj, &ConfigObject::propertiesChanged, this, [this] {
+void RootConfig::connectAutoSave(ConfigNode* node) {
+    connect(node, &ConfigNode::propertiesChanged, this, [this] {
         if (!m_loading)
             saveToFile();
     });
 
-    // Recurse into sub-objects
-    const auto* meta = obj->metaObject();
-    for (int i = ConfigObject::basePropertyOffset(); i < meta->propertyCount(); ++i) {
-        auto prop = meta->property(i);
-        auto value = prop.read(obj);
-        auto* subObj = value.value<ConfigObject*>();
-        if (subObj)
-            connectAutoSave(subObj);
-    }
+    // Recurse into child nodes
+    const auto children = node->childNodes();
+    for (auto* const child : children)
+        connectAutoSave(child);
 }
 
 void RootConfig::updateWatch() {
@@ -273,14 +204,12 @@ std::optional<QString> RootConfig::reloadFromFile() {
 
     clearLoadedKeys();
 
-    auto jsonObj = doc.object();
-    m_lastLoadedJson = jsonObj;
-    loadFromJson(jsonObj);
+    loadFromJson(doc.object());
 
     m_loading = false;
 
     // Collect unknown keys — caller is responsible for emitting signals
-    m_lastUnknownKeys = collectUnknownKeys(this, jsonObj);
+    m_lastUnknownKeys = unknownKeys();
 
     return QString(); // success
 }

--- a/plugin/src/Caelestia/Config/rootconfig.cpp
+++ b/plugin/src/Caelestia/Config/rootconfig.cpp
@@ -169,6 +169,14 @@ void RootConfig::saveToFile() {
 
     if (m_loadFailed) {
         qCWarning(lcConfig) << "Not saving" << m_filePath << "- last load failed";
+
+        // Saves are attempted on every change, so only report the first one
+        if (!m_saveBlockedNotified) {
+            m_saveBlockedNotified = true;
+            emit saveFailed(
+                QStringLiteral("Not overwriting %1 until the last load error is fixed").arg(m_filePath), m_screen);
+        }
+
         return;
     }
 
@@ -180,6 +188,7 @@ void RootConfig::saveToFile() {
 std::optional<QString> RootConfig::reloadFromFile() {
     m_lastSignature = fileSignature();
     m_loadFailed = false;
+    m_saveBlockedNotified = false;
 
     QFile file(m_filePath);
 

--- a/plugin/src/Caelestia/Config/rootconfig.cpp
+++ b/plugin/src/Caelestia/Config/rootconfig.cpp
@@ -91,6 +91,14 @@ void RootConfig::setupFileBackend(const QString& path, const QString& screen) {
     });
 }
 
+void RootConfig::markLoadFailed() {
+    m_loadFailed = true;
+
+    // A queued save would write memory over a file that could not be read
+    if (m_saveTimer)
+        m_saveTimer->stop();
+}
+
 void RootConfig::connectAutoSave(ConfigNode* node) {
     connect(node, &ConfigNode::propertiesChanged, this, [this] {
         if (!m_loading)
@@ -158,6 +166,12 @@ QString RootConfig::fileSignature() const {
 void RootConfig::saveToFile() {
     if (!m_saveTimer)
         return;
+
+    if (m_loadFailed) {
+        qCWarning(lcConfig) << "Not saving" << m_filePath << "- last load failed";
+        return;
+    }
+
     m_saveTimer->start();
     m_recentlySaved = true;
     m_cooldownTimer->start();
@@ -165,6 +179,7 @@ void RootConfig::saveToFile() {
 
 std::optional<QString> RootConfig::reloadFromFile() {
     m_lastSignature = fileSignature();
+    m_loadFailed = false;
 
     QFile file(m_filePath);
 
@@ -174,6 +189,7 @@ std::optional<QString> RootConfig::reloadFromFile() {
     }
 
     if (!file.open(QIODevice::ReadOnly)) {
+        markLoadFailed();
         auto err = QStringLiteral("Failed to open %1: %2").arg(m_filePath, file.errorString());
         qCDebug(lcConfig, "%s", qUtf8Printable(err));
         return err;
@@ -183,6 +199,8 @@ std::optional<QString> RootConfig::reloadFromFile() {
     auto doc = QJsonDocument::fromJson(file.readAll(), &error);
 
     if (error.error != QJsonParseError::NoError) {
+        markLoadFailed();
+
         if (m_retryTimer && m_parseRetries < 3) {
             m_parseRetries++;
             qCDebug(lcConfig, "Failed to parse %s: %s - retrying (%d/3)", qUtf8Printable(m_filePath),

--- a/plugin/src/Caelestia/Config/rootconfig.hpp
+++ b/plugin/src/Caelestia/Config/rootconfig.hpp
@@ -42,6 +42,8 @@ private:
     [[nodiscard]] QString fileSignature() const;
 
     void connectAutoSave(ConfigNode* node);
+    // Blocks saving until a load succeeds, memory no longer represents the file
+    void markLoadFailed();
 
     QString m_filePath;
     QString m_screen;
@@ -49,6 +51,7 @@ private:
     QString m_lastSignature;
     bool m_recentlySaved = false;
     bool m_loading = false;
+    bool m_loadFailed = false;
 
     QFileSystemWatcher* m_watcher = nullptr;
     QTimer* m_saveTimer = nullptr;

--- a/plugin/src/Caelestia/Config/rootconfig.hpp
+++ b/plugin/src/Caelestia/Config/rootconfig.hpp
@@ -34,8 +34,6 @@ signals:
     void unknownOption(const QString& key, const QString& screen);
 
 private:
-    static QStringList collectUnknownKeys(const ConfigObject* obj, const QJsonObject& json);
-    static void mergeUnknownKeys(const ConfigObject* obj, const QJsonObject& source, QJsonObject& target);
     void emitLoadSignals(const std::optional<QString>& result, bool emitLoaded = true);
     void updateWatch();
     void onWatcherEvent();
@@ -43,7 +41,7 @@ private:
     // directory events caused by unrelated sibling files.
     [[nodiscard]] QString fileSignature() const;
 
-    void connectAutoSave(ConfigObject* obj);
+    void connectAutoSave(ConfigNode* node);
 
     QString m_filePath;
     QString m_screen;
@@ -59,7 +57,6 @@ private:
     QTimer* m_reloadDebounce = nullptr;
     int m_parseRetries = 0;
     QStringList m_lastUnknownKeys;
-    QJsonObject m_lastLoadedJson;
 };
 
 } // namespace caelestia::config

--- a/plugin/src/Caelestia/Config/rootconfig.hpp
+++ b/plugin/src/Caelestia/Config/rootconfig.hpp
@@ -52,6 +52,7 @@ private:
     bool m_recentlySaved = false;
     bool m_loading = false;
     bool m_loadFailed = false;
+    bool m_saveBlockedNotified = false;
 
     QFileSystemWatcher* m_watcher = nullptr;
     QTimer* m_saveTimer = nullptr;


### PR DESCRIPTION
Add typed config lists instead of having to use QVariantLists. Also solves the issue of list elements being recreated on every list modification (which breaks ScriptModels).