### PR TITLE
ci: remove legacy controlcenter path from QML linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
           for path in $import_paths
             set -a args -I $path
           end
-          set -l qml_files (string match -vr '(build|modules/controlcenter)/.*' **.qml)
+          set -l qml_files (string match -vr 'build/.*' **.qml)
 
           # Lint
           set -l lint_out (/usr/lib/qt6/bin/qmllint --import disable $args $qml_files 2>&1 | tee /dev/stderr)


### PR DESCRIPTION
## Summary

Removes the `modules/controlcenter/.*` path from QML linting in the CI workflow.
This could be replaced with `modules/nexus` if necessary, but seeing as CI has passed with it being a no-op and it hasn't been noticed for months now, it seems it's just no longer needed.