### PR TITLE
vpn: add opt-in Tailscale exit node mode

### DIFF
--- a/modules/nexus/pages/network/AddVpnPage.qml
+++ b/modules/nexus/pages/network/AddVpnPage.qml
@@ -149,7 +149,6 @@ PageBase {
             subtext: qsTr("When only changing the exit node")
         }
 
-
         SectionHeader {
             text: qsTr("Custom commands (optional)")
         }

--- a/modules/nexus/pages/network/AddVpnPage.qml
+++ b/modules/nexus/pages/network/AddVpnPage.qml
@@ -45,7 +45,7 @@ PageBase {
             interface: interfaceField.text.trim(),
             connectCmd: joinCmd(connectField.text),
             disconnectCmd: joinCmd(disconnectField.text),
-            exitNodeOnly: exitNodeToggle.checked
+            exitNodeOnly: root.isTailscale && exitNodeToggle.checked
         };
 
         if (editing) {

--- a/modules/nexus/pages/network/AddVpnPage.qml
+++ b/modules/nexus/pages/network/AddVpnPage.qml
@@ -16,6 +16,7 @@ PageBase {
     readonly property int editIndex: nState.editingVpnIndex
     readonly property bool editing: editIndex >= 0
     readonly property VPN.Provider existing: editing ? (VPN.providers[editIndex] ?? null) : null
+    readonly property bool isTailscale: nameField.text.trim().toLowerCase() === "tailscale"
 
     function splitCmd(arr: var): string {
         return arr?.join(" ") ?? "";
@@ -43,7 +44,8 @@ PageBase {
             displayName: displayField.text.trim() || name,
             interface: interfaceField.text.trim(),
             connectCmd: joinCmd(connectField.text),
-            disconnectCmd: joinCmd(disconnectField.text)
+            disconnectCmd: joinCmd(disconnectField.text),
+            exitNodeOnly: exitNodeToggle.checked
         };
 
         if (editing) {
@@ -83,6 +85,7 @@ PageBase {
             interfaceField.text = existing.iface;
             connectField.text = splitCmd(existing.connectCmd);
             disconnectField.text = splitCmd(existing.disconnectCmd);
+            exitNodeToggle.checked = existing.exitNodeOnly;
         }
     }
 
@@ -138,6 +141,14 @@ PageBase {
 
             onAccepted: connectField.forceActiveFocus()
         }
+
+        ToggleRow {
+            id: exitNodeToggle
+            visible: root.isTailscale
+            text: qsTr("Exit node mode")
+            subtext: qsTr("When only changing the exit node")
+        }
+
 
         SectionHeader {
             text: qsTr("Custom commands (optional)")

--- a/modules/nexus/pages/network/AddVpnPage.qml
+++ b/modules/nexus/pages/network/AddVpnPage.qml
@@ -144,7 +144,7 @@ PageBase {
 
         ToggleRow {
             id: exitNodeToggle
-            
+
             visible: root.isTailscale
             text: qsTr("Exit node mode")
             subtext: qsTr("When only changing the exit node")

--- a/modules/nexus/pages/network/AddVpnPage.qml
+++ b/modules/nexus/pages/network/AddVpnPage.qml
@@ -144,6 +144,7 @@ PageBase {
 
         ToggleRow {
             id: exitNodeToggle
+            
             visible: root.isTailscale
             text: qsTr("Exit node mode")
             subtext: qsTr("When only changing the exit node")

--- a/services/VPN.qml
+++ b/services/VPN.qml
@@ -356,7 +356,6 @@ Singleton {
 
                 if (usingExitNode)
                     status.server = (exitNode.DNSName || exitNode.HostName || "").replace(/\.$/, "");
-                
             } else if (backendState === "Starting") {
                 status.state = "connecting";
             } else if (backendState === "NeedsLogin" || backendState === "NeedsMachineAuth") {

--- a/services/VPN.qml
+++ b/services/VPN.qml
@@ -64,7 +64,7 @@ Singleton {
         const input = providerInput;
         const custom = typeof input === "object" ? input : null;
         const name = custom ? (custom.name || "custom") : String(input);
-        const adapter = adapters.find(a => a.name === name) ?? null;
+        const adapter = adapters.find(a => a.name === name.toLowerCase()) ?? null;
         const iface = (custom ? custom.interface : "") || (adapter ? adapter.iface : "") || (adapter ? "" : name);
         const resolve = c => typeof c === "function" ? c(iface) : c;
         return {
@@ -73,6 +73,7 @@ Singleton {
             interface: iface,
             connectCmd: (custom && custom.connectCmd && custom.connectCmd.length > 0 ? custom.connectCmd : resolve(adapter ? adapter.connectCmd : null)) || [name, "up"],
             disconnectCmd: (custom && custom.disconnectCmd && custom.disconnectCmd.length > 0 ? custom.disconnectCmd : resolve(adapter ? adapter.disconnectCmd : null)) || [name, "down"],
+            exitNodeOnly: name.toLowerCase() === "tailscale" && custom?.exitNodeOnly === true,
             statusCmd: (adapter ? adapter.statusCmd : null) || ["ip", "link", "show"],
             parse: (adapter ? adapter.parse : null) || (out => root.parseInterfaceStatus(out, iface)),
             service: adapter ? adapter.service : `${name}d`,
@@ -111,6 +112,7 @@ Singleton {
                 interface: isObject ? (p.interface || "") : "",
                 connectCmd: isObject && p.connectCmd ? p.connectCmd : [],
                 disconnectCmd: isObject && p.disconnectCmd ? p.disconnectCmd : [],
+                exitNodeOnly: isObject && p.exitNodeOnly === true,
                 isObject: isObject
             });
         }
@@ -168,6 +170,8 @@ Singleton {
             obj.connectCmd = data.connectCmd;
         if (data.disconnectCmd && data.disconnectCmd.length > 0)
             obj.disconnectCmd = data.disconnectCmd;
+        if (data.exitNodeOnly === true)
+            obj.exitNodeOnly = true;
         return obj;
     }
 
@@ -344,20 +348,15 @@ Singleton {
             const backendState = data.BackendState || "";
 
             if (backendState === "Running") {
-                status.connected = true;
-                status.state = "connected";
+                const exitNode = data.ExitNodeStatus;
+                const usingExitNode = exitNode !== null && exitNode !== undefined;
 
-                // Exit node, if one is in use, is the most meaningful "server".
-                try {
-                    const peers = data.Peer || {};
-                    for (const key in peers) {
-                        const p = peers[key];
-                        if (p && p.ExitNode) {
-                            status.server = (p.DNSName || p.HostName || "").replace(/\.$/, "");
-                            break;
-                        }
-                    }
-                } catch (e2) {}
+                status.connected = root.active.exitNodeOnly ? usingExitNode : true;
+                status.state = status.connected ? "connected" : "disconnected";
+
+                if (usingExitNode)
+                    status.server = (exitNode.DNSName || exitNode.HostName || "").replace(/\.$/, "");
+                
             } else if (backendState === "Starting") {
                 status.state = "connecting";
             } else if (backendState === "NeedsLogin" || backendState === "NeedsMachineAuth") {
@@ -937,6 +936,7 @@ Singleton {
         readonly property var connectCmd: lastIpcObject.connectCmd
         readonly property var disconnectCmd: lastIpcObject.disconnectCmd
         readonly property bool isObject: lastIpcObject.isObject
+        readonly property bool exitNodeOnly: lastIpcObject.exitNodeOnly
     }
 
     // Everything a provider needs to be driven by the generic engine above.

--- a/services/VPN.qml
+++ b/services/VPN.qml
@@ -354,8 +354,16 @@ Singleton {
                 status.connected = root.active.exitNodeOnly ? usingExitNode : true;
                 status.state = status.connected ? "connected" : "disconnected";
 
-                if (usingExitNode)
-                    status.server = (exitNode.DNSName || exitNode.HostName || "").replace(/\.$/, "");
+                if (usingExitNode) {
+                    const peers = data.Peer || {};
+                    for (const key in peers) {
+                        const peer = peers[key];
+                        if (peer && (peer.ID === exitNode.ID || peer.ExitNode)) {
+                            status.server = (peer.DNSName || peer.HostName || "").replace(/\.$/, "");
+                            break;
+                        }
+                    }
+                }
             } else if (backendState === "Starting") {
                 status.state = "connecting";
             } else if (backendState === "NeedsLogin" || backendState === "NeedsMachineAuth") {


### PR DESCRIPTION
The Tailscale VPN integration considered the VPN to be on if Tailscale was `Running`, rather than if an exit node was connected. This meant in order to toggle the VPN, Tailscale had to be completely stopped and started. These changes make it so the connect command can just be `tailscale set --exit-node=100.x.x.x` and the disconnect command can be `tailscale set --exit-node=` by toggling a setting in the VPN configuration.

Changes:
* Exit-node toggle within VPN configuration (when provider is Tailscale)
* Exit-node connection detection