### PR TITLE
fix: don't autosave config after loading it

### DIFF
--- a/plugin/src/Caelestia/Config/confignode.cpp
+++ b/plugin/src/Caelestia/Config/confignode.cpp
@@ -97,4 +97,19 @@ void ConfigNode::emitBatchedChanges() {
     emit propertiesChanged(changes);
 }
 
+void ConfigNode::flushBatchedChanges() {
+    if (!m_batchTimer)
+        return;
+
+    m_batchTimer->stop();
+    emitBatchedChanges();
+}
+
+void ConfigNode::discardBatchedChanges() {
+    if (m_batchTimer)
+        m_batchTimer->stop();
+
+    m_pendingChanges.clear();
+}
+
 } // namespace caelestia::config

--- a/plugin/src/Caelestia/Config/confignode.hpp
+++ b/plugin/src/Caelestia/Config/confignode.hpp
@@ -36,6 +36,14 @@ public:
     void syncFromGlobal(ConfigNode* global);
     virtual void resyncFromGlobal() = 0;
 
+    // Delivers queued change notifications immediately, instead of waiting for
+    // the next event loop tick. Used by loads so listeners hear load-time
+    // writes while the root still knows a load is in progress.
+    void flushBatchedChanges();
+    // Drops queued change notifications without delivering them, for writes
+    // superseded by an incoming load.
+    void discardBatchedChanges();
+
     [[nodiscard]] bool isOverlay() const;
     [[nodiscard]] QString propertyPath(const QString& name = {}) const;
 

--- a/plugin/src/Caelestia/Config/rootconfig.cpp
+++ b/plugin/src/Caelestia/Config/rootconfig.cpp
@@ -111,6 +111,22 @@ void RootConfig::connectAutoSave(ConfigNode* node) {
         connectAutoSave(child);
 }
 
+void RootConfig::flushPendingBatches(ConfigNode* node) {
+    node->flushBatchedChanges();
+
+    const auto children = node->childNodes();
+    for (auto* const child : children)
+        flushPendingBatches(child);
+}
+
+void RootConfig::discardPendingBatches(ConfigNode* node) {
+    node->discardBatchedChanges();
+
+    const auto children = node->childNodes();
+    for (auto* const child : children)
+        discardPendingBatches(child);
+}
+
 void RootConfig::updateWatch() {
     auto targetDir = QFileInfo(m_filePath).absolutePath();
 
@@ -231,7 +247,16 @@ std::optional<QString> RootConfig::reloadFromFile() {
 
     clearLoadedKeys();
 
+    // Drop notifications queued before the load, e.g. an edit made in the same
+    // tick as a reload: the file supersedes them and queued values are stale.
+    discardPendingBatches(this);
+
     loadFromJson(doc.object());
+
+    // Deliver load-time notifications while m_loading is still set, so auto-save
+    // (gated on m_loading) does not rewrite the very file it just read. Without
+    // this the 0ms batching timer delivers after the flag has been cleared.
+    flushPendingBatches(this);
 
     m_loading = false;
 

--- a/plugin/src/Caelestia/Config/rootconfig.hpp
+++ b/plugin/src/Caelestia/Config/rootconfig.hpp
@@ -42,6 +42,10 @@ private:
     [[nodiscard]] QString fileSignature() const;
 
     void connectAutoSave(ConfigNode* node);
+    // Applies flush/discard to the whole config tree, mirroring connectAutoSave's
+    // traversal. Spans lists' child objects but not their elements, which load quietly.
+    void flushPendingBatches(ConfigNode* node);
+    void discardPendingBatches(ConfigNode* node);
     // Blocks saving until a load succeeds, memory no longer represents the file
     void markLoadFailed();
 


### PR DESCRIPTION
On every shell start, the config system rewrites the `shell.json` file it just read. The write comes from the auto-save hook, which treats the property changes delivered after a load as user edits.
On setups where the config file is immutable (e.g. NixOS/home-manager configs symlinked into the read-only nix store), that write fails with EROFS, and users see a "Failed to write config" error toast on every login.

Root cause:
`RootConfig::reloadFromFile` clears `m_loading` before the batched change notifications are actually delivered:
- Load-time changes are queued (`notifyPropertyChanged`) during `loadFromJson`.
- `m_loading = false` runs immediately after.
- The batch timer fires on the next event loop tick, and by then `m_loading` is clear, so the auto-save hook sees a load as ordinary edits and eagerly saves.

Change:
- `discardPendingBatches` before the load: drops anything queued beforehand that the load supersedes.
- `flushPendingBatches` after the load: delivers load-time notifications synchronously while `m_loading` is still set, so the auto-save hook correctly ignores the load.

Result: 
- No notification is lost; they are merely delivered during the load frame instead of after it.
- The spurious startup save no longer happens; files are untouched on start when nothing was edited.
- Per-screen overlay configs also stop receiving a redundant initial "sync" batch at start, which previously caused them to rewrite their own files once per boot. Overlays still receive the initial values at construction (`syncValuesFromGlobal`), so behavior is unchanged.
- Config consumers (fonts, animations, lists) rebuild from current values at `bind()`, so they are unaffected by the batch arriving earlier.
