### PR TITLE
feat: use pwvucontrol as default audio app

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ For example, to disable the bar on DP-1:
         "sessionGifSpeed": 0.7,
         "apps": {
             "terminal": ["foot"],
-            "audio": ["pavucontrol"],
+            "audio": ["pwvucontrol"],
             "playback": ["mpv"],
             "explorer": ["thunar"]
         },

--- a/plugin/src/Caelestia/Config/generalconfig.hpp
+++ b/plugin/src/Caelestia/Config/generalconfig.hpp
@@ -15,7 +15,7 @@ class GeneralApps : public ConfigObject {
     QML_ANONYMOUS
 
     CONFIG_GLOBAL_PROPERTY(QStringList, terminal, { u"foot"_s })
-    CONFIG_GLOBAL_PROPERTY(QStringList, audio, { u"pavucontrol"_s })
+    CONFIG_GLOBAL_PROPERTY(QStringList, audio, { u"pwvucontrol"_s })
     CONFIG_GLOBAL_PROPERTY(QStringList, playback, { u"mpv"_s })
     CONFIG_GLOBAL_PROPERTY(QStringList, explorer, { u"thunar"_s })
 


### PR DESCRIPTION
## Summary

Follow-up to caelestia-dots/caelestia#483, which switches the dots from `pavucontrol` to `pwvucontrol`. This aligns the shell: changes the default `general.apps.audio` and the documented default in the README.

## Rationale

`pwvucontrol` is designed specifically for PipeWire and WirePlumber, making it a better match for the full PipeWire audio stack than a control application using the PulseAudio compatibility layer.

It has fewer direct dependencies and automatically follows Caelestia's configured GTK theme, providing better visual integration without additional configuration.

## Side effects

Not added to `runtimeDeps` in `nix/default.nix`. This is deliberate, no default app is listed there (`foot`, `mpv` and `thunar` are all absent), nix users install their own apps.

## Screenshot

<img width="2473" height="1404" alt="screenshot-20260728-113546" src="https://github.com/user-attachments/assets/681f9bf8-d9c7-4e41-98f8-eca433d75c30" />