### PR TITLE
perf(images): defer sourceSize binding until layout has valid dimensions

### DIFF
--- a/components/images/CachingImage.qml
+++ b/components/images/CachingImage.qml
@@ -12,6 +12,6 @@ Image {
     source: IUtils.urlForPath(path, fillMode)
     sourceSize: {
         const dpr = (QsWindow.window as QsWindow)?.devicePixelRatio ?? 1;
-        return Qt.size(width * dpr, height * dpr);
+        return width > 0 && height > 0 ? Qt.size(width * dpr, height * dpr) : undefined;
     }
 }


### PR DESCRIPTION
# Fix redundant full-resolution decode in CachingImage on first paint

## The Problem

Before, `CachingImage` linked the size directly to the width and height. During the initial layout phase and before the parent's first geometry pass and both of these values are 0.

The Image component in Qt Quick interprets a 0x0 `sourceSize` value the same as an unset `sourceSize` value. As a result, the decoder uses the image's natural resolution instead of the intended target size. This causes a full-resolution decode on first paint, which is unnecessary and expensive. This happens with large source images, like high-res wallpapers which i have. The image is decoded and made larger. Then, the real dimensions are calculated. The image is discarded a frame later.

## The Solution
Guard the `sourceSize` assignment with a check for valid dimensions (`width > 0 && height > 0`). This ensures `sourceSize` is only set once the actual target dimensions are available, effectively avoiding the problem

## Benchmark Results
Tested with 7 wallpapers rendered on an active Wayland surface with OpenGL texture decoding. Memory measured via `/proc/<pid>/smaps_rollup`:

| Metric | Before (Unpatched 0x0) | After (With Fix) | Real Memory Saved |
| :--- | :--- | :--- | :--- |
| **Physical RAM (RSS)** | 440 MB (451,056 KB) | 379 MB (388,492 KB) | **–61.1 MB** |
| **Actual Footprint (PSS)** | 260 MB (266,274 KB) | 198 MB (203,578 KB) | **–61.2 MB** *(24% Drop)* |
| **Private Memory (USS)** | 175 MB (179,444 KB) | 113 MB (116,728 KB) | **–62.7 MB** *(35% Drop)* |