### PR TITLE
docs: refactor and update `README.md` for improved clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![GitHub Repo stars](https://img.shields.io/github/stars/caelestia-dots/shell?style=for-the-badge&labelColor=101418&color=b9c8da)
 ![GitHub repo size](https://img.shields.io/github/repo-size/caelestia-dots/shell?style=for-the-badge&labelColor=101418&color=d3bfe6)
 [![Ko-Fi donate](https://img.shields.io/badge/donate-kofi?style=for-the-badge&logo=ko-fi&logoColor=ffffff&label=ko-fi&labelColor=101418&color=f16061&link=https%3A%2F%2Fko-fi.com%2Fsoramane)](https://ko-fi.com/soramane)
-[![Discord invite](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscordapp.com%2Fapi%2Finvites%2FBGDCFCmMBk%3Fwith_counts%3Dtrue&query=approximate_member_count&style=for-the-badge&logo=discord&logoColor=ffffff&label=discord&labelColor=101418&color=96f1f1&link=https%3A%2F%2Fdiscord.gg%2FBGDCFCmMBk)](https://discord.gg/BGDCFCmMBk)
+[![Discord invite](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscordapp.com%2Fapi%2Finvites%2FBGDCFCmMBk%3Fwith_counts%3Dtrue&query=approximate_member_count&style=for-the-badge&logo=discord&logoColor=ffffff&label=discord&labelColor=101418&color=96f1f1&link=https%3A%2F%2Fdiscord.gg%2FBGDCFCmMBk)][discord]
 
 </div>
 
@@ -15,34 +15,33 @@ https://github.com/user-attachments/assets/0840f496-575c-4ca6-83a8-87bb01a85c5f
 ## Components
 
 -   Widgets: [`Quickshell`](https://quickshell.outfoxxed.me)
--   Window manager: [`Hyprland`](https://hyprland.org)
--   Dots: [`caelestia`](https://github.com/caelestia-dots)
+-   Window manager: [`Hyprland`](https://hypr.land)
+-   Dots: [`caelestia`][dots-repo]
 
 ## Installation
 
 > [!NOTE]
-> This repo is for the desktop shell of the caelestia dots. If you want installation instructions
-> for the entire dots, head to [the main repo](https://github.com/caelestia-dots/caelestia) instead.
+> This repo is for Caelestia's desktop shell only. If you want installation instructions
+> for the entire dotfiles (which include this shell), head to [the main repo][dots-repo] instead.
 
-### Arch linux
+### Arch Linux
 
-> [!NOTE]
-> If you want to make your own changes/tweaks to the shell do NOT edit the files installed by the AUR
+> [!WARNING]
+> If you want to make your own changes/tweaks to the shell, do NOT edit the files installed by the AUR
 > package. Instead, follow the instructions in the [manual installation section](#manual-installation).
 
-The shell is available from the AUR as `caelestia-shell`. You can install it with an AUR helper
-like [`yay`](https://github.com/Jguer/yay) or manually downloading the PKGBUILD and running `makepkg -si`.
+The shell is available from the AUR as `caelestia-shell`. You can install it with an AUR helper (recommended),
+like [`paru`](https://github.com/morganamilo/paru), or by manually downloading the PKGBUILD and running `makepkg -si`.
 
-A package following the latest commit also exists as `caelestia-shell-git`. This is bleeding edge
-and likely to be unstable/have bugs. Regular users are recommended to use the stable package
-(`caelestia-shell`).
+A package following the latest commit also exists as `caelestia-shell-git`. This is bleeding-edge
+and likely to be unstable/have bugs. Regular users are recommended to use the stable package (`caelestia-shell`).
 
 ### Nix
 
 You can run the shell directly via `nix run`:
 
 ```sh
-nix run github:caelestia-dots/shell
+nix run github:caelestia-dots/shell#with-cli
 ```
 
 Or add it to your system configuration:
@@ -60,48 +59,52 @@ Or add it to your system configuration:
 }
 ```
 
-The package is available as `caelestia-shell.packages.<system>.default`, which can be added to your
+For full functionality, use `caelestia-shell.packages.<system>.with-cli`, which can be added to your
 `environment.systemPackages`, `users.users.<username>.packages`, `home.packages` if using home-manager,
-or a devshell. The shell can then be run via `caelestia-shell`.
+or a devshell. The `default` package does not include the CLI.
+You can then run the shell with `caelestia-shell`.
 
-> [!TIP]
-> The default package does not have the CLI enabled by default, which is required for full funcionality.
-> To enable the CLI, use the `with-cli` package.
-
-For home-manager, you can also use the Caelestia's home manager module (explained in [configuring](https://github.com/caelestia-dots/shell?tab=readme-ov-file#home-manager-module)) that installs and configures the shell and the CLI.
+For home-manager, you can also use Caelestia's Home Manager module (explained in [the configuration section](#home-manager-module)), which installs and configures the shell and CLI.
 
 ### Manual installation
 
 Dependencies:
 
 -   [`caelestia-cli`](https://github.com/caelestia-dots/cli)
--   [`quickshell-git`](https://quickshell.outfoxxed.me) - this has to be the git version, not the latest tagged version
+-   [`quickshell-git`](https://git.outfoxxed.me/quickshell/quickshell) - this has to be the git version, not the latest tagged version
+-   `glibc`
+-   `gcc-libs`
 -   [`ddcutil`](https://github.com/rockowitz/ddcutil)
 -   [`brightnessctl`](https://github.com/Hummer12007/brightnessctl)
 -   [`libcava`](https://github.com/LukashonakV/cava)
--   [`networkmanager`](https://networkmanager.dev)
--   [`lm-sensors`](https://github.com/lm-sensors/lm-sensors)
--   [`fish`](https://github.com/fish-shell/fish-shell)
+-   [`networkmanager`](https://gitlab.freedesktop.org/NetworkManager/NetworkManager)
+-   [`lm_sensors`](https://github.com/lm-sensors/lm-sensors)
 -   [`aubio`](https://github.com/aubio/aubio)
--   [`libpipewire`](https://pipewire.org)
--   `glibc`
--   `qt6-declarative`
--   `gcc-libs`
--   [`material-symbols`](https://fonts.google.com/icons)
--   [`caskaydia-cove-nerd`](https://www.nerdfonts.com/font-downloads)
--   [`swappy`](https://github.com/jtheoof/swappy)
+-   [`libpipewire`](https://github.com/PipeWire/pipewire)
 -   [`libqalculate`](https://github.com/Qalculate/libqalculate)
--   [`bash`](https://www.gnu.org/software/bash)
+-   [`power-profiles-daemon`](https://gitlab.freedesktop.org/upower/power-profiles-daemon)
+-   [`ttf-material-symbols-variable`](https://github.com/google/material-design-icons)
+-   [`ttf-rubik-vf`](https://github.com/googlefonts/rubik)
+-   [`ttf-cascadia-code-nerd`](https://github.com/ryanoasis/nerd-fonts)
 -   `qt6-base`
 -   `qt6-declarative`
+-   `qt6-imageformats`
+-   [`swappy`](https://github.com/jtheoof/swappy)
+-   [`fish`](https://github.com/fish-shell/fish-shell)
+-   [`bash`](https://www.gnu.org/software/bash)
 
 Build dependencies:
 
--   [`cmake`](https://cmake.org)
+-   [`cmake`](https://gitlab.kitware.com/cmake/cmake)
 -   [`ninja`](https://github.com/ninja-build/ninja)
+-   `qt6-shadertools`
+
+> [!IMPORTANT]
+> The commands (and in the "Updating" section) expect `$XDG_CONFIG_HOME` to be set.
+> If it is unset, substitute it with the path to your config folder (typically `~/.config`).
 
 To install the shell manually, install all dependencies and clone this repo to `$XDG_CONFIG_HOME/quickshell/caelestia`.
-Then simply build and install using `cmake`.
+Then build and install using `cmake`.
 
 ```sh
 cd $XDG_CONFIG_HOME/quickshell
@@ -114,16 +117,16 @@ sudo cmake --install build
 ```
 
 > [!TIP]
-> You can customise the installation location via the `cmake` flags `INSTALL_LIBDIR`, `INSTALL_QMLDIR` and
-> `INSTALL_QSCONFDIR` for the libraries (the beat detector), QML plugin and Quickshell config directories
+> You can customise the installation location via the CMake flags `INSTALL_LIBDIR`, `INSTALL_QMLDIR`, and
+> `INSTALL_QSCONFDIR` for the libraries (e.g., the beat detector), QML plugin, and Quickshell config directories
 > respectively. If changing the library directory, remember to set the `CAELESTIA_LIB_DIR` environment
 > variable to the custom directory when launching the shell.
 >
-> e.g. installing to `~/.config/quickshell/caelestia` for easy local changes:
+> e.g., installing to `~/.config/quickshell/caelestia` for easy local changes:
 >
 > ```sh
 > mkdir -p ~/.config/quickshell/caelestia
-> cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/ -DINSTALL_QSCONFDIR=~/.config/quickshell/caelestia
+> cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/ -DINSTALL_QSCONFDIR="$HOME/.config/quickshell/caelestia"
 > cmake --build build
 > sudo cmake --install build
 > sudo chown -R $USER ~/.config/quickshell/caelestia
@@ -131,70 +134,53 @@ sudo cmake --install build
 
 ## Usage
 
-The shell can be started via the `caelestia shell -d` command or `qs -c caelestia`.
-If the entire caelestia dots are installed, the shell will be autostarted on login
-via an `exec-once` in the hyprland config.
+You can start the shell by running `caelestia shell -d` (preferred) or `qs -c caelestia -n -d`.
+You may omit `-d` from the command to keep the shell attached to the current terminal if necessary,
+though you likely want it to be detached (so it doesn't close when the terminal is closed).
+
+If using the [Caelestia dotfiles][dots-repo], the shell will be autostarted on login
+via a `hl.on("hyprland.start", ...)` function in the Hyprland config.
 
 ### Shortcuts/IPC
 
-All keybinds are accessible via Hyprland [global shortcuts](https://wiki.hyprland.org/Configuring/Binds/#dbus-global-shortcuts).
-If using the entire caelestia dots, the keybinds are already configured for you.
-Otherwise, [this file](https://github.com/caelestia-dots/caelestia/blob/main/hypr/hyprland/keybinds.conf#L1-L39)
-contains an example on how to use global shortcuts.
+All keybinds are accessible via Hyprland [global shortcuts](https://wiki.hypr.land/Configuring/Basics/Binds/#dbus-global-shortcuts).
+If using the [Caelestia dotfiles][dots-repo], the keybinds are already configured for you.
+Otherwise, the [`keybinds.lua` file](https://github.com/caelestia-dots/caelestia/blob/main/hypr/hyprland/keybinds.lua#L63-L67)
+contains an example of how to use global shortcuts.
 
-All IPC commands can be accessed via `caelestia shell ...`. For example
+All IPC commands can be accessed via `caelestia shell ...`, for example:
 
 ```sh
 caelestia shell mpris getActive trackTitle
 ```
 
-The list of IPC commands can be shown via `caelestia shell -s`:
-
-```
-$ caelestia shell -s
-target drawers
-  function toggle(drawer: string): void
-  function list(): string
-target notifs
-  function clear(): void
-target lock
-  function lock(): void
-  function unlock(): void
-  function isLocked(): bool
-target mpris
-  function playPause(): void
-  function getActive(prop: string): string
-  function next(): void
-  function stop(): void
-  function play(): void
-  function list(): string
-  function pause(): void
-  function previous(): void
-target picker
-  function openFreeze(): void
-  function open(): void
-target wallpaper
-  function set(path: string): void
-  function get(): string
-  function list(): string
-```
+You can view the list of available IPC commands by running `caelestia shell -s`.
 
 ### PFP/Wallpapers
 
-The profile picture for the dashboard is read from the file `~/.face`, so to set
-it you can copy your image to there or set it via the dashboard.
+The profile picture for the dashboard is read from the file `~/.face`. You can set it by clicking it in the dashboard,
+or by manually copying or symlinking your image to the path.
 
 The wallpapers for the wallpaper switcher are read from `~/Pictures/Wallpapers`
-by default. To change it, change the wallpapers path in `~/.config/caelestia/shell.json`.
+by default. To change it, modify `paths.wallpaperDir` in `~/.config/caelestia/shell.json`.
 
-To set the wallpaper, you can use the command `caelestia wallpaper`. Use `caelestia wallpaper -h` for more info about
-the command.
+To set the wallpaper, you can use `caelestia wallpaper -f <path_to_wallpaper>`.
+Use `caelestia wallpaper -h` for more info about this command.
 
 ## Updating
 
-If installed via the AUR package, simply update your system (e.g. using `yay`).
+### Packaged install (AUR)
 
-If installed manually, you can update by running `git pull` in `$XDG_CONFIG_HOME/quickshell/caelestia`.
+If using the full dotfiles or the CLI, run `caelestia update` to perform a full system update and
+update the dots.
+Otherwise, if you installed the shell on its own, update your system using your AUR helper (e.g., `paru`).
+
+### Manual install
+
+If you installed the shell manually by cloning the repo, you can update by pulling the changes from git
+in the local checkout.
+
+For example, if you installed to `$XDG_CONFIG_HOME/quickshell/caelestia`:
 
 ```sh
 cd $XDG_CONFIG_HOME/quickshell/caelestia
@@ -203,17 +189,24 @@ git pull
 
 ## Configuring
 
-All configuration options should be put in `~/.config/caelestia/shell.json`. This file is _not_ created by
-default, you must create it manually. Options that you omit from the config file will use their default
+All configuration options belong in `~/.config/caelestia/shell.json`. This file is _not_ created by
+default; you must create it manually. Options that you omit from the config file will use their default
 values.
 
 ### Per-monitor configuration
 
-You can configure options per-monitor in `~/.config/caelestia/monitors/<screen-name>/shell.json`. Options
-set in this file will **override** the respective options in the global config. Otherwise, the options will
-use their values from the global config.
+You can configure per-monitor options in `~/.config/caelestia/monitors/<monitor_name>/shell.json`.
+List the names of your available monitors by running:
 
-For example, to disable the bar on DP-1:
+```sh
+hyprctl monitors -j | jq -r '.[].name'
+```
+
+Options set in these files will **override** the respective options in the global config. Any options not present in
+per-monitor configs will inherit their values from the global config.
+
+
+For example, to disable the bar on the monitor named `DP-1`:
 
 **`~/.config/caelestia/monitors/DP-1/shell.json`**
 
@@ -226,608 +219,607 @@ For example, to disable the bar on DP-1:
 ```
 
 > [!NOTE]
-> Not all options are respect per-monitor overrides. Most notably, the following options will only read
+> Not all options respect per-monitor overrides. Most notably, the following options will only read
 > from the global config, and ignore the respective option in per-monitor config files.
 >
 > <details><summary>Ignored options</summary>
 >
-> - `appearance` (`anim`, `transparency`)
-> - `general` (`logo`, `apps`, `idle`, `battery`)
-> - `bar.workspaces` (`perMonitorWorkspaces`, `specialWorkspaceIcons`, `windowIcons`)
-> - `bar.tray` (`iconSubs`, `hiddenIcons`)
-> - `dashboard` (`mediaUpdateInterval`, `resourceUpdateInterval`)
-> - `launcher` (`specialPrefix`, `actionPrefix`, `enableDangerousActions`, `vimKeybinds`,
->   `favouriteApps`, `hiddenApps`, `actions`)
-> - `launcher.useFuzzy` (`apps`, `actions`, `schemes`, `variants`, `wallpapers`)
-> - `notifs` (`expire`, `fullscreen`, `defaultExpireTimeout`, `fullscreenExpireTimeout`, `actionOnClick`)
-> - `lock` (`enableFprint`, `maxFprintTries`)
-> - `nexus` (`networkRescanInterval`)
-> - `utilities.toasts` (all except `fullscreen`)
-> - `utilities.vpn` (`enabled`, `provider`)
-> - `services` (`weatherLocation`, `useFahrenheit`, `useFahrenheitPerformance`, `useTwelveHourClock`,
->   `gpuType`, `visualiserBars`, `audioIncrement`, `brightnessIncrement`, `maxVolume`, `smartScheme`,
->   `defaultPlayer`, `playerAliases`, `lyricsBackend`)
-> - `paths` (`wallpaperDir`, `lyricsDir`)
+> - `appearance`: `anim.*`, `transparency.*`
+> - `bar.tray`: `hiddenIcons`, `iconSubs`
+> - `bar.workspaces`: `perMonitorWorkspaces`, `specialWorkspaceIcons`, `windowIcons`
+> - `dashboard`: `mediaUpdateInterval`, `resourceUpdateInterval`
+> - `general`: `apps.*`, `battery.*`, `idle.*`, `logo`
+> - `launcher`: `actionPrefix`, `actions`, `enableDangerousActions`, `favouriteApps`, `hiddenApps`, `specialPrefix`, `useFuzzy.*`, `vimKeybinds`
+> - `lock`: `enableFprint`, `enableHowdy`, `maxFprintTries`, `maxHowdyTries`, `triggerHowdyOnWake`
+> - `nexus`: `networkRescanInterval`
+> - `notifs`: `actionOnClick`, `defaultExpireTimeout`, `expire`, `fullscreen`, `fullscreenExpireTimeout`
+> - `paths`: `lyricsDir`, `wallpaperDir`
+> - `services`: `audioIncrement`, `brightnessIncrement`, `defaultPlayer`, `gpuType`, `lyricsBackend`, `maxVolume`, `playerAliases`, `smartScheme`, `useFahrenheit`, `useFahrenheitPerformance`, `useTwelveHourClock`, `visualiserBars`, `weatherLocation`
+> - `utilities.toasts`: all except `fullscreen`
+> - `utilities.vpn`: `enabled`, `provider`, `selectedProvider`
 >
 > </details>
 
 ### Example configuration
 
-> [!NOTE]
-> The example configuration includes ALL configuration options in `shell.json`. You are
-> **not** recommended to copy and paste this entire configuration into `shell.json`.
+> [!WARNING]
+> The example configuration includes **ALL** configuration options in `shell.json`. It is
+> **not** recommended to copy and paste this entire configuration into `shell.json`,
+> as options or their default values may be updated, resulting in a stale config.
+>
 > This is meant to serve as a reference of all the available options, and you should
-> only add the ones you want to change to `shell.json`.
+> <ins>only add the ones you want to change</ins> to `shell.json`.
 
-<details><summary>Example</summary>
+<details><summary>Example config</summary>
 
 ```json
 {
-    "enabled": true,
     "appearance": {
+        "anim": {
+            "durations": {
+                "scale": 1
+            }
+        },
         "deformScale": 1,
+        "font": {
+            "body": {
+                "family": "GoogleSansFlex",
+                "large": { "italic": false, "size": 16, "vaxes": { "ROND": 25 }, "weight": 400 },
+                "medium": { "italic": false, "size": 14, "vaxes": { "ROND": 25 }, "weight": 400 },
+                "small": { "italic": false, "size": 12, "vaxes": { "ROND": 25 }, "weight": 400 }
+            },
+            "clock": "Rubik",
+            "headline": {
+                "family": "GoogleSansFlex",
+                "large": { "italic": false, "size": 32, "vaxes": { "ROND": 25 }, "weight": 500 },
+                "medium": { "italic": false, "size": 28, "vaxes": { "ROND": 25 }, "weight": 500 },
+                "small": { "italic": false, "size": 24, "vaxes": {"ROND": 25 }, "weight": 500 }
+            },
+            "icon": {
+                "extraLarge": { "italic": false, "size": 36, "vaxes": {}, "weight": 400 },
+                "family": "Material Symbols Rounded",
+                "large": { "italic": false, "size": 24, "vaxes": {}, "weight": 400 },
+                "medium": { "italic": false, "size": 18, "vaxes": {}, "weight": 400 },
+                "small": { "italic": false, "size": 15, "vaxes": {}, "weight": 400 }
+            },
+            "label": {
+                "family": "GoogleSansFlex",
+                "large": { "italic": false, "size": 14, "vaxes": { "ROND": 25 }, "weight": 500 },
+                "medium": { "italic": false, "size": 12, "vaxes": { "ROND": 25 }, "weight": 500 },
+                "small": { "italic": false, "size": 11, "vaxes": { "ROND": 25 }, "weight": 400 }
+            },
+            "mono": {
+                "family": "CaskaydiaCove NF",
+                "large": { "italic": false, "size": 16, "vaxes": {}, "weight": 400 },
+                "medium": { "italic": false, "size": 14, "vaxes": {}, "weight": 400 },
+                "small": { "italic": false, "size": 12, "vaxes": {}, "weight": 400 }
+            },
+            "scale": 1,
+            "title": {
+                "family": "GoogleSansFlex",
+                "large": { "italic": false, "size": 22, "vaxes": { "ROND": 25 }, "weight": 500 },
+                "medium": { "italic": false, "size": 16, "vaxes": { "ROND": 25 }, "weight": 500 },
+                "small": { "italic": false, "size": 14, "vaxes": { "ROND": 25 }, "weight": 500 }
+            },
+            "workspaces": "Rubik"
+        },
+        "padding": {
+            "scale": 1
+        },
         "rounding": {
             "scale": 1
         },
         "spacing": {
             "scale": 1
         },
-        "padding": {
-            "scale": 1
-        },
-        "font": {
-            "scale": 1,
-            "clock": "Rubik",
-            "workspaces": "Rubik",
-            "headline": {
-                "family": "GoogleSansFlex",
-                "large": { "size": 32, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } },
-                "medium": { "size": 28, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } },
-                "small": { "size": 24, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } }
-            },
-            "title": {
-                "family": "GoogleSansFlex",
-                "large": { "size": 22, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } },
-                "medium": { "size": 16, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } },
-                "small": { "size": 14, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } }
-            },
-            "body": {
-                "family": "GoogleSansFlex",
-                "large": { "size": 16, "weight": 400, "italic": false, "vaxes": { "ROND": 25 } },
-                "medium": { "size": 14, "weight": 400, "italic": false, "vaxes": { "ROND": 25 } },
-                "small": { "size": 12, "weight": 400, "italic": false, "vaxes": { "ROND": 25 } }
-            },
-            "label": {
-                "family": "GoogleSansFlex",
-                "large": { "size": 14, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } },
-                "medium": { "size": 12, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } },
-                "small": { "size": 11, "weight": 400, "italic": false, "vaxes": { "ROND": 25 } }
-            },
-            "mono": {
-                "family": "CaskaydiaCove NF",
-                "large": { "size": 16, "weight": 400, "italic": false, "vaxes": {} },
-                "medium": { "size": 14, "weight": 400, "italic": false, "vaxes": {} },
-                "small": { "size": 12, "weight": 400, "italic": false, "vaxes": {} }
-            },
-            "icon": {
-                "family": "Material Symbols Rounded",
-                "extraLarge": { "size": 36, "weight": 400, "italic": false, "vaxes": {} },
-                "large": { "size": 24, "weight": 400, "italic": false, "vaxes": {} },
-                "medium": { "size": 18, "weight": 400, "italic": false, "vaxes": {} },
-                "small": { "size": 15, "weight": 400, "italic": false, "vaxes": {} }
-            }
-        },
-        "anim": {
-            "durations": {
-                "scale": 1
-            }
-        },
         "transparency": {
-            "enabled": false,
             "base": 0.85,
+            "enabled": false,
             "layers": 0.4
         }
     },
-    "general": {
-        "logo": "",
-        "showOverFullscreen": false,
-        "mediaGifSpeedAdjustment": 300,
-        "sessionGifSpeed": 0.7,
-        "apps": {
-            "terminal": ["foot"],
-            "audio": ["pwvucontrol"],
-            "playback": ["mpv"],
-            "explorer": ["thunar"]
-        },
-        "idle": {
-            "lockBeforeSleep": true,
-            "inhibitWhenAudio": true,
-            "inhibitWhenCharging": false,
-            "timeouts": [
-                {
-                    "timeout": 180,
-                    "idleAction": "lock",
-                    "inhibitWhenAudio": false,
-                    "inhibitWhenCharging": false,
-                    "respectInhibitors": true
-                },
-                {
-                    "timeout": 300,
-                    "idleAction": "dpms off",
-                    "returnAction": "dpms on"
-                },
-                {
-                    "timeout": 600,
-                    "idleAction": ["suspendThenHibernate"]
-                }
-            ]
-        },
-        "battery": {
-            "warnLevels": [
-                {
-                    "level": 20,
-                    "title": "Low battery",
-                    "message": "You might want to plug in a charger",
-                    "icon": "battery_android_frame_2"
-                },
-                {
-                    "level": 10,
-                    "title": "Did you see the previous message?",
-                    "message": "You should probably plug in a charger <b>now</b>",
-                    "icon": "battery_android_frame_1"
-                },
-                {
-                    "level": 5,
-                    "title": "Critical battery level",
-                    "message": "PLUG THE CHARGER RIGHT NOW!!",
-                    "icon": "battery_android_alert",
-                    "critical": true
-                }
-            ],
-            "criticalLevel": 3
-        }
-    },
     "background": {
-        "enabled": true,
-        "wallpaperEnabled": true,
         "desktopClock": {
-            "enabled": false,
-            "scale": 1.0,
-            "position": "bottom-right",
-            "invertColors": false,
             "background": {
+                "blur": true,
                 "enabled": false,
-                "opacity": 0.7,
-                "blur": true
+                "opacity": 0.7
             },
+            "enabled": false,
+            "invertColors": false,
+            "position": "bottom-right",
+            "scale": 1.0,
             "shadow": {
+                "blur": 0.4,
                 "enabled": true,
-                "opacity": 0.7,
-                "blur": 0.4
+                "opacity": 0.7
             }
         },
+        "enabled": true,
         "visualiser": {
-            "enabled": false,
             "autoHide": true,
             "blur": false,
+            "enabled": false,
             "rounding": 1,
             "spacing": 1
-        }
+        },
+        "wallpaperEnabled": true
     },
     "bar": {
-        "persistent": true,
-        "showOnHover": true,
-        "dragThreshold": 20,
-        "scrollActions": {
-            "workspaces": true,
-            "volume": true,
-            "brightness": true
-        },
-        "popouts": {
-            "activeWindow": true,
-            "tray": true,
-            "statusIcons": true
-        },
-        "workspaces": {
-            "shown": 5,
-            "activeIndicator": true,
-            "occupiedBg": false,
-            "showWindows": true,
-            "showWindowsOnSpecialWorkspaces": true,
-            "maxWindowIcons": 5,
-            "activeTrail": false,
-            "perMonitorWorkspaces": true,
-            "label": "  ",
-            "occupiedLabel": "󰮯",
-            "activeLabel": "󰮯",
-            "capitalisation": "preserve",
-            "specialWorkspaceIcons": [
-                {
-                    "name": "steam",
-                    "icon": "sports_esports"
-                }
-            ],
-            "windowIcons": [
-                {
-                    "regex": "steam(_app_(default|[0-9]+))?",
-                    "icon": "sports_esports"
-                }
-            ]
-        },
         "activeWindow": {
             "compact": false,
             "inverted": false,
             "showOnHover": true
-        },
-        "tray": {
-            "background": false,
-            "recolour": false,
-            "compact": false,
-            "iconSubs": [],
-            "hiddenIcons": []
         },
         "clock": {
             "background": false,
             "showDate": false,
             "showIcon": true
         },
-        "statusIcons": [
-            {
-                "id": "lockStatus",
-                "enabled": true
-            },
-            {
-                "id": "audio",
-                "enabled": false
-            },
-            {
-                "id": "microphone",
-                "enabled": false
-            },
-            {
-                "id": "kbLayout",
-                "enabled": false
-            },
-            {
-                "id": "network",
-                "enabled": true
-            },
-            {
-                "id": "bluetooth",
-                "enabled": true
-            },
-            {
-                "id": "battery",
-                "enabled": true
-            }
-        ],
+        "dragThreshold": 20,
         "entries": [
             {
-                "id": "logo",
-                "enabled": true
+                "enabled": true,
+                "id": "logo"
             },
             {
-                "id": "workspaces",
-                "enabled": true
+                "enabled": true,
+                "id": "workspaces"
             },
             {
-                "id": "spacer",
-                "enabled": true
+                "enabled": true,
+                "id": "spacer"
             },
             {
-                "id": "activeWindow",
-                "enabled": true
+                "enabled": true,
+                "id": "activeWindow"
             },
             {
-                "id": "spacer",
-                "enabled": true
+                "enabled": true,
+                "id": "spacer"
             },
             {
-                "id": "tray",
-                "enabled": true
+                "enabled": true,
+                "id": "tray"
             },
             {
-                "id": "clock",
-                "enabled": true
+                "enabled": true,
+                "id": "clock"
             },
             {
-                "id": "statusIcons",
-                "enabled": true
+                "enabled": true,
+                "id": "statusIcons"
             },
             {
-                "id": "power",
-                "enabled": true
+                "enabled": true,
+                "id": "power"
             }
         ],
-        "excludedScreens": []
-    },
-    "border": {
-        "thickness": 10,
-        "rounding": 25,
-        "smoothing": 20
-    },
-    "dashboard": {
-        "enabled": true,
+        "excludedScreens": [],
+        "persistent": true,
+        "popouts": {
+            "activeWindow": true,
+            "statusIcons": true,
+            "tray": true
+        },
+        "scrollActions": {
+            "brightness": true,
+            "volume": true,
+            "workspaces": true
+        },
         "showOnHover": true,
-        "showDashboard": true,
-        "showMedia": true,
-        "showPerformance": true,
-        "showWeather": true,
-        "mediaUpdateInterval": 500,
-        "resourceUpdateInterval": 1000,
-        "dragThreshold": 50,
-        "performance": {
-            "showBattery": true,
-            "showGpu": true,
-            "showCpu": true,
-            "showMemory": true,
-            "showStorage": true,
-            "showNetwork": true
+        "statusIcons": [
+            {
+                "enabled": true,
+                "id": "lockStatus"
+            },
+            {
+                "enabled": false,
+                "id": "audio"
+            },
+            {
+                "enabled": false,
+                "id": "microphone"
+            },
+            {
+                "enabled": false,
+                "id": "kbLayout"
+            },
+            {
+                "enabled": true,
+                "id": "network"
+            },
+            {
+                "enabled": true,
+                "id": "bluetooth"
+            },
+            {
+                "enabled": true,
+                "id": "battery"
+            }
+        ],
+        "tray": {
+            "background": false,
+            "compact": false,
+            "hiddenIcons": [],
+            "iconSubs": [],
+            "recolour": false
+        },
+        "workspaces": {
+            "activeIndicator": true,
+            "activeLabel": "󰮯",
+            "activeTrail": false,
+            "capitalisation": "preserve",
+            "label": "  ",
+            "maxWindowIcons": 5,
+            "occupiedBg": false,
+            "occupiedLabel": "󰮯",
+            "perMonitorWorkspaces": true,
+            "showWindows": true,
+            "showWindowsOnSpecialWorkspaces": true,
+            "shown": 5,
+            "specialWorkspaceIcons": [
+                {
+                    "icon": "sports_esports",
+                    "name": "steam"
+                }
+            ],
+            "windowIcons": [
+                {
+                    "icon": "sports_esports",
+                    "regex": "steam(_app_(default|[0-9]+))?"
+                }
+            ]
         }
     },
-    "launcher": {
-        "enabled": true,
-        "showOnHover": false,
-        "maxShown": 7,
-        "maxWallpapers": 9,
-        "specialPrefix": "@",
-        "actionPrefix": ">",
-        "enableDangerousActions": false,
+    "border": {
+        "rounding": 25,
+        "smoothing": 20,
+        "thickness": 10
+    },
+    "dashboard": {
         "dragThreshold": 50,
-        "vimKeybinds": false,
+        "enabled": true,
+        "mediaUpdateInterval": 500,
+        "performance": {
+            "showBattery": true,
+            "showCpu": true,
+            "showGpu": true,
+            "showMemory": true,
+            "showNetwork": true,
+            "showStorage": true
+        },
+        "resourceUpdateInterval": 1000,
+        "showDashboard": true,
+        "showMedia": true,
+        "showOnHover": true,
+        "showPerformance": true,
+        "showWeather": true
+    },
+    "enabled": true,
+    "general": {
+        "apps": {
+            "audio": ["pwvucontrol"],
+            "explorer": ["thunar"],
+            "playback": ["mpv"],
+            "terminal": ["foot"]
+        },
+        "battery": {
+            "criticalLevel": 3,
+            "warnLevels": [
+                {
+                    "icon": "battery_android_frame_2",
+                    "level": 20,
+                    "message": "You might want to plug in a charger",
+                    "title": "Low battery"
+                },
+                {
+                    "icon": "battery_android_frame_1",
+                    "level": 10,
+                    "message": "You should probably plug in a charger <b>now</b>",
+                    "title": "Did you see the previous message?"
+                },
+                {
+                    "critical": true,
+                    "icon": "battery_android_alert",
+                    "level": 5,
+                    "message": "PLUG THE CHARGER RIGHT NOW!!",
+                    "title": "Critical battery level"
+                }
+            ]
+        },
+        "idle": {
+            "inhibitWhenAudio": true,
+            "inhibitWhenCharging": false,
+            "lockBeforeSleep": true,
+            "timeouts": [
+                {
+                    "idleAction": "lock",
+                    "inhibitWhenAudio": false,
+                    "inhibitWhenCharging": false,
+                    "respectInhibitors": true,
+                    "timeout": 180
+                },
+                {
+                    "idleAction": "dpms off",
+                    "returnAction": "dpms on",
+                    "timeout": 300
+                },
+                {
+                    "idleAction": ["suspendThenHibernate"],
+                    "timeout": 600
+                }
+            ]
+        },
+        "logo": "",
+        "mediaGifSpeedAdjustment": 300,
+        "sessionGifSpeed": 0.7,
+        "showOverFullscreen": false
+    },
+    "launcher": {
+        "actionPrefix": ">",
+        "actions": [
+            {
+                "command": ["autocomplete", "calc"],
+                "dangerous": false,
+                "description": "Do simple math equations (powered by Qalc)",
+                "enabled": true,
+                "icon": "calculate",
+                "name": "Calculator"
+            },
+            {
+                "command": ["autocomplete", "scheme"],
+                "dangerous": false,
+                "description": "Change the current colour scheme",
+                "enabled": true,
+                "icon": "palette",
+                "name": "Scheme"
+            },
+            {
+                "command": ["autocomplete", "wallpaper"],
+                "dangerous": false,
+                "description": "Change the current wallpaper",
+                "enabled": true,
+                "icon": "image",
+                "name": "Wallpaper"
+            },
+            {
+                "command": ["autocomplete", "variant"],
+                "dangerous": false,
+                "description": "Change the current scheme variant",
+                "enabled": true,
+                "icon": "colors",
+                "name": "Variant"
+            },
+            {
+                "command": ["caelestia", "wallpaper", "-r"],
+                "dangerous": false,
+                "description": "Switch to a random wallpaper",
+                "enabled": true,
+                "icon": "casino",
+                "name": "Random"
+            },
+            {
+                "command": ["setMode", "light"],
+                "dangerous": false,
+                "description": "Change the scheme to light mode",
+                "enabled": true,
+                "icon": "light_mode",
+                "name": "Light"
+            },
+            {
+                "command": ["setMode", "dark"],
+                "dangerous": false,
+                "description": "Change the scheme to dark mode",
+                "enabled": true,
+                "icon": "dark_mode",
+                "name": "Dark"
+            },
+            {
+                "command": ["poweroff"],
+                "dangerous": true,
+                "description": "Shutdown the system",
+                "enabled": true,
+                "icon": "power_settings_new",
+                "name": "Shutdown"
+            },
+            {
+                "command": ["reboot"],
+                "dangerous": true,
+                "description": "Reboot the system",
+                "enabled": true,
+                "icon": "cached",
+                "name": "Reboot"
+            },
+            {
+                "command": ["logout"],
+                "dangerous": true,
+                "description": "Log out of the current session",
+                "enabled": true,
+                "icon": "exit_to_app",
+                "name": "Logout"
+            },
+            {
+                "command": ["loginctl", "lock-session"],
+                "dangerous": false,
+                "description": "Lock the current session",
+                "enabled": true,
+                "icon": "lock",
+                "name": "Lock"
+            },
+            {
+                "command": ["suspendThenHibernate"],
+                "dangerous": false,
+                "description": "Suspend then hibernate",
+                "enabled": true,
+                "icon": "bedtime",
+                "name": "Sleep"
+            },
+            {
+                "command": ["caelestia", "shell", "nexus", "open"],
+                "dangerous": false,
+                "description": "Configure the shell",
+                "enabled": true,
+                "icon": "settings",
+                "name": "Settings"
+            }
+        ],
+        "dragThreshold": 50,
+        "enableDangerousActions": false,
+        "enabled": true,
         "favouriteApps": [],
         "hiddenApps": [],
+        "maxShown": 7,
+        "maxWallpapers": 9,
+        "showOnHover": false,
+        "specialPrefix": "@",
         "useFuzzy": {
-            "apps": false,
             "actions": false,
+            "apps": false,
             "schemes": false,
             "variants": false,
             "wallpapers": false
         },
-        "actions": [
-            {
-                "name": "Calculator",
-                "icon": "calculate",
-                "description": "Do simple math equations (powered by Qalc)",
-                "command": ["autocomplete", "calc"],
-                "enabled": true,
-                "dangerous": false
-            },
-            {
-                "name": "Scheme",
-                "icon": "palette",
-                "description": "Change the current colour scheme",
-                "command": ["autocomplete", "scheme"],
-                "enabled": true,
-                "dangerous": false
-            },
-            {
-                "name": "Wallpaper",
-                "icon": "image",
-                "description": "Change the current wallpaper",
-                "command": ["autocomplete", "wallpaper"],
-                "enabled": true,
-                "dangerous": false
-            },
-            {
-                "name": "Variant",
-                "icon": "colors",
-                "description": "Change the current scheme variant",
-                "command": ["autocomplete", "variant"],
-                "enabled": true,
-                "dangerous": false
-            },
-            {
-                "name": "Random",
-                "icon": "casino",
-                "description": "Switch to a random wallpaper",
-                "command": ["caelestia", "wallpaper", "-r"],
-                "enabled": true,
-                "dangerous": false
-            },
-            {
-                "name": "Light",
-                "icon": "light_mode",
-                "description": "Change the scheme to light mode",
-                "command": ["setMode", "light"],
-                "enabled": true,
-                "dangerous": false
-            },
-            {
-                "name": "Dark",
-                "icon": "dark_mode",
-                "description": "Change the scheme to dark mode",
-                "command": ["setMode", "dark"],
-                "enabled": true,
-                "dangerous": false
-            },
-            {
-                "name": "Shutdown",
-                "icon": "power_settings_new",
-                "description": "Shutdown the system",
-                "command": ["poweroff"],
-                "enabled": true,
-                "dangerous": true
-            },
-            {
-                "name": "Reboot",
-                "icon": "cached",
-                "description": "Reboot the system",
-                "command": ["reboot"],
-                "enabled": true,
-                "dangerous": true
-            },
-            {
-                "name": "Logout",
-                "icon": "exit_to_app",
-                "description": "Log out of the current session",
-                "command": ["logout"],
-                "enabled": true,
-                "dangerous": true
-            },
-            {
-                "name": "Lock",
-                "icon": "lock",
-                "description": "Lock the current session",
-                "command": ["loginctl", "lock-session"],
-                "enabled": true,
-                "dangerous": false
-            },
-            {
-                "name": "Sleep",
-                "icon": "bedtime",
-                "description": "Suspend then hibernate",
-                "command": ["suspendThenHibernate"],
-                "enabled": true,
-                "dangerous": false
-            },
-            {
-                "name": "Settings",
-                "icon": "settings",
-                "description": "Configure the shell",
-                "command": ["caelestia", "shell", "nexus", "open"],
-                "enabled": true,
-                "dangerous": false
-            }
-        ]
+        "vimKeybinds": false
     },
     "lock": {
-        "enabled": true,
-        "useWallpaper": false,
-        "recolourLogo": true,
         "enableFprint": true,
-        "maxFprintTries": 3,
         "enableHowdy": true,
+        "enabled": true,
+        "hideNotifs": false,
+        "maxFprintTries": 3,
         "maxHowdyTries": 3,
+        "recolourLogo": true,
         "triggerHowdyOnWake": true,
-        "hideNotifs": false
+        "useWallpaper": false
     },
     "nexus": {
-        "wallpapersPerRow": 4,
-        "networkRescanInterval": 15000
+        "networkRescanInterval": 15000,
+        "wallpapersPerRow": 4
     },
     "notifs": {
+        "actionOnClick": false,
+        "clearThreshold": 0.3,
+        "defaultExpireTimeout": 5000,
+        "expandThreshold": 20,
         "expire": true,
         "fullscreen": "on",
-        "defaultExpireTimeout": 5000,
         "fullscreenExpireTimeout": 2000,
-        "clearThreshold": 0.3,
-        "expandThreshold": 20,
-        "actionOnClick": false,
         "groupPreviewNum": 3,
         "openExpanded": false
     },
     "osd": {
-        "enabled": true,
-        "hideDelay": 2000,
         "enableBrightness": true,
-        "enableMicrophone": false
+        "enableMicrophone": false,
+        "enabled": true,
+        "hideDelay": 2000
+    },
+    "paths": {
+        "lockNoNotifsPic": "root:/assets/dino.png",
+        "lyricsDir": "~/Music/lyrics/",
+        "mediaGif": "root:/assets/bongocat.gif",
+        "noNotifsPic": "root:/assets/dino.png",
+        "sessionGif": "root:/assets/kurukuru.gif",
+        "wallpaperDir": "~/Pictures/Wallpapers"
     },
     "services": {
-        "weatherLocation": "",
+        "audioIncrement": 0.1,
+        "brightnessIncrement": 0.1,
+        "defaultPlayer": "Spotify",
+        "gpuType": "",
+        "lyricsBackend": "Auto",
+        "maxVolume": 1.0,
+        "playerAliases": [{ "from": "com.github.th_ch.youtube_music", "to": "YT Music" }],
+        "smartScheme": true,
         "useFahrenheit": false,
         "useFahrenheitPerformance": false,
         "useTwelveHourClock": false,
-        "gpuType": "",
         "visualiserBars": 60,
-        "audioIncrement": 0.1,
-        "brightnessIncrement": 0.1,
-        "maxVolume": 1.0,
-        "smartScheme": true,
-        "defaultPlayer": "Spotify",
-        "playerAliases": [{ "from": "com.github.th_ch.youtube_music", "to": "YT Music" }],
-        "lyricsBackend": "Auto"
+        "weatherLocation": ""
     },
     "session": {
-        "enabled": true,
-        "dragThreshold": 30,
-        "vimKeybinds": false,
-        "icons": {
-            "logout": "logout",
-            "shutdown": "power_settings_new",
-            "hibernate": "downloading",
-            "reboot": "cached"
-        },
         "commands": {
-            "logout": ["logout"],
-            "shutdown": ["poweroff"],
             "hibernate": ["hibernate"],
-            "reboot": ["reboot"]
-        }
+            "logout": ["logout"],
+            "reboot": ["reboot"
+            ],
+            "shutdown": ["poweroff"]
+        },
+        "dragThreshold": 30,
+        "enabled": true,
+        "icons": {
+            "hibernate": "downloading",
+            "logout": "logout",
+            "reboot": "cached",
+            "shutdown": "power_settings_new"
+        },
+        "vimKeybinds": false
     },
     "sidebar": {
+        "dragThreshold": 80,
         "enabled": true,
-        "showOnHover": false,
         "minHoverThreshold": 200,
-        "dragThreshold": 80
+        "showOnHover": false
     },
     "utilities": {
         "enabled": true,
         "maxToasts": 4,
+        "quickToggles": [
+            {
+                "enabled": true,
+                "id": "wifi"
+            },
+            {
+                "enabled": true,
+                "id": "bluetooth"
+            },
+            {
+                "enabled": true,
+                "id": "mic"
+            },
+            {
+                "enabled": true,
+                "id": "settings"
+            },
+            {
+                "enabled": true,
+                "id": "gameMode"
+            },
+            {
+                "enabled": true,
+                "id": "dnd"
+            },
+            {
+                "enabled": false,
+                "id": "vpn"
+            }
+        ],
         "toasts": {
-            "fullscreen": "off",
-            "configLoaded": true,
-            "chargingChanged": true,
-            "gameModeChanged": true,
-            "dndChanged": true,
-            "audioOutputChanged": true,
             "audioInputChanged": true,
+            "audioOutputChanged": true,
             "capsLockChanged": true,
-            "numLockChanged": true,
+            "chargingChanged": true,
+            "configLoaded": true,
+            "dndChanged": true,
+            "fullscreen": "off",
+            "gameModeChanged": true,
             "kbLayoutChanged": true,
             "kbLimit": true,
-            "vpnChanged": true,
-            "nowPlaying": false
+            "nowPlaying": false,
+            "numLockChanged": true,
+            "vpnChanged": true
         },
         "vpn": {
             "enabled": false,
             "provider": [
                 {
-                    "name": "wireguard",
-                    "interface": "your-connection-name",
                     "displayName": "Wireguard (Your VPN)",
-                    "enabled": false
+                    "enabled": false,
+                    "interface": "your-connection-name",
+                    "name": "wireguard"
                 }
             ]
-        },
-        "quickToggles": [
-            {
-                "id": "wifi",
-                "enabled": true
-            },
-            {
-                "id": "bluetooth",
-                "enabled": true
-            },
-            {
-                "id": "mic",
-                "enabled": true
-            },
-            {
-                "id": "settings",
-                "enabled": true
-            },
-            {
-                "id": "gameMode",
-                "enabled": true
-            },
-            {
-                "id": "dnd",
-                "enabled": true
-            },
-            {
-                "id": "vpn",
-                "enabled": false
-            }
-        ]
-    },
-    "paths": {
-        "wallpaperDir": "~/Pictures/Wallpapers",
-        "lyricsDir": "~/Music/lyrics/",
-        "sessionGif": "root:/assets/kurukuru.gif",
-        "mediaGif": "root:/assets/bongocat.gif",
-        "noNotifsPic": "root:/assets/dino.png",
-        "lockNoNotifsPic": "root:/assets/dino.png"
+        }
     }
 }
 ```
@@ -836,23 +828,23 @@ For example, to disable the bar on DP-1:
 
 ### Advanced configuration
 
-> [!WARNING]
-> Do NOT change any of these options if you do not know what you are doing. These options control the
-> tokens used internally within the shell, and can cause visual issues if changed. The existence of
-> the options are also not guaranteed across versions, and may change or be removed without notice.
+> [!CAUTION]
+> Do NOT change any of these options unless you know what you are doing. These options control the
+> tokens used internally within the shell, and can cause visual issues if modified incorrectly.
+> The available options may change or be removed without notice across versions.
 
 A separate `~/.config/caelestia/shell-tokens.json` file allows editing the internal tokens without
-touching the source code of the shell. These tokens affect, for example, individual rounding,
-spacing, padding, font size, animation duration and easing curves tokens, and the sizes of certain
-components. The appearance scale values in `shell.json` are multiplied against these base
+touching the source code of the shell. These tokens affect the dimensions and appearance of visual elements,
+including individual rounding, spacing, padding, font size, animation durations and curves, and the sizes of
+certain components. The appearance scale values in `shell.json` are multiplied against these base
 token values to produce the final computed values.
 
 Per-monitor token overrides are also available at
-`~/.config/caelestia/monitors/<screen-name>/shell-tokens.json`.
+`~/.config/caelestia/monitors/<monitor_name>/shell-tokens.json`.
 
 ### Home Manager Module
 
-For NixOS users, a home manager module is also available.
+For NixOS users, a Home Manager module is also available.
 
 <details><summary><code>home.nix</code></summary>
 
@@ -882,7 +874,7 @@ programs.caelestia = {
 };
 ```
 
-The module automatically adds Caelestia shell to the path with **full functionality**. The CLI is not required, however you have the option to enable and configure it.
+The module automatically adds the shell to the path with **full functionality**. The CLI is not required; however, you can enable and configure it.
 
 </details>
 
@@ -890,40 +882,28 @@ The module automatically adds Caelestia shell to the path with **full functional
 
 ### Need help or support?
 
-You can join the community Discord server for assistance and discussion:
-https://discord.gg/BGDCFCmMBk
+You can join the Caelestia Discord server for assistance and discussion [here][discord].
 
-### My screen is flickering, help pls!
+### I want to make my own changes to the Hyprland config!
 
-Try disabling VRR in the hyprland config. You can do this by adding the following to `~/.config/caelestia/hypr-user.conf`:
-
-```conf
-misc {
-    vrr = 0
-}
-```
-
-### I want to make my own changes to the hyprland config!
-
-You can add your custom hyprland configs to `~/.config/caelestia/hypr-user.conf`.
+You can add your custom Hyprland configs to `~/.config/caelestia/hypr-user.lua`.
 
 ### I want to make my own changes to other stuff!
 
-See the [manual installation](https://github.com/caelestia-dots/shell?tab=readme-ov-file#manual-installation) section
-for the corresponding repo.
+See the [manual installation](#manual-installation) section for the corresponding repo.
 
-### I want to disable XXX feature!
+### I want to disable ___ feature!
 
-Please read the [configuring](https://github.com/caelestia-dots/shell?tab=readme-ov-file#configuring) section in the readme.
-If there is no corresponding option, make feature request.
+Please read the [configuring](#configuring) section.
+If there is no corresponding option, make a [feature request](https://github.com/caelestia-dots/shell/issues/new?template=feature.yml).
 
-### How do I make my colour scheme change with my wallpaper?
+### How do I make my colour scheme change to match my wallpaper?
 
-Set a wallpaper via the launcher or `caelestia wallpaper` and set the scheme to the dynamic scheme via the launcher
-or `caelestia scheme set`. e.g.
+Set a wallpaper via `>wallpaper` in the launcher or `caelestia wallpaper`, and set the scheme to the dynamic scheme via 
+`>scheme` in the launcher or `caelestia scheme set`, e.g.:
 
 ```sh
-caelestia wallpaper -f <path/to/file>
+caelestia wallpaper -f <path_to_wallpaper>
 caelestia scheme set -n dynamic
 ```
 
@@ -935,7 +915,7 @@ the launcher only shows an odd number of wallpapers at one time. If you only hav
 
 ## Credits
 
-Thanks to the Hyprland discord community (especially the homies in #rice-discussion) for all the help and suggestions
+Thanks to the Hyprland Discord community (especially the homies in #rice-discussion) for all the help and suggestions
 for improving these dots!
 
 A special thanks to [@outfoxxed](https://github.com/outfoxxed) for making Quickshell and the effort put into fixing issues
@@ -944,7 +924,7 @@ and implementing various feature requests.
 Another special thanks to [@end_4](https://github.com/end-4) for his [config](https://github.com/end-4/dots-hyprland)
 which helped me a lot with learning how to use Quickshell.
 
-Finally another thank you to all the configs I took inspiration from (only one for now):
+Finally, another thank you to all the configs I took inspiration from (only one for now):
 
 -   [Axenide/Ax-Shell](https://github.com/Axenide/Ax-Shell)
 
@@ -957,3 +937,6 @@ Finally another thank you to all the configs I took inspiration from (only one f
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=caelestia-dots/shell&type=Date" />
  </picture>
 </a>
+
+[dots-repo]: https://github.com/caelestia-dots/caelestia
+[discord]: https://caelestiashell.com/discord

--- a/README.md
+++ b/README.md
@@ -886,10 +886,7 @@ You can join the Caelestia Discord server for assistance and discussion [here][d
 
 ### I want to make my own changes to the Hyprland config!
 
-You can add your custom Hyprland configs to `~/.config/caelestia/hypr-user.lua`.
-Most default Hyprland values can be modified by overriding variables in `~/.config/caelestia/hypr-vars.lua`.
-You can reference the [variables.lua](https://github.com/caelestia-dots/caelestia/blob/main/hypr/variables.lua) file for all available
-variables and their default values.
+Check out the configuring section on the [dots repo](https://github.com/caelestia-dots/caelestia#configuring).
 
 ### I want to make my own changes to other stuff!
 

--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ Build dependencies:
 -   `qt6-shadertools`
 
 > [!IMPORTANT]
-> The commands (and in the "Updating" section) expect `$XDG_CONFIG_HOME` to be set.
+> The commands below (and in the "Updating" section) assume `$XDG_CONFIG_HOME` is set.
 > If it is unset, substitute it with the path to your config folder (typically `~/.config`).
 
 To install the shell manually, install all dependencies and clone this repo to `$XDG_CONFIG_HOME/quickshell/caelestia`.
-Then build and install using `cmake`.
+Then build and install using CMake.
 
 ```sh
 cd $XDG_CONFIG_HOME/quickshell
@@ -118,11 +118,11 @@ sudo cmake --install build
 
 > [!TIP]
 > You can customise the installation location via the CMake flags `INSTALL_LIBDIR`, `INSTALL_QMLDIR`, and
-> `INSTALL_QSCONFDIR` for the libraries (e.g., the beat detector), QML plugin, and Quickshell config directories
+> `INSTALL_QSCONFDIR` for the libraries (e.g. the version helper), QML plugin, and Quickshell config directories
 > respectively. If changing the library directory, remember to set the `CAELESTIA_LIB_DIR` environment
 > variable to the custom directory when launching the shell.
 >
-> e.g., installing to `~/.config/quickshell/caelestia` for easy local changes:
+> For example, installing to `~/.config/quickshell/caelestia` for easy local changes:
 >
 > ```sh
 > mkdir -p ~/.config/quickshell/caelestia
@@ -145,7 +145,7 @@ via a `hl.on("hyprland.start", ...)` function in the Hyprland config.
 
 All keybinds are accessible via Hyprland [global shortcuts](https://wiki.hypr.land/Configuring/Basics/Binds/#dbus-global-shortcuts).
 If using the [Caelestia dotfiles][dots-repo], the keybinds are already configured for you.
-Otherwise, the [`keybinds.lua` file](https://github.com/caelestia-dots/caelestia/blob/main/hypr/hyprland/keybinds.lua#L63-L67)
+Otherwise, the [`keybinds.lua`](https://github.com/caelestia-dots/caelestia/blob/main/hypr/hyprland/keybinds.lua#L63-L67) file
 contains an example of how to use global shortcuts.
 
 All IPC commands can be accessed via `caelestia shell ...`, for example:
@@ -164,7 +164,8 @@ or by manually copying or symlinking your image to the path.
 The wallpapers for the wallpaper switcher are read from `~/Pictures/Wallpapers`
 by default. To change it, modify `paths.wallpaperDir` in `~/.config/caelestia/shell.json`.
 
-To set the wallpaper, you can use `caelestia wallpaper -f <path_to_wallpaper>`.
+To set the wallpaper, you can type `>wallpaper` in the launcher to open the wallpaper switcher.
+Alternatively, you can also use `caelestia wallpaper -f <path_to_wallpaper>` to set the wallpaper directly.
 Use `caelestia wallpaper -h` for more info about this command.
 
 ## Updating
@@ -245,7 +246,7 @@ For example, to disable the bar on the monitor named `DP-1`:
 > [!WARNING]
 > The example configuration includes **ALL** configuration options in `shell.json`. It is
 > **not** recommended to copy and paste this entire configuration into `shell.json`,
-> as options or their default values may be updated, resulting in a stale config.
+> as options or their default values may change across updates, resulting in a stale config.
 >
 > This is meant to serve as a reference of all the available options, and you should
 > <ins>only add the ones you want to change</ins> to `shell.json`.
@@ -254,572 +255,571 @@ For example, to disable the bar on the monitor named `DP-1`:
 
 ```json
 {
+    "enabled": true,
     "appearance": {
-        "anim": {
-            "durations": {
-                "scale": 1
-            }
-        },
         "deformScale": 1,
-        "font": {
-            "body": {
-                "family": "GoogleSansFlex",
-                "large": { "italic": false, "size": 16, "vaxes": { "ROND": 25 }, "weight": 400 },
-                "medium": { "italic": false, "size": 14, "vaxes": { "ROND": 25 }, "weight": 400 },
-                "small": { "italic": false, "size": 12, "vaxes": { "ROND": 25 }, "weight": 400 }
-            },
-            "clock": "Rubik",
-            "headline": {
-                "family": "GoogleSansFlex",
-                "large": { "italic": false, "size": 32, "vaxes": { "ROND": 25 }, "weight": 500 },
-                "medium": { "italic": false, "size": 28, "vaxes": { "ROND": 25 }, "weight": 500 },
-                "small": { "italic": false, "size": 24, "vaxes": {"ROND": 25 }, "weight": 500 }
-            },
-            "icon": {
-                "extraLarge": { "italic": false, "size": 36, "vaxes": {}, "weight": 400 },
-                "family": "Material Symbols Rounded",
-                "large": { "italic": false, "size": 24, "vaxes": {}, "weight": 400 },
-                "medium": { "italic": false, "size": 18, "vaxes": {}, "weight": 400 },
-                "small": { "italic": false, "size": 15, "vaxes": {}, "weight": 400 }
-            },
-            "label": {
-                "family": "GoogleSansFlex",
-                "large": { "italic": false, "size": 14, "vaxes": { "ROND": 25 }, "weight": 500 },
-                "medium": { "italic": false, "size": 12, "vaxes": { "ROND": 25 }, "weight": 500 },
-                "small": { "italic": false, "size": 11, "vaxes": { "ROND": 25 }, "weight": 400 }
-            },
-            "mono": {
-                "family": "CaskaydiaCove NF",
-                "large": { "italic": false, "size": 16, "vaxes": {}, "weight": 400 },
-                "medium": { "italic": false, "size": 14, "vaxes": {}, "weight": 400 },
-                "small": { "italic": false, "size": 12, "vaxes": {}, "weight": 400 }
-            },
-            "scale": 1,
-            "title": {
-                "family": "GoogleSansFlex",
-                "large": { "italic": false, "size": 22, "vaxes": { "ROND": 25 }, "weight": 500 },
-                "medium": { "italic": false, "size": 16, "vaxes": { "ROND": 25 }, "weight": 500 },
-                "small": { "italic": false, "size": 14, "vaxes": { "ROND": 25 }, "weight": 500 }
-            },
-            "workspaces": "Rubik"
-        },
-        "padding": {
-            "scale": 1
-        },
         "rounding": {
             "scale": 1
         },
         "spacing": {
             "scale": 1
         },
+        "padding": {
+            "scale": 1
+        },
+        "font": {
+            "scale": 1,
+            "clock": "Rubik",
+            "workspaces": "Rubik",
+            "headline": {
+                "family": "GoogleSansFlex",
+                "large": { "size": 32, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } },
+                "medium": { "size": 28, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } },
+                "small": { "size": 24, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } }
+            },
+            "title": {
+                "family": "GoogleSansFlex",
+                "large": { "size": 22, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } },
+                "medium": { "size": 16, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } },
+                "small": { "size": 14, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } }
+            },
+            "body": {
+                "family": "GoogleSansFlex",
+                "large": { "size": 16, "weight": 400, "italic": false, "vaxes": { "ROND": 25 } },
+                "medium": { "size": 14, "weight": 400, "italic": false, "vaxes": { "ROND": 25 } },
+                "small": { "size": 12, "weight": 400, "italic": false, "vaxes": { "ROND": 25 } }
+            },
+            "label": {
+                "family": "GoogleSansFlex",
+                "large": { "size": 14, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } },
+                "medium": { "size": 12, "weight": 500, "italic": false, "vaxes": { "ROND": 25 } },
+                "small": { "size": 11, "weight": 400, "italic": false, "vaxes": { "ROND": 25 } }
+            },
+            "mono": {
+                "family": "CaskaydiaCove NF",
+                "large": { "size": 16, "weight": 400, "italic": false, "vaxes": {} },
+                "medium": { "size": 14, "weight": 400, "italic": false, "vaxes": {} },
+                "small": { "size": 12, "weight": 400, "italic": false, "vaxes": {} }
+            },
+            "icon": {
+                "family": "Material Symbols Rounded",
+                "extraLarge": { "size": 36, "weight": 400, "italic": false, "vaxes": {} },
+                "large": { "size": 24, "weight": 400, "italic": false, "vaxes": {} },
+                "medium": { "size": 18, "weight": 400, "italic": false, "vaxes": {} },
+                "small": { "size": 15, "weight": 400, "italic": false, "vaxes": {} }
+            }
+        },
+        "anim": {
+            "durations": {
+                "scale": 1
+            }
+        },
         "transparency": {
-            "base": 0.85,
             "enabled": false,
+            "base": 0.85,
             "layers": 0.4
         }
     },
+    "general": {
+        "logo": "",
+        "showOverFullscreen": false,
+        "mediaGifSpeedAdjustment": 300,
+        "sessionGifSpeed": 0.7,
+        "apps": {
+            "terminal": ["foot"],
+            "audio": ["pwvucontrol"],
+            "playback": ["mpv"],
+            "explorer": ["thunar"]
+        },
+        "idle": {
+            "lockBeforeSleep": true,
+            "inhibitWhenAudio": true,
+            "inhibitWhenCharging": false,
+            "timeouts": [
+                {
+                    "timeout": 180,
+                    "idleAction": "lock",
+                    "inhibitWhenAudio": false,
+                    "inhibitWhenCharging": false,
+                    "respectInhibitors": true
+                },
+                {
+                    "timeout": 300,
+                    "idleAction": "dpms off",
+                    "returnAction": "dpms on"
+                },
+                {
+                    "timeout": 600,
+                    "idleAction": ["suspendThenHibernate"]
+                }
+            ]
+        },
+        "battery": {
+            "warnLevels": [
+                {
+                    "level": 20,
+                    "title": "Low battery",
+                    "message": "You might want to plug in a charger",
+                    "icon": "battery_android_frame_2"
+                },
+                {
+                    "level": 10,
+                    "title": "Did you see the previous message?",
+                    "message": "You should probably plug in a charger <b>now</b>",
+                    "icon": "battery_android_frame_1"
+                },
+                {
+                    "level": 5,
+                    "title": "Critical battery level",
+                    "message": "PLUG THE CHARGER RIGHT NOW!!",
+                    "icon": "battery_android_alert",
+                    "critical": true
+                }
+            ],
+            "criticalLevel": 3
+        }
+    },
     "background": {
+        "enabled": true,
+        "wallpaperEnabled": true,
         "desktopClock": {
-            "background": {
-                "blur": true,
-                "enabled": false,
-                "opacity": 0.7
-            },
             "enabled": false,
-            "invertColors": false,
-            "position": "bottom-right",
             "scale": 1.0,
+            "position": "bottom-right",
+            "invertColors": false,
+            "background": {
+                "enabled": false,
+                "opacity": 0.7,
+                "blur": true
+            },
             "shadow": {
-                "blur": 0.4,
                 "enabled": true,
-                "opacity": 0.7
+                "opacity": 0.7,
+                "blur": 0.4
             }
         },
-        "enabled": true,
         "visualiser": {
+            "enabled": false,
             "autoHide": true,
             "blur": false,
-            "enabled": false,
             "rounding": 1,
             "spacing": 1
-        },
-        "wallpaperEnabled": true
+        }
     },
     "bar": {
+        "persistent": true,
+        "showOnHover": true,
+        "dragThreshold": 20,
+        "scrollActions": {
+            "workspaces": true,
+            "volume": true,
+            "brightness": true
+        },
+        "popouts": {
+            "activeWindow": true,
+            "tray": true,
+            "statusIcons": true
+        },
+        "workspaces": {
+            "shown": 5,
+            "activeIndicator": true,
+            "occupiedBg": false,
+            "showWindows": true,
+            "showWindowsOnSpecialWorkspaces": true,
+            "maxWindowIcons": 5,
+            "activeTrail": false,
+            "perMonitorWorkspaces": true,
+            "label": "  ",
+            "occupiedLabel": "󰮯",
+            "activeLabel": "󰮯",
+            "capitalisation": "preserve",
+            "specialWorkspaceIcons": [
+                {
+                    "name": "steam",
+                    "icon": "sports_esports"
+                }
+            ],
+            "windowIcons": [
+                {
+                    "regex": "steam(_app_(default|[0-9]+))?",
+                    "icon": "sports_esports"
+                }
+            ]
+        },
         "activeWindow": {
             "compact": false,
             "inverted": false,
             "showOnHover": true
+        },
+        "tray": {
+            "background": false,
+            "recolour": false,
+            "compact": false,
+            "iconSubs": [],
+            "hiddenIcons": []
         },
         "clock": {
             "background": false,
             "showDate": false,
             "showIcon": true
         },
-        "dragThreshold": 20,
-        "entries": [
-            {
-                "enabled": true,
-                "id": "logo"
-            },
-            {
-                "enabled": true,
-                "id": "workspaces"
-            },
-            {
-                "enabled": true,
-                "id": "spacer"
-            },
-            {
-                "enabled": true,
-                "id": "activeWindow"
-            },
-            {
-                "enabled": true,
-                "id": "spacer"
-            },
-            {
-                "enabled": true,
-                "id": "tray"
-            },
-            {
-                "enabled": true,
-                "id": "clock"
-            },
-            {
-                "enabled": true,
-                "id": "statusIcons"
-            },
-            {
-                "enabled": true,
-                "id": "power"
-            }
-        ],
-        "excludedScreens": [],
-        "persistent": true,
-        "popouts": {
-            "activeWindow": true,
-            "statusIcons": true,
-            "tray": true
-        },
-        "scrollActions": {
-            "brightness": true,
-            "volume": true,
-            "workspaces": true
-        },
-        "showOnHover": true,
         "statusIcons": [
             {
-                "enabled": true,
-                "id": "lockStatus"
+                "id": "lockStatus",
+                "enabled": true
             },
             {
-                "enabled": false,
-                "id": "audio"
+                "id": "audio",
+                "enabled": false
             },
             {
-                "enabled": false,
-                "id": "microphone"
+                "id": "microphone",
+                "enabled": false
             },
             {
-                "enabled": false,
-                "id": "kbLayout"
+                "id": "kbLayout",
+                "enabled": false
             },
             {
-                "enabled": true,
-                "id": "network"
+                "id": "network",
+                "enabled": true
             },
             {
-                "enabled": true,
-                "id": "bluetooth"
+                "id": "bluetooth",
+                "enabled": true
             },
             {
-                "enabled": true,
-                "id": "battery"
+                "id": "battery",
+                "enabled": true
             }
         ],
-        "tray": {
-            "background": false,
-            "compact": false,
-            "hiddenIcons": [],
-            "iconSubs": [],
-            "recolour": false
-        },
-        "workspaces": {
-            "activeIndicator": true,
-            "activeLabel": "󰮯",
-            "activeTrail": false,
-            "capitalisation": "preserve",
-            "label": "  ",
-            "maxWindowIcons": 5,
-            "occupiedBg": false,
-            "occupiedLabel": "󰮯",
-            "perMonitorWorkspaces": true,
-            "showWindows": true,
-            "showWindowsOnSpecialWorkspaces": true,
-            "shown": 5,
-            "specialWorkspaceIcons": [
-                {
-                    "icon": "sports_esports",
-                    "name": "steam"
-                }
-            ],
-            "windowIcons": [
-                {
-                    "icon": "sports_esports",
-                    "regex": "steam(_app_(default|[0-9]+))?"
-                }
-            ]
-        }
+        "entries": [
+            {
+                "id": "logo",
+                "enabled": true
+            },
+            {
+                "id": "workspaces",
+                "enabled": true
+            },
+            {
+                "id": "spacer",
+                "enabled": true
+            },
+            {
+                "id": "activeWindow",
+                "enabled": true
+            },
+            {
+                "id": "spacer",
+                "enabled": true
+            },
+            {
+                "id": "tray",
+                "enabled": true
+            },
+            {
+                "id": "clock",
+                "enabled": true
+            },
+            {
+                "id": "statusIcons",
+                "enabled": true
+            },
+            {
+                "id": "power",
+                "enabled": true
+            }
+        ],
+        "excludedScreens": []
     },
     "border": {
+        "thickness": 10,
         "rounding": 25,
-        "smoothing": 20,
-        "thickness": 10
+        "smoothing": 20
     },
     "dashboard": {
-        "dragThreshold": 50,
         "enabled": true,
-        "mediaUpdateInterval": 500,
-        "performance": {
-            "showBattery": true,
-            "showCpu": true,
-            "showGpu": true,
-            "showMemory": true,
-            "showNetwork": true,
-            "showStorage": true
-        },
-        "resourceUpdateInterval": 1000,
+        "showOnHover": true,
         "showDashboard": true,
         "showMedia": true,
-        "showOnHover": true,
         "showPerformance": true,
-        "showWeather": true
-    },
-    "enabled": true,
-    "general": {
-        "apps": {
-            "audio": ["pwvucontrol"],
-            "explorer": ["thunar"],
-            "playback": ["mpv"],
-            "terminal": ["foot"]
-        },
-        "battery": {
-            "criticalLevel": 3,
-            "warnLevels": [
-                {
-                    "icon": "battery_android_frame_2",
-                    "level": 20,
-                    "message": "You might want to plug in a charger",
-                    "title": "Low battery"
-                },
-                {
-                    "icon": "battery_android_frame_1",
-                    "level": 10,
-                    "message": "You should probably plug in a charger <b>now</b>",
-                    "title": "Did you see the previous message?"
-                },
-                {
-                    "critical": true,
-                    "icon": "battery_android_alert",
-                    "level": 5,
-                    "message": "PLUG THE CHARGER RIGHT NOW!!",
-                    "title": "Critical battery level"
-                }
-            ]
-        },
-        "idle": {
-            "inhibitWhenAudio": true,
-            "inhibitWhenCharging": false,
-            "lockBeforeSleep": true,
-            "timeouts": [
-                {
-                    "idleAction": "lock",
-                    "inhibitWhenAudio": false,
-                    "inhibitWhenCharging": false,
-                    "respectInhibitors": true,
-                    "timeout": 180
-                },
-                {
-                    "idleAction": "dpms off",
-                    "returnAction": "dpms on",
-                    "timeout": 300
-                },
-                {
-                    "idleAction": ["suspendThenHibernate"],
-                    "timeout": 600
-                }
-            ]
-        },
-        "logo": "",
-        "mediaGifSpeedAdjustment": 300,
-        "sessionGifSpeed": 0.7,
-        "showOverFullscreen": false
+        "showWeather": true,
+        "mediaUpdateInterval": 500,
+        "resourceUpdateInterval": 1000,
+        "dragThreshold": 50,
+        "performance": {
+            "showBattery": true,
+            "showGpu": true,
+            "showCpu": true,
+            "showMemory": true,
+            "showStorage": true,
+            "showNetwork": true
+        }
     },
     "launcher": {
-        "actionPrefix": ">",
-        "actions": [
-            {
-                "command": ["autocomplete", "calc"],
-                "dangerous": false,
-                "description": "Do simple math equations (powered by Qalc)",
-                "enabled": true,
-                "icon": "calculate",
-                "name": "Calculator"
-            },
-            {
-                "command": ["autocomplete", "scheme"],
-                "dangerous": false,
-                "description": "Change the current colour scheme",
-                "enabled": true,
-                "icon": "palette",
-                "name": "Scheme"
-            },
-            {
-                "command": ["autocomplete", "wallpaper"],
-                "dangerous": false,
-                "description": "Change the current wallpaper",
-                "enabled": true,
-                "icon": "image",
-                "name": "Wallpaper"
-            },
-            {
-                "command": ["autocomplete", "variant"],
-                "dangerous": false,
-                "description": "Change the current scheme variant",
-                "enabled": true,
-                "icon": "colors",
-                "name": "Variant"
-            },
-            {
-                "command": ["caelestia", "wallpaper", "-r"],
-                "dangerous": false,
-                "description": "Switch to a random wallpaper",
-                "enabled": true,
-                "icon": "casino",
-                "name": "Random"
-            },
-            {
-                "command": ["setMode", "light"],
-                "dangerous": false,
-                "description": "Change the scheme to light mode",
-                "enabled": true,
-                "icon": "light_mode",
-                "name": "Light"
-            },
-            {
-                "command": ["setMode", "dark"],
-                "dangerous": false,
-                "description": "Change the scheme to dark mode",
-                "enabled": true,
-                "icon": "dark_mode",
-                "name": "Dark"
-            },
-            {
-                "command": ["poweroff"],
-                "dangerous": true,
-                "description": "Shutdown the system",
-                "enabled": true,
-                "icon": "power_settings_new",
-                "name": "Shutdown"
-            },
-            {
-                "command": ["reboot"],
-                "dangerous": true,
-                "description": "Reboot the system",
-                "enabled": true,
-                "icon": "cached",
-                "name": "Reboot"
-            },
-            {
-                "command": ["logout"],
-                "dangerous": true,
-                "description": "Log out of the current session",
-                "enabled": true,
-                "icon": "exit_to_app",
-                "name": "Logout"
-            },
-            {
-                "command": ["loginctl", "lock-session"],
-                "dangerous": false,
-                "description": "Lock the current session",
-                "enabled": true,
-                "icon": "lock",
-                "name": "Lock"
-            },
-            {
-                "command": ["suspendThenHibernate"],
-                "dangerous": false,
-                "description": "Suspend then hibernate",
-                "enabled": true,
-                "icon": "bedtime",
-                "name": "Sleep"
-            },
-            {
-                "command": ["caelestia", "shell", "nexus", "open"],
-                "dangerous": false,
-                "description": "Configure the shell",
-                "enabled": true,
-                "icon": "settings",
-                "name": "Settings"
-            }
-        ],
-        "dragThreshold": 50,
-        "enableDangerousActions": false,
         "enabled": true,
-        "favouriteApps": [],
-        "hiddenApps": [],
+        "showOnHover": false,
         "maxShown": 7,
         "maxWallpapers": 9,
-        "showOnHover": false,
         "specialPrefix": "@",
+        "actionPrefix": ">",
+        "enableDangerousActions": false,
+        "dragThreshold": 50,
+        "vimKeybinds": false,
+        "favouriteApps": [],
+        "hiddenApps": [],
         "useFuzzy": {
-            "actions": false,
             "apps": false,
+            "actions": false,
             "schemes": false,
             "variants": false,
             "wallpapers": false
         },
-        "vimKeybinds": false
+        "actions": [
+            {
+                "name": "Calculator",
+                "icon": "calculate",
+                "description": "Do simple math equations (powered by Qalc)",
+                "command": ["autocomplete", "calc"],
+                "enabled": true,
+                "dangerous": false
+            },
+            {
+                "name": "Scheme",
+                "icon": "palette",
+                "description": "Change the current colour scheme",
+                "command": ["autocomplete", "scheme"],
+                "enabled": true,
+                "dangerous": false
+            },
+            {
+                "name": "Wallpaper",
+                "icon": "image",
+                "description": "Change the current wallpaper",
+                "command": ["autocomplete", "wallpaper"],
+                "enabled": true,
+                "dangerous": false
+            },
+            {
+                "name": "Variant",
+                "icon": "colors",
+                "description": "Change the current scheme variant",
+                "command": ["autocomplete", "variant"],
+                "enabled": true,
+                "dangerous": false
+            },
+            {
+                "name": "Random",
+                "icon": "casino",
+                "description": "Switch to a random wallpaper",
+                "command": ["caelestia", "wallpaper", "-r"],
+                "enabled": true,
+                "dangerous": false
+            },
+            {
+                "name": "Light",
+                "icon": "light_mode",
+                "description": "Change the scheme to light mode",
+                "command": ["setMode", "light"],
+                "enabled": true,
+                "dangerous": false
+            },
+            {
+                "name": "Dark",
+                "icon": "dark_mode",
+                "description": "Change the scheme to dark mode",
+                "command": ["setMode", "dark"],
+                "enabled": true,
+                "dangerous": false
+            },
+            {
+                "name": "Shutdown",
+                "icon": "power_settings_new",
+                "description": "Shutdown the system",
+                "command": ["poweroff"],
+                "enabled": true,
+                "dangerous": true
+            },
+            {
+                "name": "Reboot",
+                "icon": "cached",
+                "description": "Reboot the system",
+                "command": ["reboot"],
+                "enabled": true,
+                "dangerous": true
+            },
+            {
+                "name": "Logout",
+                "icon": "exit_to_app",
+                "description": "Log out of the current session",
+                "command": ["logout"],
+                "enabled": true,
+                "dangerous": true
+            },
+            {
+                "name": "Lock",
+                "icon": "lock",
+                "description": "Lock the current session",
+                "command": ["loginctl", "lock-session"],
+                "enabled": true,
+                "dangerous": false
+            },
+            {
+                "name": "Sleep",
+                "icon": "bedtime",
+                "description": "Suspend then hibernate",
+                "command": ["suspendThenHibernate"],
+                "enabled": true,
+                "dangerous": false
+            },
+            {
+                "name": "Settings",
+                "icon": "settings",
+                "description": "Configure the shell",
+                "command": ["caelestia", "shell", "nexus", "open"],
+                "enabled": true,
+                "dangerous": false
+            }
+        ]
     },
     "lock": {
-        "enableFprint": true,
-        "enableHowdy": true,
         "enabled": true,
-        "hideNotifs": false,
-        "maxFprintTries": 3,
-        "maxHowdyTries": 3,
+        "useWallpaper": false,
         "recolourLogo": true,
+        "enableFprint": true,
+        "maxFprintTries": 3,
+        "enableHowdy": true,
+        "maxHowdyTries": 3,
         "triggerHowdyOnWake": true,
-        "useWallpaper": false
+        "hideNotifs": false
     },
     "nexus": {
-        "networkRescanInterval": 15000,
-        "wallpapersPerRow": 4
+        "wallpapersPerRow": 4,
+        "networkRescanInterval": 15000
     },
     "notifs": {
-        "actionOnClick": false,
-        "clearThreshold": 0.3,
-        "defaultExpireTimeout": 5000,
-        "expandThreshold": 20,
         "expire": true,
         "fullscreen": "on",
+        "defaultExpireTimeout": 5000,
         "fullscreenExpireTimeout": 2000,
+        "clearThreshold": 0.3,
+        "expandThreshold": 20,
+        "actionOnClick": false,
         "groupPreviewNum": 3,
         "openExpanded": false
     },
     "osd": {
-        "enableBrightness": true,
-        "enableMicrophone": false,
         "enabled": true,
-        "hideDelay": 2000
-    },
-    "paths": {
-        "lockNoNotifsPic": "root:/assets/dino.png",
-        "lyricsDir": "~/Music/lyrics/",
-        "mediaGif": "root:/assets/bongocat.gif",
-        "noNotifsPic": "root:/assets/dino.png",
-        "sessionGif": "root:/assets/kurukuru.gif",
-        "wallpaperDir": "~/Pictures/Wallpapers"
+        "hideDelay": 2000,
+        "enableBrightness": true,
+        "enableMicrophone": false
     },
     "services": {
-        "audioIncrement": 0.1,
-        "brightnessIncrement": 0.1,
-        "defaultPlayer": "Spotify",
-        "gpuType": "",
-        "lyricsBackend": "Auto",
-        "maxVolume": 1.0,
-        "playerAliases": [{ "from": "com.github.th_ch.youtube_music", "to": "YT Music" }],
-        "smartScheme": true,
+        "weatherLocation": "",
         "useFahrenheit": false,
         "useFahrenheitPerformance": false,
         "useTwelveHourClock": false,
+        "gpuType": "",
         "visualiserBars": 60,
-        "weatherLocation": ""
+        "audioIncrement": 0.1,
+        "brightnessIncrement": 0.1,
+        "maxVolume": 1.0,
+        "smartScheme": true,
+        "defaultPlayer": "Spotify",
+        "playerAliases": [{ "from": "com.github.th_ch.youtube_music", "to": "YT Music" }],
+        "lyricsBackend": "Auto"
     },
     "session": {
-        "commands": {
-            "hibernate": ["hibernate"],
-            "logout": ["logout"],
-            "reboot": ["reboot"
-            ],
-            "shutdown": ["poweroff"]
-        },
-        "dragThreshold": 30,
         "enabled": true,
+        "dragThreshold": 30,
+        "vimKeybinds": false,
         "icons": {
-            "hibernate": "downloading",
             "logout": "logout",
-            "reboot": "cached",
-            "shutdown": "power_settings_new"
+            "shutdown": "power_settings_new",
+            "hibernate": "downloading",
+            "reboot": "cached"
         },
-        "vimKeybinds": false
+        "commands": {
+            "logout": ["logout"],
+            "shutdown": ["poweroff"],
+            "hibernate": ["hibernate"],
+            "reboot": ["reboot"]
+        }
     },
     "sidebar": {
-        "dragThreshold": 80,
         "enabled": true,
+        "showOnHover": false,
         "minHoverThreshold": 200,
-        "showOnHover": false
+        "dragThreshold": 80
     },
     "utilities": {
         "enabled": true,
         "maxToasts": 4,
-        "quickToggles": [
-            {
-                "enabled": true,
-                "id": "wifi"
-            },
-            {
-                "enabled": true,
-                "id": "bluetooth"
-            },
-            {
-                "enabled": true,
-                "id": "mic"
-            },
-            {
-                "enabled": true,
-                "id": "settings"
-            },
-            {
-                "enabled": true,
-                "id": "gameMode"
-            },
-            {
-                "enabled": true,
-                "id": "dnd"
-            },
-            {
-                "enabled": false,
-                "id": "vpn"
-            }
-        ],
         "toasts": {
-            "audioInputChanged": true,
-            "audioOutputChanged": true,
-            "capsLockChanged": true,
-            "chargingChanged": true,
-            "configLoaded": true,
-            "dndChanged": true,
             "fullscreen": "off",
+            "configLoaded": true,
+            "chargingChanged": true,
             "gameModeChanged": true,
+            "dndChanged": true,
+            "audioOutputChanged": true,
+            "audioInputChanged": true,
+            "capsLockChanged": true,
+            "numLockChanged": true,
             "kbLayoutChanged": true,
             "kbLimit": true,
-            "nowPlaying": false,
-            "numLockChanged": true,
-            "vpnChanged": true
+            "vpnChanged": true,
+            "nowPlaying": false
         },
         "vpn": {
             "enabled": false,
             "provider": [
                 {
-                    "displayName": "Wireguard (Your VPN)",
-                    "enabled": false,
+                    "name": "wireguard",
                     "interface": "your-connection-name",
-                    "name": "wireguard"
+                    "displayName": "Wireguard (Your VPN)",
+                    "enabled": false
                 }
             ]
-        }
+        },
+        "quickToggles": [
+            {
+                "id": "wifi",
+                "enabled": true
+            },
+            {
+                "id": "bluetooth",
+                "enabled": true
+            },
+            {
+                "id": "mic",
+                "enabled": true
+            },
+            {
+                "id": "settings",
+                "enabled": true
+            },
+            {
+                "id": "gameMode",
+                "enabled": true
+            },
+            {
+                "id": "dnd",
+                "enabled": true
+            },
+            {
+                "id": "vpn",
+                "enabled": false
+            }
+        ]
+    },
+    "paths": {
+        "wallpaperDir": "~/Pictures/Wallpapers",
+        "lyricsDir": "~/Music/lyrics/",
+        "sessionGif": "root:/assets/kurukuru.gif",
+        "mediaGif": "root:/assets/bongocat.gif",
+        "noNotifsPic": "root:/assets/dino.png",
+        "lockNoNotifsPic": "root:/assets/dino.png"
     }
 }
 ```
@@ -887,6 +887,9 @@ You can join the Caelestia Discord server for assistance and discussion [here][d
 ### I want to make my own changes to the Hyprland config!
 
 You can add your custom Hyprland configs to `~/.config/caelestia/hypr-user.lua`.
+Most default Hyprland values can be modified by overriding variables in `~/.config/caelestia/hypr-vars.lua`.
+You can reference the [variables.lua](https://github.com/caelestia-dots/caelestia/blob/main/hypr/variables.lua) file for all available
+variables and their default values.
 
 ### I want to make my own changes to other stuff!
 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ sudo cmake --install build
 > [!TIP]
 > You can customise the installation location via the CMake flags `INSTALL_LIBDIR`, `INSTALL_QMLDIR`, and
 > `INSTALL_QSCONFDIR` for the libraries (e.g. the version helper), QML plugin, and Quickshell config directories
-> respectively. If changing the library directory, remember to set the `CAELESTIA_LIB_DIR` environment
-> variable to the custom directory when launching the shell.
+> respectively. If you set the `INSTALL_LIBDIR` flag, the `CAELESTIA_LIB_DIR` variable must also be set to
+> the same directory in your system's environment.
 >
 > For example, installing to `~/.config/quickshell/caelestia` for easy local changes:
 >

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Options set in these files will **override** the respective options in the globa
 per-monitor configs will inherit their values from the global config.
 
 
-For example, to disable the bar on the monitor named `DP-1`:
+For example, to automatically hide the bar on the monitor named `DP-1`:
 
 **`~/.config/caelestia/monitors/DP-1/shell.json`**
 


### PR DESCRIPTION
## Summary

Update `README.md` for improved clarity, consistency, accuracy, and maintainability.
Changes included:

- Use reference-style links for reused external links (such as the dots repo and Discord)
- Replace the old Discord link with the standardized `caelestiashell.com` link
- Fix various grammatical errors throughout the README
- Reword sections across the doc for clarity and consistency
- Make capitalisation of project names and titles consistent
- Modify the levels of existing alerts to align with their intended purpose
- Replace `yay` with `paru`, as paru is the recommended AUR helper by default in the other repos
- Specify the `with-cli` shell package as the default for Nix
  - This can be reverted if necessary, but with the amount of interop between the shell and cli I don't see any reason not to recommend this by default.
- Replace explicit links to the README's section with `(#section)`-style links
- Reorder dependencies to match the shell's PKGBUILD
- Update outdated links to various dependencies which were broken before (Hyprland, Pipewire, etc.)
- Standardize links to dependencies by using links to their sources directly, instead of mixing sources, homepages, and adjacent pages
- Replace `lm-sensors` with it's correct name of `lm_sensors` and use the correct names for the font packages
- Add missing `power-profiles-daemon` and `ttf-rubik-vf` dependencies, along with the `qt6-shadertools` build dependency
- Add alert explaining that `$XDG_CONFIG_HOME` is expected to be set for the manual installation and updating commands (this can be unset since we don't depend on `xdg-user-dirs`)
- Use `$HOME` instead of `~` in `cmake -B build`, since tilde expansion shouldn't be relied upon there
- Include `-d` in the alternative Quickshell launch command to match the `caelestia shell -d` before it
- Explain that `-d` can be omitted to run the shell as an attached instance
- Replace references to `hypr-user.conf` with `hypr-user.lua`
- Change the broken `hyprland.org` link for global shortcuts to actually navigate to the current wiki
- Update the `keybinds.conf` link to direct users to the correct section in the new `keybinds.lua` file for an example of global shortcuts
- Remove the IPC command list, replacing it with a note on how to view the available IPC commands.
  - This has been heavily outdated for a while now, and while I could replace it with an updated version I don't believe that's the best idea for long-term maintainability. This would just be another thing to update every time a new IPC method is added, and users should be using `caelestia shell -s` as the ultimate source of truth.
- Specify the option used to modify the wallpapers path in 'PFP/Wallpapers'
- Document the full command used to set the wallpaper instead of just `caelestia wallpaper`
- Section out the "Updating" section into packaged installs vs manual installs
- Instruct users to update with `caelestia update` if using the dotfiles, otherwise use their AUR helper if using the shell standalone
- Generalize the instructions for manual installs, providing an install to `$XDG_CONFIG_HOME/quickshell/caelestia` as an example
- Clarify wording on per-monitor overrides, noting that the *monitor name* is used
- Include instructions on how to list the current monitor names for per-monitor configuration
- Sort the `Ignored options` in the per-monitor exclusions alphabetically
- Update per-monitor exclusions to include previously absent options that were global properties (namely `utilities.vpn.selectedProvider` and multiple `lock` options)
- Use `section.*` for config sections that are completely ignored in per-monitor configs
  - This helps differentiate them and clarify that the entire section is ignored
- Elaborate in the default config alert why copying the entire config isn't recommended and emphasize the importance of it
- Sort the keys of the default config
  - This can also be reverted if necessary, though imo it's easier to use as reference after configuring the shell, since `shell.json` is automatically sorted on save.
  - If this isn't desired, then the shell probably shouldn't be sorting the config on save, or certain parts of the structure should be changed for readability.
  - Intentionally kept some of the formatting compact even though it differs from `jq` output to save space in the browser's display.
- Remove the 'VRR screen flickering' FAQ
  - Hyprland now defaults to `vrr = 0`, so this would only be needed if they already changed the value.
- Provide a direct link to creating a feature request instead of linking the shell's issues page
- Specify launcher commands for setting the wallpaper and dynamic scheme
