### PR TITLE
fix(notifs): strip markup from elided body previews

### DIFF
--- a/modules/lock/NotifGroup.qml
+++ b/modules/lock/NotifGroup.qml
@@ -314,7 +314,7 @@ StyledRect {
         textFormat: Text.MarkdownText
         text: {
             const summary = modelData.summary.replace(/\n/g, " ");
-            const body = modelData.body.replace(/\n/g, " ");
+            const body = Strings.stripMarkup(modelData.body).replace(/\n/g, " ");
             const colour = root.urgency === "critical" ? Colours.palette.m3secondary : Colours.palette.m3outline;
 
             if (metrics.text === metrics.elidedText)
@@ -334,7 +334,7 @@ StyledRect {
         TextMetrics {
             id: metrics
 
-            text: `${notifLine.modelData.summary} ${notifLine.modelData.body}`.replace(/\n/g, " ")
+            text: `${notifLine.modelData.summary} ${Strings.stripMarkup(notifLine.modelData.body)}`.replace(/\n/g, " ")
             font: notifLine.font
             elideWidth: notifLine.width
             elide: Text.ElideRight

--- a/modules/notifications/Notification.qml
+++ b/modules/notifications/Notification.qml
@@ -19,6 +19,11 @@ StyledRect {
     readonly property bool hasImage: modelData.image.length > 0
     readonly property bool hasAppIcon: modelData.appIcon.length > 0
     readonly property int bodyTextFormat: /[<*_`#\[\]]/.test(modelData.body) ? Text.MarkdownText : Text.PlainText
+    // The preview goes through TextMetrics, which knows nothing about
+    // textFormat and so elides the raw markup: use the text only there. Links
+    // stay clickable in the expanded body, which is rendered in full.
+    readonly property string bodyPreviewText: Strings.stripMarkup(modelData.body)
+    readonly property int bodyPreviewTextFormat: Strings.hasMarkup(modelData.body) ? Text.PlainText : bodyTextFormat
     readonly property int nonAnimHeight: summary.implicitHeight + (root.expanded ? Tokens.spacing.extraSmall * 2 + appName.height + body.height + actions.height + actions.anchors.topMargin : bodyPreview.height) + inner.anchors.margins * 2
     property bool expanded: Config.notifs.openExpanded
 
@@ -391,7 +396,7 @@ StyledRect {
                 anchors.rightMargin: Tokens.spacing.small
 
                 animate: true
-                textFormat: root.bodyTextFormat
+                textFormat: root.bodyPreviewTextFormat
                 text: bodyPreviewMetrics.elidedText
                 color: Colours.palette.m3onSurfaceVariant
                 font: Tokens.font.body.small
@@ -408,7 +413,7 @@ StyledRect {
             TextMetrics {
                 id: bodyPreviewMetrics
 
-                text: root.modelData.body
+                text: root.bodyPreviewText
                 font: bodyPreview.font
                 elide: Text.ElideRight
                 elideWidth: bodyPreview.width

--- a/modules/sidebar/Notif.qml
+++ b/modules/sidebar/Notif.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts
 import Caelestia.Config
 import qs.components
 import qs.services
+import qs.utils
 
 StyledRect {
     id: root
@@ -88,7 +89,7 @@ StyledRect {
         anchors.leftMargin: Tokens.spacing.small
 
         sourceComponent: StyledText {
-            text: String(root.modelData?.body ?? "").replace(/\n/g, " ")
+            text: Strings.stripMarkup(String(root.modelData?.body ?? "")).replace(/\n/g, " ")
             color: root.modelData?.urgency === "critical" ? Colours.palette.m3secondary : Colours.palette.m3outline
             elide: Text.ElideRight
         }

--- a/utils/Strings.qml
+++ b/utils/Strings.qml
@@ -5,6 +5,21 @@ import Quickshell
 Singleton {
     property var _regexCache: ({})
 
+    // Notification bodies may contain the small HTML subset from the
+    // freedesktop spec (b, i, u, a, img). That is fine wherever the text is
+    // rendered in full, but where it gets elided or truncated the markup is cut
+    // in half and Qt shows it verbatim - e.g. the <a href> Chrome puts in the
+    // body of web notifications. Those places need the text only.
+    function hasMarkup(text: string): bool {
+        return /<[a-z!\/][^>]*>/i.test(text);
+    }
+
+    function stripMarkup(text: string): string {
+        if (!hasMarkup(text))
+            return text;
+        return text.replace(/<br\s*\/?>/gi, " ").replace(/<[^>]+>/g, "").replace(/&(?:nbsp|#160);/gi, " ").replace(/&(?:quot|#34);/gi, '"').replace(/&(?:apos|#39);/gi, "'").replace(/&(?:lt|#60);/gi, "<").replace(/&(?:gt|#62);/gi, ">").replace(/&(?:amp|#38);/gi, "&").replace(/[ \t]+/g, " ").trim();
+    }
+
     function testRegexList(filterList: list<string>, target: string): bool {
         const regexChecker = /^\^.*\$$/;
         for (const filter of filterList) {


### PR DESCRIPTION
Fixes #1652.

## The problem

Notification bodies may contain the small HTML subset from the freedesktop spec, and Chrome uses it for web notifications: the body of a WhatsApp Web notification is

```
<a href="https://web.whatsapp.com/">web.whatsapp.com</a>

Sincronizzazione dei messaggi in background in corso…
```

The collapsed popup preview reads its text from `bodyPreviewMetrics.elidedText`. `TextMetrics` is `QFontMetrics` based and knows nothing about `textFormat`, so it elides the raw markup: the opening tag comes back cut in half and Qt renders it verbatim. The preview shows

```
<a href="https://web.whatsapp.co...
```

instead of the message. It only happens when the body is long enough to be elided, which with Chrome is nearly always, since the link comes first. `bodyTextFormat` itself is fine — an HTML body that is rendered in full comes out correctly.

Two other places truncate the body the same way:

- `modules/sidebar/Notif.qml`, the compact row: `StyledText` defaults to `Text.PlainText`, so there the tags show up whole.
- `modules/lock/NotifGroup.qml`, the lock screen row: the text is truncated by hand and wrapped in a `<span>`.

## The fix

`Strings.hasMarkup()` / `Strings.stripMarkup()`, used in those three places so they measure and display the text without tags (entities decoded, runs of spaces collapsed). The expanded body is untouched: it is rendered in full, so bold, italics and clickable links keep working — the preview never had clickable links anyway, `onLinkActivated` returns early unless the notification is expanded.

## Testing

On the popup, with the WhatsApp body above sent through `notify-send -a "Google Chrome"`: before, the preview reads `<a href="https://web.whatsapp.co...`; after, it reads `web.whatsapp.com` followed by the elided message. Bodies with no markup are returned unchanged by `stripMarkup`, so plain and Markdown notifications render exactly as before — checked against my own notification history. Sidebar and lock rows go through the same helper. `qmlformat` and `scripts/qml-lint-conventions.py` are clean.

## Side effects

For an HTML body the preview is now `Text.PlainText` rather than `Text.MarkdownText`. Inline formatting is therefore not rendered in the collapsed preview of those notifications — which is what already happened in practice, since the truncated markup could not render either.

No breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
