### PR TITLE
feat(lock): add configurable lock screen background

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,14 +693,14 @@ For example, to disable the bar on DP-1:
     },
     "lock": {
         "enabled": true,
+        "useWallpaper": false,
         "recolourLogo": true,
         "enableFprint": true,
         "maxFprintTries": 3,
         "enableHowdy": true,
         "maxHowdyTries": 3,
         "triggerHowdyOnWake": true,
-        "hideNotifs": false,
-        "useWallpaper": false
+        "hideNotifs": false
     },
     "nexus": {
         "wallpapersPerRow": 4,

--- a/README.md
+++ b/README.md
@@ -700,7 +700,7 @@ For example, to disable the bar on DP-1:
         "maxHowdyTries": 3,
         "triggerHowdyOnWake": true,
         "hideNotifs": false,
-        "useScreencopy": true
+        "useWallpaper": false
     },
     "nexus": {
         "wallpapersPerRow": 4,

--- a/README.md
+++ b/README.md
@@ -699,7 +699,8 @@ For example, to disable the bar on DP-1:
         "enableHowdy": true,
         "maxHowdyTries": 3,
         "triggerHowdyOnWake": true,
-        "hideNotifs": false
+        "hideNotifs": false,
+        "useScreencopy": true
     },
     "nexus": {
         "wallpapersPerRow": 4,

--- a/modules/lock/LockSurface.qml
+++ b/modules/lock/LockSurface.qml
@@ -5,6 +5,7 @@ import QtQuick.Effects
 import Quickshell.Wayland
 import Caelestia.Config
 import qs.components
+import qs.components.images
 import qs.services
 
 WlSessionLockSurface {
@@ -154,11 +155,10 @@ WlSessionLockSurface {
         }
     }
 
-    ScreencopyView {
+    Item {
         id: background
 
         anchors.fill: parent
-        captureSource: root.screen
         opacity: 0
 
         layer.enabled: true
@@ -168,6 +168,27 @@ WlSessionLockSurface {
             blur: 1
             blurMax: 64
             blurMultiplier: 1
+        }
+
+        Loader {
+            anchors.fill: parent
+            sourceComponent: Config.lock.useScreencopy ? screencopyBackground : wallpaperBackground
+        }
+    }
+
+    Component {
+        id: screencopyBackground
+
+        ScreencopyView {
+            captureSource: root.screen
+        }
+    }
+
+    Component {
+        id: wallpaperBackground
+
+        CachingImage {
+            path: Wallpapers.current || Wallpapers.fallback
         }
     }
 

--- a/modules/lock/LockSurface.qml
+++ b/modules/lock/LockSurface.qml
@@ -172,7 +172,7 @@ WlSessionLockSurface {
 
         Loader {
             anchors.fill: parent
-            sourceComponent: Config.lock.useScreencopy ? screencopyBackground : wallpaperBackground
+            sourceComponent: Config.lock.useWallpaper ? wallpaperBackground : screencopyBackground
         }
     }
 
@@ -188,7 +188,7 @@ WlSessionLockSurface {
         id: wallpaperBackground
 
         CachingImage {
-            path: Wallpapers.current || Wallpapers.fallback
+            path: Wallpapers.current
         }
     }
 

--- a/plugin/src/Caelestia/Config/lockconfig.hpp
+++ b/plugin/src/Caelestia/Config/lockconfig.hpp
@@ -9,7 +9,7 @@ class LockConfig : public ConfigObject {
     QML_ANONYMOUS
 
     CONFIG_PROPERTY(bool, enabled, true)
-    CONFIG_PROPERTY(bool, useScreencopy, true)
+    CONFIG_PROPERTY(bool, useWallpaper, false)
     CONFIG_PROPERTY(bool, recolourLogo, true)
     CONFIG_GLOBAL_PROPERTY(bool, enableFprint, true)
     CONFIG_GLOBAL_PROPERTY(int, maxFprintTries, 3)

--- a/plugin/src/Caelestia/Config/lockconfig.hpp
+++ b/plugin/src/Caelestia/Config/lockconfig.hpp
@@ -9,6 +9,7 @@ class LockConfig : public ConfigObject {
     QML_ANONYMOUS
 
     CONFIG_PROPERTY(bool, enabled, true)
+    CONFIG_PROPERTY(bool, useScreencopy, true)
     CONFIG_PROPERTY(bool, recolourLogo, true)
     CONFIG_GLOBAL_PROPERTY(bool, enableFprint, true)
     CONFIG_GLOBAL_PROPERTY(int, maxFprintTries, 3)


### PR DESCRIPTION
## Summary

Introduces a `useScreencopy` config option for the lock screen, which defaults to `true` for the current behavior of displaying the blurred screencopy of the desktop and uses a blurred version of the current wallpaper as the background when `false`. This allows users to opt for a more privacy-focused version where opened applications aren't displayed in any form.

Closes #1320.

## Testing

- Builds successfully
- Passed `qmlformat` and linting checks
- Verified that toggling the option behaves as intended
- Tested both the screencopy and wallpaper versions for the lockscreen