### PR TITLE
services/hypr: fix CapsLock refresh shortcut on Lua Hyprland setups

### DIFF
--- a/services/Hypr.qml
+++ b/services/Hypr.qml
@@ -95,6 +95,7 @@ Singleton {
         }
     }
 
+    onUsingLuaChanged: reloadDynamicConfs()
     Component.onCompleted: reloadDynamicConfs()
 
     onCapsLockChanged: {


### PR DESCRIPTION
## Summary

Fixes CapsLock & NumLock refresh shortcuts failing on Hyprland setups using `hyprland.lua`.

Multiple people confirmed that their CapsLock tray icon doesn't show up on startup. A workaround was changing the wallpaper, which makes it start working. Because of this, not everyone seems affected (for example, if you change your wallpaper often or use an auto-changer on boot). But some said they cannot replicate the bug at all.

`Quickshell.Hyprland` doesn't provide `usingLua`, so `Hypr.qml` was defaulting to `false` and sending legacy `keyword bindlni` commands, which Hyprland rejects on Lua configs.

- Auto-detects `hyprland.lua` in `HyprExtras` and wires `Hypr.usingLua` to it.
- Handles error responses in `makeRequest` instead of ignoring non-ok replies.

## Testing

- Tested in nested Hyprland with Lua configuration.
- Verified CapsLock status bar indicator updates properly on toggle.

## Showcase

### Before (Vanilla `main` branch):
https://github.com/user-attachments/assets/b534b07a-d656-4aea-ae84-edb1af920efb

### After (With fix):
https://github.com/user-attachments/assets/31efa1a5-80b7-42c1-8ffa-b1e3dd97a2c9