### PR TITLE
fix: restore broken star history chart in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,10 +950,10 @@ Finally another thank you to all the configs I took inspiration from (only one f
 
 ## Stonks 📈
 
-<a href="https://www.star-history.com/#caelestia-dots/shell&Date">
+<a href="https://star-history.dera.page/#caelestia-dots/shell&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=caelestia-dots/shell&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=caelestia-dots/shell&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=caelestia-dots/shell&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=caelestia-dots/shell&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=caelestia-dots/shell&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=caelestia-dots/shell&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the readme is currently broken because the GitHub stargazer API is restricted. This change points it at a working mirror so the chart renders again.