### PR TITLE
feat: manage ydotool for clipboard paste

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -72,6 +72,14 @@ in {
           description = "Caelestia CLI extra configs written to cli.json";
         };
       };
+      ydotool = {
+        enable = mkEnableOption "Enable ydotool daemon";
+        package = mkOption {
+          type = types.package;
+          default = pkgs.ydotool;
+          description = "ydotool package";
+        };
+      };
     };
   };
 
@@ -80,33 +88,54 @@ in {
     shell = cfg.package;
   in
     lib.mkIf cfg.enable {
-      systemd.user.services.caelestia = lib.mkIf cfg.systemd.enable {
-        Unit = {
-          Description = "Caelestia Shell Service";
-          After = [cfg.systemd.target];
-          PartOf = [cfg.systemd.target];
-          X-Restart-Triggers = lib.mkIf (cfg.settings != {}) [
-            "${config.xdg.configFile."caelestia/shell.json".source}"
-          ];
+      systemd.user.services = {
+        caelestia = lib.mkIf cfg.systemd.enable {
+          Unit = {
+            Description = "Caelestia Shell Service";
+            After = [cfg.systemd.target];
+            PartOf = [cfg.systemd.target];
+            X-Restart-Triggers = lib.mkIf (cfg.settings != {}) [
+              "${config.xdg.configFile."caelestia/shell.json".source}"
+            ];
+          };
+
+          Service = {
+            Type = "exec";
+            ExecStart = "${shell}/bin/caelestia-shell";
+            Restart = "on-failure";
+            RestartSec = "5s";
+            TimeoutStopSec = "5s";
+            Environment =
+              [
+                "QT_QPA_PLATFORM=wayland"
+                "YDOTOOL_SOCKET=%t/.ydotool_socket"
+              ]
+              ++ cfg.systemd.environment;
+
+            Slice = "session.slice";
+          };
+
+          Install = {
+            WantedBy = [cfg.systemd.target];
+          };
         };
 
-        Service = {
-          Type = "exec";
-          ExecStart = "${shell}/bin/caelestia-shell";
-          Restart = "on-failure";
-          RestartSec = "5s";
-          TimeoutStopSec = "5s";
-          Environment =
-            [
-              "QT_QPA_PLATFORM=wayland"
-            ]
-            ++ cfg.systemd.environment;
+        caelestia-ydotoold = lib.mkIf cfg.ydotool.enable {
+          Unit = {
+            Description = "ydotool daemon";
+            After = [cfg.systemd.target];
+            PartOf = [cfg.systemd.target];
+          };
 
-          Slice = "session.slice";
-        };
+          Service = {
+            Type = "simple";
+            ExecStart = "${cfg.ydotool.package}/bin/ydotoold --socket-path=%t/.ydotool_socket";
+            Restart = "on-failure";
+          };
 
-        Install = {
-          WantedBy = [cfg.systemd.target];
+          Install = {
+            WantedBy = [cfg.systemd.target];
+          };
         };
       };
 


### PR DESCRIPTION
## Summary

This PR adds optional `ydotool` integration to the Home Manager module by:

* adding `programs.caelestia.ydotool.enable`
* managing `ydotoold` as a user systemd service
* exporting `YDOTOOL_SOCKET` to the shell environment

This provides the runtime support required for clipboard typing functionality without requiring users to manually start `ydotoold` or configure the socket.

## Depends on

This PR builds on the new clipboard functionality introduced in **caelestia-dots/cli#143**. I recommend reviewing that PR first, as this one provides the Home Manager integration needed to support it.

- https://github.com/caelestia-dots/cli/pull/143
