### PR TITLE
feat(utilities): add capture modes and audio sources to the recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,6 +790,11 @@ For example, to disable the bar on DP-1:
                 }
             ]
         },
+        "recording": {
+            "recordSystem": true,
+            "recordMicrophone": false,
+            "videoMode": "fullscreen"
+        },
         "quickToggles": [
             {
                 "id": "wifi",

--- a/modules/utilities/Wrapper.qml
+++ b/modules/utilities/Wrapper.qml
@@ -19,6 +19,7 @@ Item {
 
     readonly property PersistentProperties props: PersistentProperties {
         property bool recordingListExpanded: false
+        property bool recordingAudioExpanded: false
         property string recordingConfirmDelete
         property string recordingMode
 

--- a/modules/utilities/cards/Record.qml
+++ b/modules/utilities/cards/Record.qml
@@ -15,10 +15,77 @@ StyledRect {
     required property ScreenState screenState
     readonly property real nonAnimHeight: btnLayout.implicitHeight + listOrControls.implicitHeight + layout.spacing + layout.anchors.margins * 2
 
+    readonly property bool recordingBusy: Recorder.running || Recorder.starting
+    property string lastError: ""
+    readonly property string currentVideoMode: GlobalConfig.utilities?.recording?.videoMode ?? "fullscreen"
+
+    // gpu-screen-recorder takes one audio argument, so the two switches collapse
+    // into a single mode
+    readonly property string currentAudioMode: {
+        const recordSystem = GlobalConfig.utilities?.recording?.recordSystem ?? true;
+        const recordMic = GlobalConfig.utilities?.recording?.recordMicrophone ?? false;
+        if (recordSystem && recordMic)
+            return "combined";
+        if (recordSystem)
+            return "system";
+        if (recordMic)
+            return "mic";
+        return "none";
+    }
+
+    function setVideoMode(mode: string): void {
+        if (GlobalConfig.utilities?.recording) {
+            GlobalConfig.utilities.recording.videoMode = mode;
+            GlobalConfig.save();
+        }
+    }
+
+    function startRecording(mode: string): void {
+        root.setVideoMode(mode);
+        Recorder.start(mode, root.currentAudioMode);
+    }
+
+    function startingText(mode: string): string {
+        return qsTr("Starting %1...").arg(root.videoModeLabel(mode));
+    }
+
+    function videoModeLabel(mode: string): string {
+        if (mode === "fullscreen")
+            return qsTr("fullscreen");
+        if (mode === "region")
+            return qsTr("region");
+        if (mode === "window")
+            return qsTr("window");
+        return mode;
+    }
+
+    function audioModeLabel(mode: string): string {
+        if (mode === "combined")
+            return qsTr("system + mic");
+        if (mode === "system")
+            return qsTr("system audio");
+        if (mode === "mic")
+            return qsTr("microphone");
+        return qsTr("no audio");
+    }
+
+    Layout.fillWidth: true
     implicitHeight: layout.implicitHeight + layout.anchors.margins * 2
 
     radius: Tokens.rounding.large
     color: Colours.tPalette.m3surfaceContainer
+
+    Connections {
+        function onErrorOccurred(errorMsg: string): void {
+            root.lastError = errorMsg;
+        }
+
+        function onRecordingStarted(): void {
+            root.lastError = "";
+        }
+
+        target: Recorder
+    }
 
     ColumnLayout {
         id: layout
@@ -40,7 +107,7 @@ StyledRect {
                 }
 
                 radius: Tokens.rounding.full
-                color: Recorder.running ? Colours.palette.m3secondary : Colours.palette.m3secondaryContainer
+                color: root.recordingBusy ? Colours.palette.m3secondary : Colours.palette.m3secondaryContainer
 
                 MaterialIcon {
                     id: icon
@@ -66,8 +133,21 @@ StyledRect {
 
                 StyledText {
                     Layout.fillWidth: true
-                    text: Recorder.paused ? qsTr("Paused") : Recorder.running ? qsTr("Running...") : qsTr("Ready")
-                    color: Colours.palette.m3onSurfaceVariant
+                    text: {
+                        if (root.lastError !== "")
+                            return qsTr("Error: %1").arg(root.lastError);
+                        if (Recorder.starting)
+                            return root.startingText(Recorder.videoMode || root.currentVideoMode);
+                        if (Recorder.paused)
+                            return qsTr("Recording paused");
+                        if (Recorder.running) {
+                            const videoText = root.videoModeLabel(Recorder.videoMode || root.currentVideoMode);
+                            const audioText = root.audioModeLabel(Recorder.audioMode || root.currentAudioMode);
+                            return qsTr("Recording %1 with %2").arg(videoText).arg(audioText);
+                        }
+                        return qsTr("Recording off");
+                    }
+                    color: root.lastError !== "" ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
                     font: Tokens.font.body.small
                     elide: Text.ElideRight
                     animate: true
@@ -75,44 +155,244 @@ StyledRect {
             }
 
             SplitButton {
-                disabled: Recorder.running
-
-                active: menuItems.find(m => root.props.recordingMode === m.icon + m.text) ?? menuItems[0]
-                menu.onItemSelected: item => root.props.recordingMode = item.icon + item.text
+                disabled: root.recordingBusy
+                active: menuItems.find(m => m["mode"] === root.currentVideoMode) ?? menuItems[0]
+                menu.onItemSelected: item => root.setVideoMode(item["mode"])
 
                 menuItems: [
                     MenuItem {
+                        id: modeFullscreen
+
+                        property string mode: "fullscreen"
+
                         icon: "fullscreen"
                         text: qsTr("Record fullscreen")
                         activeText: qsTr("Fullscreen")
-                        onClicked: Recorder.start()
+                        onClicked: root.startRecording(modeFullscreen.mode)
                     },
                     MenuItem {
+                        id: modeRegion
+
+                        property string mode: "region"
+
                         icon: "screenshot_region"
                         text: qsTr("Record region")
                         activeText: qsTr("Region")
-                        onClicked: Recorder.start(["-r"])
+                        onClicked: root.startRecording(modeRegion.mode)
                     },
                     MenuItem {
-                        icon: "select_to_speak"
-                        text: qsTr("Record fullscreen with sound")
-                        activeText: qsTr("Fullscreen")
-                        onClicked: Recorder.start(["-s"])
-                    },
-                    MenuItem {
-                        icon: "volume_up"
-                        text: qsTr("Record region with sound")
-                        activeText: qsTr("Region")
-                        onClicked: Recorder.start(["-sr"])
+                        id: modeWindow
+
+                        property string mode: "window"
+
+                        icon: "web_asset"
+                        text: qsTr("Record window")
+                        activeText: qsTr("Window")
+                        onClicked: root.startRecording(modeWindow.mode)
                     }
                 ]
+            }
+        }
+
+        StyledRect {
+            Layout.fillWidth: true
+
+            visible: root.lastError !== ""
+            implicitHeight: visible ? errorText.implicitHeight + Tokens.padding.medium * 2 : 0
+            radius: Tokens.rounding.small
+            color: Colours.palette.m3errorContainer
+
+            StyledText {
+                id: errorText
+
+                anchors.fill: parent
+                anchors.margins: Tokens.padding.medium
+                text: root.lastError
+                color: Colours.palette.m3onErrorContainer
+                wrapMode: Text.Wrap
+                font: Tokens.font.body.small
+            }
+
+            Behavior on implicitHeight {
+                Anim {
+                    duration: Tokens.anim.durations.small
+                }
+            }
+        }
+
+        // Audio Sources Section
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: !root.recordingBusy
+            spacing: Tokens.spacing.small
+
+            RowLayout {
+                spacing: Tokens.spacing.small
+
+                StyledText {
+                    text: qsTr("Audio Sources")
+                    font: Tokens.font.body.small
+                    color: Colours.palette.m3onSurfaceVariant
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                IconButton {
+                    icon: root.props.recordingAudioExpanded ? "unfold_less" : "unfold_more"
+                    type: IconButton.Text
+                    label.animate: true
+                    onClicked: {
+                        root.props.recordingAudioExpanded = !root.props.recordingAudioExpanded;
+                    }
+                }
+            }
+
+            Item {
+                id: audioSourcesContainer
+
+                Layout.fillWidth: true
+                Layout.preferredHeight: root.props.recordingAudioExpanded ? audioSourcesLayout.implicitHeight : 0
+                clip: true
+                enabled: root.props.recordingAudioExpanded
+                opacity: root.props.recordingAudioExpanded ? 1 : 0
+                visible: root.props.recordingAudioExpanded || height > 0
+
+                ColumnLayout {
+                    id: audioSourcesLayout
+
+                    width: parent.width
+                    y: root.props.recordingAudioExpanded ? 0 : -Tokens.spacing.small
+                    spacing: Tokens.spacing.extraSmall
+
+                    // System Audio (Default Sink)
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Tokens.spacing.medium
+
+                        StyledSwitch {
+                            checked: GlobalConfig.utilities?.recording?.recordSystem ?? true
+                            onToggled: {
+                                if (GlobalConfig.utilities?.recording) {
+                                    GlobalConfig.utilities.recording.recordSystem = checked;
+                                    GlobalConfig.save();
+                                }
+                            }
+                        }
+
+                        StyledText {
+                            Layout.preferredWidth: 85
+                            text: qsTr("System")
+                            font: Tokens.font.body.small
+                            elide: Text.ElideRight
+                        }
+
+                        StyledSlider {
+                            Layout.fillWidth: true
+
+                            implicitHeight: 24
+                            opacity: (GlobalConfig.utilities?.recording?.recordSystem ?? true) ? 1.0 : 0.5
+                            from: 0
+                            to: 1
+                            value: Audio.volume
+                            onMoved: Audio.setVolume(value)
+                        }
+
+                        StyledText {
+                            text: Math.round(Audio.volume * 100) + "%"
+                            font: Tokens.font.body.small
+                            color: Colours.palette.m3onSurfaceVariant
+                            Layout.preferredWidth: 40
+                        }
+
+                        IconButton {
+                            icon: Audio.muted ? "volume_off" : "volume_up"
+                            type: Audio.muted ? IconButton.Filled : IconButton.Tonal
+                            font: Tokens.font.icon.small
+                            onClicked: {
+                                if (Audio.sink?.audio)
+                                    Audio.sink.audio.muted = !Audio.sink.audio.muted;
+                            }
+                        }
+                    }
+
+                    // Microphone (Default Source)
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Tokens.spacing.medium
+
+                        StyledSwitch {
+                            checked: GlobalConfig.utilities?.recording?.recordMicrophone ?? false
+                            onToggled: {
+                                if (GlobalConfig.utilities?.recording) {
+                                    GlobalConfig.utilities.recording.recordMicrophone = checked;
+                                    GlobalConfig.save();
+                                }
+                            }
+                        }
+
+                        StyledText {
+                            Layout.preferredWidth: 85
+                            text: qsTr("Microphone")
+                            font: Tokens.font.body.small
+                            elide: Text.ElideRight
+                        }
+
+                        StyledSlider {
+                            Layout.fillWidth: true
+
+                            implicitHeight: 24
+                            opacity: (GlobalConfig.utilities?.recording?.recordMicrophone ?? false) ? 1.0 : 0.5
+                            from: 0
+                            to: 1
+                            value: Audio.sourceVolume
+                            onMoved: Audio.setSourceVolume(value)
+                        }
+
+                        StyledText {
+                            text: Math.round(Audio.sourceVolume * 100) + "%"
+                            font: Tokens.font.body.small
+                            color: Colours.palette.m3onSurfaceVariant
+                            Layout.preferredWidth: 40
+                        }
+
+                        IconButton {
+                            icon: Audio.sourceMuted ? "mic_off" : "mic"
+                            type: Audio.sourceMuted ? IconButton.Filled : IconButton.Tonal
+                            font: Tokens.font.icon.small
+                            onClicked: {
+                                if (Audio.source?.audio)
+                                    Audio.source.audio.muted = !Audio.source.audio.muted;
+                            }
+                        }
+                    }
+
+                    Behavior on y {
+                        Anim {
+                            duration: Tokens.anim.durations.small
+                        }
+                    }
+                }
+
+                Behavior on Layout.preferredHeight {
+                    Anim {
+                        type: Anim.DefaultSpatial
+                    }
+                }
+
+                Behavior on opacity {
+                    Anim {
+                        duration: Tokens.anim.durations.small
+                    }
+                }
             }
         }
 
         Loader {
             id: listOrControls
 
-            property bool running: Recorder.running
+            property bool running: root.recordingBusy
 
             asynchronous: true
             Layout.fillWidth: true
@@ -182,7 +462,7 @@ StyledRect {
 
             StyledRect {
                 radius: Tokens.rounding.full
-                color: Recorder.paused ? Colours.palette.m3tertiary : Colours.palette.m3error
+                color: Recorder.starting ? Colours.palette.m3secondary : Recorder.paused ? Colours.palette.m3tertiary : Colours.palette.m3error
 
                 implicitWidth: recText.implicitWidth + Tokens.padding.medium * 2
                 implicitHeight: recText.implicitHeight + Tokens.padding.large
@@ -202,7 +482,7 @@ StyledRect {
                 }
 
                 SequentialAnimation on opacity {
-                    running: !Recorder.paused
+                    running: !Recorder.starting && !Recorder.paused && Recorder.running
                     alwaysRunToEnd: true
                     loops: Animation.Infinite
 
@@ -224,18 +504,17 @@ StyledRect {
             StyledText {
                 Layout.fillWidth: true
                 text: {
+                    if (Recorder.starting)
+                        return root.startingText(Recorder.videoMode || root.currentVideoMode);
                     const elapsed = Recorder.elapsed;
-
                     const hours = Math.floor(elapsed / 3600);
                     const mins = Math.floor((elapsed % 3600) / 60);
                     const secs = Math.floor(elapsed % 60).toString().padStart(2, "0");
-
                     let time;
                     if (hours > 0)
                         time = `${hours}:${mins.toString().padStart(2, "0")}:${secs}`;
                     else
                         time = `${mins}:${secs}`;
-
                     return qsTr("Recording for %1").arg(time);
                 }
                 font: Tokens.font.body.medium
@@ -246,44 +525,23 @@ StyledRect {
                 spacing: Tokens.spacing.extraSmall
 
                 IconButton {
-                    shapeMorph: true
-                    isRound: true
-                    label.animate: true
                     icon: Recorder.paused ? "play_arrow" : "pause"
                     isToggle: true
                     checked: Recorder.paused
                     type: IconButton.Tonal
-                    font: Tokens.font.icon.medium
+                    font: Tokens.font.icon.large
                     onClicked: {
                         Recorder.togglePause();
                         internalChecked = Recorder.paused;
                     }
-
-                    implicitWidth: {
-                        // Ensure even size so icon is centered properly
-                        const h = label.implicitHeight + Tokens.padding.large * 2;
-                        if (h % 2 !== 0)
-                            return h + 1;
-                        return h;
-                    }
                 }
 
                 IconButton {
-                    shapeMorph: true
-                    isRound: true
                     icon: "stop"
                     inactiveColour: Colours.palette.m3error
                     inactiveOnColour: Colours.palette.m3onError
-                    font: Tokens.font.icon.medium
+                    font: Tokens.font.icon.large
                     onClicked: Recorder.stop()
-
-                    implicitWidth: {
-                        // Ensure even size so icon is centered properly
-                        const h = label.implicitHeight + Tokens.padding.large * 2;
-                        if (h % 2 !== 0)
-                            return h + 1;
-                        return h;
-                    }
                 }
             }
         }

--- a/modules/utilities/cards/Record.qml
+++ b/modules/utilities/cards/Record.qml
@@ -19,6 +19,9 @@ StyledRect {
     property string lastError: ""
     readonly property string currentVideoMode: GlobalConfig.utilities?.recording?.videoMode ?? "fullscreen"
 
+    // Parallel to the split button's menu items
+    readonly property list<string> videoModes: ["fullscreen", "region", "window"]
+
     // gpu-screen-recorder takes one audio argument, so the two switches collapse
     // into a single mode
     readonly property string currentAudioMode: {
@@ -156,39 +159,31 @@ StyledRect {
 
             SplitButton {
                 disabled: root.recordingBusy
-                active: menuItems.find(m => m["mode"] === root.currentVideoMode) ?? menuItems[0]
-                menu.onItemSelected: item => root.setVideoMode(item["mode"])
+                active: menuItems[root.videoModes.indexOf(root.currentVideoMode)] ?? menuItems[0]
+                menu.onItemSelected: item => {
+                    const idx = menuItems.indexOf(item);
+                    if (idx >= 0)
+                        root.setVideoMode(root.videoModes[idx]);
+                }
 
                 menuItems: [
                     MenuItem {
-                        id: modeFullscreen
-
-                        property string mode: "fullscreen"
-
                         icon: "fullscreen"
                         text: qsTr("Record fullscreen")
                         activeText: qsTr("Fullscreen")
-                        onClicked: root.startRecording(modeFullscreen.mode)
+                        onClicked: root.startRecording("fullscreen")
                     },
                     MenuItem {
-                        id: modeRegion
-
-                        property string mode: "region"
-
                         icon: "screenshot_region"
                         text: qsTr("Record region")
                         activeText: qsTr("Region")
-                        onClicked: root.startRecording(modeRegion.mode)
+                        onClicked: root.startRecording("region")
                     },
                     MenuItem {
-                        id: modeWindow
-
-                        property string mode: "window"
-
                         icon: "web_asset"
                         text: qsTr("Record window")
                         activeText: qsTr("Window")
-                        onClicked: root.startRecording(modeWindow.mode)
+                        onClicked: root.startRecording("window")
                     }
                 ]
             }

--- a/plugin/src/Caelestia/Config/utilitiesconfig.hpp
+++ b/plugin/src/Caelestia/Config/utilitiesconfig.hpp
@@ -59,6 +59,19 @@ public:
         : ConfigObject(parent) {}
 };
 
+class UtilitiesRecording : public ConfigObject {
+    Q_OBJECT
+    QML_ANONYMOUS
+
+    CONFIG_GLOBAL_PROPERTY(bool, recordSystem, true)
+    CONFIG_GLOBAL_PROPERTY(bool, recordMicrophone, false)
+    CONFIG_GLOBAL_PROPERTY(QString, videoMode, u"fullscreen"_s)
+
+public:
+    explicit UtilitiesRecording(QObject* parent = nullptr)
+        : ConfigObject(parent) {}
+};
+
 class UtilitiesConfig : public ConfigObject {
     Q_OBJECT
     QML_ANONYMOUS
@@ -68,6 +81,7 @@ class UtilitiesConfig : public ConfigObject {
     CONFIG_SUBOBJECT(UtilitiesCards, cards)
     CONFIG_SUBOBJECT(UtilitiesToasts, toasts)
     CONFIG_SUBOBJECT(UtilitiesVpn, vpn)
+    CONFIG_SUBOBJECT(UtilitiesRecording, recording)
     CONFIG_LIST(EntryList, quickToggles,
         {
             LIST_ENTRY(wifi, true),
@@ -84,7 +98,8 @@ public:
         : ConfigObject(parent)
         , m_cards(new UtilitiesCards(this))
         , m_toasts(new UtilitiesToasts(this))
-        , m_vpn(new UtilitiesVpn(this)) {}
+        , m_vpn(new UtilitiesVpn(this))
+        , m_recording(new UtilitiesRecording(this)) {}
 };
 
 } // namespace caelestia::config

--- a/services/Recorder.qml
+++ b/services/Recorder.qml
@@ -8,75 +8,142 @@ Singleton {
     id: root
 
     readonly property alias running: props.running
+    readonly property alias starting: props.starting
     readonly property alias paused: props.paused
     readonly property alias elapsed: props.elapsed
-    property bool needsStart
-    property list<string> startArgs
-    property bool needsStop
-    property bool needsPause
+    readonly property alias videoMode: props.videoMode
+    readonly property alias audioMode: props.audioMode
 
-    function start(extraArgs = []): void {
-        needsStart = true;
-        startArgs = extraArgs;
-        checkProc.running = true;
+    // Region and window captures only spawn the recorder once the user has
+    // picked a target, so give them room before calling the start a failure.
+    readonly property int maxChecks: 30
+
+    property bool stopping: false
+    property int checks: 0
+
+    signal errorOccurred(errorMsg: string)
+    signal recordingStarted
+    signal recordingStopped
+
+    function start(videoMode: string, audioMode: string): void {
+        if (props.running || props.starting) {
+            root.errorOccurred(qsTr("A recording is already in progress"));
+            return;
+        }
+
+        props.videoMode = videoMode || "fullscreen";
+        props.audioMode = audioMode || "none";
+        props.starting = true;
+        props.paused = false;
+        props.elapsed = 0;
+        root.checks = 0;
+
+        Quickshell.execDetached(["caelestia", "record", "--mode", props.videoMode, "--audio", props.audioMode]);
+        poll.restart();
     }
 
     function stop(): void {
-        needsStop = true;
-        checkProc.running = true;
+        if (!props.running && !props.starting)
+            return;
+
+        root.stopping = true;
+        root.checks = 0;
+        Quickshell.execDetached(["caelestia", "record", "--stop"]);
+        poll.restart();
     }
 
     function togglePause(): void {
-        needsPause = true;
-        checkProc.running = true;
+        if (!props.running || root.stopping)
+            return;
+
+        Quickshell.execDetached(["caelestia", "record", "--pause"]);
+        props.paused = !props.paused;
     }
+
+    function reset(): void {
+        root.stopping = false;
+        root.checks = 0;
+        props.starting = false;
+        props.running = false;
+        props.paused = false;
+        props.elapsed = 0;
+    }
+
+    Component.onCompleted: pidof.running = true
 
     PersistentProperties {
         id: props
 
         property bool running: false
+        property bool starting: false
         property bool paused: false
         property real elapsed: 0 // Might get too large for int
+        property string videoMode: "fullscreen"
+        property string audioMode: "none"
 
         reloadableId: "recorder"
     }
 
+    // The CLI hands off to gpu-screen-recorder and exits, so its own exit says
+    // nothing about whether a recording is up. Watching for the process is the
+    // only way to know, and it also picks up a recording started from a
+    // terminal or one that died on its own.
     Process {
-        id: checkProc
+        id: pidof
 
-        running: true
         command: ["pidof", "gpu-screen-recorder"]
+
         onExited: code => { // qmllint disable signal-handler-parameters
-            props.running = code === 0;
+            const alive = code === 0;
 
-            if (code === 0) {
-                if (root.needsStop) {
-                    Quickshell.execDetached(["caelestia", "record"]);
-                    props.running = false;
-                    props.paused = false;
-                } else if (root.needsPause) {
-                    Quickshell.execDetached(["caelestia", "record", "-p"]);
-                    props.paused = !props.paused;
+            if (root.stopping) {
+                if (alive && ++root.checks < root.maxChecks) {
+                    poll.restart();
+                    return;
                 }
-            } else if (root.needsStart) {
-                Quickshell.execDetached(["caelestia", "record", ...root.startArgs]);
+                root.reset();
+                root.recordingStopped();
+            } else if (props.starting) {
+                if (alive) {
+                    root.checks = 0;
+                    props.starting = false;
+                    props.running = true;
+                    root.recordingStarted();
+                    poll.restart();
+                    return;
+                }
+                if (++root.checks < root.maxChecks) {
+                    poll.restart();
+                    return;
+                }
+                root.reset();
+                root.errorOccurred(qsTr("Recording did not start"));
+            } else if (props.running) {
+                if (alive) {
+                    poll.restart();
+                    return;
+                }
+                root.reset();
+                root.recordingStopped();
+            } else if (alive) {
+                // Adopt whatever was already recording when the shell came up
                 props.running = true;
-                props.paused = false;
-                props.elapsed = 0;
+                poll.restart();
             }
-
-            root.needsStart = false;
-            root.needsStop = false;
-            root.needsPause = false;
         }
     }
 
-    Connections {
-        // enabled: props.running && !props.paused
-        function onSecondsChanged(): void {
-            props.elapsed++;
-        }
+    Timer {
+        id: poll
 
-        target: Time // qmllint disable incompatible-type
+        interval: root.stopping ? 500 : props.starting ? 1000 : 3000
+        onTriggered: pidof.running = true
+    }
+
+    Timer {
+        interval: 1000
+        repeat: true
+        running: props.running && !props.paused
+        onTriggered: props.elapsed++
     }
 }


### PR DESCRIPTION
Moves screen recording control out of the CLI and into the utilities card.

> [!NOTE]
> Needs caelestia-dots/cli#150, which adds `caelestia record --mode/--audio/--stop`. Without it the card renders fine but starting a recording does nothing.

### Capture modes

The split button now picks **fullscreen**, **region** or **window** and remembers the choice, so it both starts the recording and doubles as the mode selector.

### Audio sources

System and microphone toggle independently, each with the live volume slider and mute button for that device, so you can set levels at the moment you start recording instead of hunting for them afterwards. The pair collapses into the single audio mode `gpu-screen-recorder` takes.

### State that reflects reality

Previously the card assumed whatever it last asked for had happened. It now watches for the recorder process:

- **Start is confirmed** before the card claims to be recording. This matters for region and window captures, where nothing spawns until you have picked a target — the card says "Starting…" until the recorder is actually up.
- **Stop is confirmed** the same way.
- **A recording that dies on its own is noticed**, rather than leaving a timer running forever.
- **A recording started outside the shell is adopted**, so the card is right after a shell reload or when you started from a terminal.
- **Failures surface on the card** instead of leaving it stuck showing a recording that is not happening.

### Config

```json
"utilities": {
    "recording": {
        "recordSystem": true,
        "recordMicrophone": false,
        "videoMode": "fullscreen"
    }
}
```
