### PR TITLE
lock: add lifecycle hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ string(REGEX REPLACE "^v" "" VERSION "${VERSION}")
 project(caelestia-shell VERSION ${VERSION} LANGUAGES CXX)
 
 include(GNUInstallDirs)
+include(CTest)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ For example, to automatically hide the bar on the monitor named `DP-1`:
 > - `dashboard`: `mediaUpdateInterval`, `resourceUpdateInterval`
 > - `general`: `apps.*`, `battery.*`, `idle.*`, `logo`
 > - `launcher`: `actionPrefix`, `actions`, `enableDangerousActions`, `favouriteApps`, `hiddenApps`, `specialPrefix`, `useFuzzy.*`, `vimKeybinds`
-> - `lock`: `enableFprint`, `enableHowdy`, `maxFprintTries`, `maxHowdyTries`, `triggerHowdyOnWake`
+> - `lock`: `enableFprint`, `enableHowdy`, `maxFprintTries`, `maxHowdyTries`, `onRelease`, `onSecure`, `triggerHowdyOnWake`
 > - `nexus`: `networkRescanInterval`
 > - `notifs`: `actionOnClick`, `defaultExpireTimeout`, `expire`, `fullscreen`, `fullscreenExpireTimeout`
 > - `paths`: `lyricsDir`, `wallpaperDir`
@@ -247,9 +247,31 @@ For example, to automatically hide the bar on the monitor named `DP-1`:
 > The example configuration includes **ALL** configuration options in `shell.json`. It is
 > **not** recommended to copy and paste this entire configuration into `shell.json`,
 > as options or their default values may change across updates, resulting in a stale config.
+
 >
 > This is meant to serve as a reference of all the available options, and you should
 > <ins>only add the ones you want to change</ins> to `shell.json`.
+
+### Lock lifecycle hooks
+
+`lock.onSecure` and `lock.onRelease` optionally run one command each. `onSecure` runs after a lock becomes
+secure; `onRelease` runs when the active lock is fully released. Each lifecycle event requests its command
+once per lock cycle. Each command is a direct argv array, not a shell command, and runs asynchronously as the
+session user. Use a wrapper program if sequencing or shell syntax is required.
+
+Both options are global-only. Definitions in per-monitor configuration files are ignored. An empty array, or an
+omitted option, disables that hook. Each non-empty array must contain only strings; other values are rejected by
+Settings and the effective command falls back to empty. A blank or whitespace-only first item is schema-valid but
+is logged and skipped at execution time.
+
+```json
+{
+    "lock": {
+        "onSecure": ["lock-lifecycle-hook", "secure"],
+        "onRelease": ["lock-lifecycle-hook", "release"]
+    }
+}
+```
 
 <details><summary>Example config</summary>
 
@@ -696,7 +718,9 @@ For example, to automatically hide the bar on the monitor named `DP-1`:
         "enableHowdy": true,
         "maxHowdyTries": 3,
         "triggerHowdyOnWake": true,
-        "hideNotifs": false
+        "hideNotifs": false,
+        "onSecure": [],
+        "onRelease": []
     },
     "nexus": {
         "wallpapersPerRow": 4,

--- a/modules/lock/Lock.qml
+++ b/modules/lock/Lock.qml
@@ -4,10 +4,28 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import Quickshell.Wayland
+import Caelestia.Config
 import qs.components.misc
 
 Scope {
     property alias lock: lock
+
+    Component.onCompleted: lifecycle.initialize(lock.locked, lock.secure)
+
+    LockLifecycle {
+        id: lifecycle
+
+        function onSecureHookRequested(command): void {
+            Quickshell.execDetached(command);
+        }
+
+        function onReleaseHookRequested(command): void {
+            Quickshell.execDetached(command);
+        }
+
+        secureCommand: GlobalConfig.lock.onSecure
+        releaseCommand: GlobalConfig.lock.onRelease
+    }
 
     WlSessionLock {
         id: lock
@@ -18,6 +36,19 @@ Scope {
             lock: lock
             pam: pam
         }
+    }
+
+    Connections {
+        function onLockedChanged(): void {
+            lifecycle.update(lock.locked, lock.secure);
+        }
+
+        function onSecureChanged(): void {
+            lifecycle.update(lock.locked, lock.secure);
+        }
+
+        enabled: lifecycle.initialized
+        target: lock
     }
 
     Pam {

--- a/modules/lock/LockLifecycle.qml
+++ b/modules/lock/LockLifecycle.qml
@@ -1,0 +1,83 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+
+QtObject {
+    id: root
+
+    property var secureCommand: []
+    property var releaseCommand: []
+    property bool initialized: false
+
+    property bool wasLocked: false
+    property bool cycleActive: false
+    property bool secureFired: false
+    property bool releaseFired: false
+
+    signal secureHookRequested(var command)
+    signal releaseHookRequested(var command)
+
+    function initialize(locked, secure): bool {
+        if (initialized) {
+            console.warn(lc, "Lock lifecycle controller initialized more than once");
+            return false;
+        }
+
+        initialized = true;
+        wasLocked = locked;
+        cycleActive = locked;
+        secureFired = locked && secure;
+        releaseFired = false;
+        return true;
+    }
+
+    function update(locked, secure): void {
+        if (!initialized) {
+            console.warn(lc, "Lock lifecycle update before initialization");
+            return;
+        }
+
+        if (locked && !wasLocked) {
+            cycleActive = true;
+            secureFired = false;
+            releaseFired = false;
+        }
+
+        if (cycleActive && locked && secure && !secureFired) {
+            secureFired = true;
+            if (canRun(secureCommand))
+                secureHookRequested(secureCommand);
+        }
+
+        if (cycleActive && wasLocked && !locked) {
+            if (!releaseFired) {
+                releaseFired = true;
+                if (canRun(releaseCommand))
+                    releaseHookRequested(releaseCommand);
+            }
+            cycleActive = false;
+        }
+
+        wasLocked = locked;
+    }
+
+    function canRun(command): bool {
+        if (command.length === 0)
+            return false;
+
+        if (command[0].trim().length === 0) {
+            console.warn(lc, "Ignoring lock lifecycle hook with blank argv[0]");
+            return false;
+        }
+
+        return true;
+    }
+
+    LoggingCategory {
+        id: lc
+
+        name: "caelestia.qml.lock.lifecycle"
+        defaultLogLevel: LoggingCategory.Info
+    }
+}

--- a/modules/lock/LockLifecycle.qml
+++ b/modules/lock/LockLifecycle.qml
@@ -1,7 +1,6 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import Quickshell
 
 QtObject {
     id: root
@@ -20,7 +19,7 @@ QtObject {
 
     function initialize(locked, secure): bool {
         if (initialized) {
-            console.warn(lc, "Lock lifecycle controller initialized more than once");
+            console.warn("Lock lifecycle controller initialized more than once");
             return false;
         }
 
@@ -34,7 +33,7 @@ QtObject {
 
     function update(locked, secure): void {
         if (!initialized) {
-            console.warn(lc, "Lock lifecycle update before initialization");
+            console.warn("Lock lifecycle update before initialization");
             return;
         }
 
@@ -67,17 +66,10 @@ QtObject {
             return false;
 
         if (command[0].trim().length === 0) {
-            console.warn(lc, "Ignoring lock lifecycle hook with blank argv[0]");
+            console.warn("Ignoring lock lifecycle hook with blank argv[0]");
             return false;
         }
 
         return true;
-    }
-
-    LoggingCategory {
-        id: lc
-
-        name: "caelestia.qml.lock.lifecycle"
-        defaultLogLevel: LoggingCategory.Info
     }
 }

--- a/plugin/src/Caelestia/Config/CMakeLists.txt
+++ b/plugin/src/Caelestia/Config/CMakeLists.txt
@@ -35,3 +35,7 @@ target_link_libraries(caelestia-config PUBLIC
     Qt::Gui
     caelestia-settings
 )
+
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/plugin/src/Caelestia/Config/lockconfig.hpp
+++ b/plugin/src/Caelestia/Config/lockconfig.hpp
@@ -3,6 +3,8 @@
 #include "common.hpp"
 #include "settings/objectnode.hpp"
 
+#include <qstringlist.h>
+
 namespace caelestia::config {
 
 class LockConfig : public settings::ObjectNode {
@@ -17,6 +19,8 @@ class LockConfig : public settings::ObjectNode {
     CONFIG_GLOBAL_PROPERTY(int, maxHowdyTries, 3)
     CONFIG_GLOBAL_PROPERTY(bool, triggerHowdyOnWake, true)
     CONFIG_PROPERTY(bool, hideNotifs, false)
+    CONFIG_GLOBAL_PROPERTY(QStringList, onSecure, {})
+    CONFIG_GLOBAL_PROPERTY(QStringList, onRelease, {})
 };
 
 } // namespace caelestia::config

--- a/plugin/src/Caelestia/Config/tests/CMakeLists.txt
+++ b/plugin/src/Caelestia/Config/tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+find_package(Qt6 REQUIRED COMPONENTS Qml QuickTest Test)
+
+add_executable(test-lock-config
+    test_lockconfig.cpp
+)
+
+target_include_directories(test-lock-config PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/..")
+target_link_libraries(test-lock-config PRIVATE caelestia-config Qt::Test)
+
+add_test(NAME caelestia-lock-config COMMAND test-lock-config)
+
+add_executable(test-lock-lifecycle-qml
+    test_locklifecycleqml.cpp
+)
+
+target_compile_definitions(test-lock-lifecycle-qml PRIVATE
+    QUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/qml"
+)
+target_link_libraries(test-lock-lifecycle-qml PRIVATE Qt::QuickTest Qt::Qml)
+
+add_test(NAME caelestia-lock-lifecycle-qml COMMAND test-lock-lifecycle-qml)
+set_tests_properties(caelestia-lock-lifecycle-qml PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/plugin/src/Caelestia/Config/tests/CMakeLists.txt
+++ b/plugin/src/Caelestia/Config/tests/CMakeLists.txt
@@ -5,7 +5,11 @@ add_executable(test-lock-config
 )
 
 target_include_directories(test-lock-config PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/..")
-target_link_libraries(test-lock-config PRIVATE caelestia-config Qt::Test)
+target_link_libraries(test-lock-config PRIVATE caelestia-config Qt::Qml Qt::Test)
+# Shields only upstream Settings header MOC diagnostics; test source warnings remain enabled.
+target_compile_options(test-lock-config PRIVATE
+    "SHELL:-Xclang -plugin-arg-clazy -Xclang no-fully-qualified-moc-types"
+)
 
 add_test(NAME caelestia-lock-config COMMAND test-lock-config)
 
@@ -19,4 +23,8 @@ target_compile_definitions(test-lock-lifecycle-qml PRIVATE
 target_link_libraries(test-lock-lifecycle-qml PRIVATE Qt::QuickTest Qt::Qml)
 
 add_test(NAME caelestia-lock-lifecycle-qml COMMAND test-lock-lifecycle-qml)
-set_tests_properties(caelestia-lock-lifecycle-qml PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+get_filename_component(qt_qml_prefix "${Qt6Qml_DIR}/../../.." ABSOLUTE)
+set(qt_qml_import_path "${qt_qml_prefix}/${QT6_INSTALL_QML}")
+set_tests_properties(caelestia-lock-lifecycle-qml PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QML2_IMPORT_PATH=${qt_qml_import_path}:$ENV{QML2_IMPORT_PATH}"
+)

--- a/plugin/src/Caelestia/Config/tests/qml/tst_LockLifecycle.qml
+++ b/plugin/src/Caelestia/Config/tests/qml/tst_LockLifecycle.qml
@@ -8,18 +8,6 @@ import "../../../../../../modules/lock" as Lock
 TestCase {
     name: "LockLifecycle"
 
-    Component {
-        id: lifecycleComponent
-
-        Lock.LockLifecycle {}
-    }
-
-    Component {
-        id: signalSpyComponent
-
-        SignalSpy {}
-    }
-
     function createLifecycle(properties): var {
         return lifecycleComponent.createObject(this, properties);
     }
@@ -173,5 +161,17 @@ TestCase {
         lifecycle.update(false, false);
         compare(secureSpy.count, 0);
         compare(releaseSpy.count, 0);
+    }
+
+    Component {
+        id: lifecycleComponent
+
+        Lock.LockLifecycle {}
+    }
+
+    Component {
+        id: signalSpyComponent
+
+        SignalSpy {}
     }
 }

--- a/plugin/src/Caelestia/Config/tests/qml/tst_LockLifecycle.qml
+++ b/plugin/src/Caelestia/Config/tests/qml/tst_LockLifecycle.qml
@@ -6,8 +6,6 @@ import "../../../../../../modules/lock" as Lock
 
 // qmllint disable unqualified
 TestCase {
-    name: "LockLifecycle"
-
     function createLifecycle(properties): var {
         return lifecycleComponent.createObject(this, properties);
     }
@@ -162,6 +160,8 @@ TestCase {
         compare(secureSpy.count, 0);
         compare(releaseSpy.count, 0);
     }
+
+    name: "LockLifecycle"
 
     Component {
         id: lifecycleComponent

--- a/plugin/src/Caelestia/Config/tests/qml/tst_LockLifecycle.qml
+++ b/plugin/src/Caelestia/Config/tests/qml/tst_LockLifecycle.qml
@@ -1,0 +1,174 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtTest
+import "../../../../../../modules/lock" as Lock
+
+TestCase {
+    name: "LockLifecycle"
+
+    Component {
+        id: lifecycleComponent
+
+        Lock.LockLifecycle {}
+    }
+
+    Component {
+        id: signalSpyComponent
+
+        SignalSpy {}
+    }
+
+    function createLifecycle(properties): var {
+        return lifecycleComponent.createObject(this, properties);
+    }
+
+    function createSpy(lifecycle, signalName): var {
+        return signalSpyComponent.createObject(lifecycle, {
+            target: lifecycle,
+            signalName: signalName
+        });
+    }
+
+    function ignoreLifecycleWarning(message): void {
+        ignoreWarning(new RegExp("caelestia\\.qml\\.lock\\.lifecycle.*" + message));
+    }
+
+    function test_secureAndReleaseFireOncePerCycle(): void {
+        const lifecycle = createLifecycle({
+            secureCommand: ["hook", "secure"],
+            releaseCommand: ["hook", "release"]
+        });
+        const secureSpy = createSpy(lifecycle, "secureHookRequested");
+        const releaseSpy = createSpy(lifecycle, "releaseHookRequested");
+
+        verify(lifecycle.initialize(false, false));
+        lifecycle.update(true, false);
+        lifecycle.update(true, true);
+        lifecycle.update(true, true);
+        compare(secureSpy.count, 1);
+        compare(secureSpy.signalArguments[0][0], ["hook", "secure"]);
+        compare(releaseSpy.count, 0);
+
+        lifecycle.update(true, false);
+        compare(releaseSpy.count, 0);
+        lifecycle.update(false, false);
+        lifecycle.update(false, false);
+        compare(releaseSpy.count, 1);
+        compare(releaseSpy.signalArguments[0][0], ["hook", "release"]);
+
+        lifecycle.update(true, false);
+        lifecycle.update(false, false);
+        compare(secureSpy.count, 1);
+        compare(releaseSpy.count, 2);
+    }
+
+    function test_preservesSecuredCycleAcrossReload(): void {
+        const first = createLifecycle({ secureCommand: ["hook", "secure"] });
+        const firstSecureSpy = createSpy(first, "secureHookRequested");
+
+        verify(first.initialize(false, false));
+        first.update(true, true);
+        compare(firstSecureSpy.count, 1);
+
+        const restored = createLifecycle({
+            secureCommand: ["hook", "secure"],
+            releaseCommand: ["hook", "release"]
+        });
+        const secureSpy = createSpy(restored, "secureHookRequested");
+        const releaseSpy = createSpy(restored, "releaseHookRequested");
+
+        verify(restored.initialize(true, true));
+        restored.update(true, true);
+        compare(secureSpy.count, 0);
+        restored.update(false, false);
+        restored.update(false, false);
+        compare(releaseSpy.count, 1);
+    }
+
+    function test_initializationSnapshots(): void {
+        const idle = createLifecycle({
+            secureCommand: ["hook", "secure"],
+            releaseCommand: ["hook", "release"]
+        });
+        const idleSecureSpy = createSpy(idle, "secureHookRequested");
+        const idleReleaseSpy = createSpy(idle, "releaseHookRequested");
+        verify(idle.initialize(false, false));
+        idle.update(false, false);
+        compare(idleSecureSpy.count, 0);
+        compare(idleReleaseSpy.count, 0);
+
+        const inconsistent = createLifecycle({
+            secureCommand: ["hook", "secure"],
+            releaseCommand: ["hook", "release"]
+        });
+        const inconsistentSecureSpy = createSpy(inconsistent, "secureHookRequested");
+        const inconsistentReleaseSpy = createSpy(inconsistent, "releaseHookRequested");
+        verify(inconsistent.initialize(false, true));
+        inconsistent.update(false, true);
+        compare(inconsistentSecureSpy.count, 0);
+        compare(inconsistentReleaseSpy.count, 0);
+
+        const preSecure = createLifecycle({
+            secureCommand: ["hook", "secure"],
+            releaseCommand: ["hook", "release"]
+        });
+        const preSecureSpy = createSpy(preSecure, "secureHookRequested");
+        const preReleaseSpy = createSpy(preSecure, "releaseHookRequested");
+        verify(preSecure.initialize(true, false));
+        preSecure.update(true, true);
+        preSecure.update(false, false);
+        compare(preSecureSpy.count, 1);
+        compare(preReleaseSpy.count, 1);
+
+        const secured = createLifecycle({
+            secureCommand: ["hook", "secure"],
+            releaseCommand: ["hook", "release"]
+        });
+        const securedSecureSpy = createSpy(secured, "secureHookRequested");
+        const securedReleaseSpy = createSpy(secured, "releaseHookRequested");
+        verify(secured.initialize(true, true));
+        secured.update(true, true);
+        secured.update(false, false);
+        compare(securedSecureSpy.count, 0);
+        compare(securedReleaseSpy.count, 1);
+    }
+
+    function test_rejectsInitializationMisuse(): void {
+        const lifecycle = createLifecycle({
+            secureCommand: ["hook", "secure"],
+            releaseCommand: ["hook", "release"]
+        });
+        const secureSpy = createSpy(lifecycle, "secureHookRequested");
+        const releaseSpy = createSpy(lifecycle, "releaseHookRequested");
+
+        ignoreLifecycleWarning("Lock lifecycle update before initialization");
+        lifecycle.update(true, true);
+        compare(secureSpy.count, 0);
+        compare(releaseSpy.count, 0);
+
+        verify(lifecycle.initialize(false, false));
+        ignoreLifecycleWarning("Lock lifecycle controller initialized more than once");
+        verify(!lifecycle.initialize(true, true));
+        lifecycle.update(false, false);
+        compare(secureSpy.count, 0);
+        compare(releaseSpy.count, 0);
+    }
+
+    function test_suppressesBlankExecutables(): void {
+        const lifecycle = createLifecycle({
+            secureCommand: ["   ", "secure"],
+            releaseCommand: [""]
+        });
+        const secureSpy = createSpy(lifecycle, "secureHookRequested");
+        const releaseSpy = createSpy(lifecycle, "releaseHookRequested");
+
+        verify(lifecycle.initialize(false, false));
+        ignoreLifecycleWarning("Ignoring lock lifecycle hook with blank argv\\[0\\]");
+        lifecycle.update(true, true);
+        ignoreLifecycleWarning("Ignoring lock lifecycle hook with blank argv\\[0\\]");
+        lifecycle.update(false, false);
+        compare(secureSpy.count, 0);
+        compare(releaseSpy.count, 0);
+    }
+}

--- a/plugin/src/Caelestia/Config/tests/qml/tst_LockLifecycle.qml
+++ b/plugin/src/Caelestia/Config/tests/qml/tst_LockLifecycle.qml
@@ -4,6 +4,7 @@ import QtQuick
 import QtTest
 import "../../../../../../modules/lock" as Lock
 
+// qmllint disable unqualified
 TestCase {
     name: "LockLifecycle"
 
@@ -31,7 +32,7 @@ TestCase {
     }
 
     function ignoreLifecycleWarning(message): void {
-        ignoreWarning(new RegExp("caelestia\\.qml\\.lock\\.lifecycle.*" + message));
+        ignoreWarning(new RegExp(message));
     }
 
     function test_secureAndReleaseFireOncePerCycle(): void {
@@ -64,7 +65,9 @@ TestCase {
     }
 
     function test_preservesSecuredCycleAcrossReload(): void {
-        const first = createLifecycle({ secureCommand: ["hook", "secure"] });
+        const first = createLifecycle({
+            secureCommand: ["hook", "secure"]
+        });
         const firstSecureSpy = createSpy(first, "secureHookRequested");
 
         verify(first.initialize(false, false));

--- a/plugin/src/Caelestia/Config/tests/test_lockconfig.cpp
+++ b/plugin/src/Caelestia/Config/tests/test_lockconfig.cpp
@@ -55,7 +55,7 @@ void LockConfigTest::decodesValidHooks() {
         QVERIFY(!lock->quarantine());
     }
 
-    for (const auto& blank : { QStringList{ QStringLiteral("") }, QStringList{ QStringLiteral("   ") } }) {
+    for (const auto& blank : { QStringList{ QString() }, QStringList{ QStringLiteral("   ") } }) {
         for (const auto& field : { QStringLiteral("onSecure"), QStringLiteral("onRelease") }) {
             TestConfig config;
             auto* const lock = config.lock();
@@ -88,8 +88,10 @@ void LockConfigTest::quarantinesInvalidHooks() {
             QCOMPARE(diagnostics.size(), 1);
             QCOMPARE(diagnostics.constFirst().type, settings::DiagnosticType::TypeMismatch);
             QCOMPARE(diagnostics.constFirst().option, QStringLiteral("lock.%1").arg(field));
-            QVERIFY(lock->quarantine());
-            QCOMPARE(lock->toJson(false).toObject().value(field), value);
+            const auto* const quarantine = lock->quarantine();
+            QVERIFY(quarantine);
+            QCOMPARE(quarantine->apply(QJsonObject{}).toObject().value(field), value);
+            QCOMPARE(lock->toJson(false).toObject().value(field), QJsonValue(QJsonArray{}));
         }
     }
 }
@@ -124,8 +126,10 @@ void LockConfigTest::resetsHooksOnSubsequentSync() {
         QCOMPARE(command(lock, field), QStringList());
         QCOMPARE(diagnostics.size(), 1);
         QCOMPARE(diagnostics.constFirst().type, settings::DiagnosticType::TypeMismatch);
-        QVERIFY(lock->quarantine());
-        QCOMPARE(lock->toJson(false).toObject().value(field), QJsonValue(malformed));
+        const auto* const quarantine = lock->quarantine();
+        QVERIFY(quarantine);
+        QCOMPARE(quarantine->apply(QJsonObject{}).toObject().value(field), QJsonValue(malformed));
+        QCOMPARE(lock->toJson(false).toObject().value(field), QJsonValue(QJsonArray{}));
     }
 }
 
@@ -148,8 +152,11 @@ void LockConfigTest::retainsGlobalFallbackInOverlays() {
         QCOMPARE(diagnostics.size(), 1);
         QCOMPARE(diagnostics.constFirst().type, settings::DiagnosticType::GlobalOption);
         QCOMPARE(diagnostics.constFirst().option, QStringLiteral("lock.%1").arg(field));
-        QVERIFY(overlayLock->quarantine());
-        QCOMPARE(overlayLock->toJson(false).toObject().value(field), QJsonValue(overlayValue));
+        const auto* const quarantine = overlayLock->quarantine();
+        QVERIFY(quarantine);
+        QCOMPARE(quarantine->apply(QJsonObject{}).toObject().value(field), QJsonValue(overlayValue));
+        QCOMPARE(
+            overlayLock->toJson(false).toObject().value(field), QJsonValue(QJsonArray::fromStringList(globalCommand)));
     }
 }
 

--- a/plugin/src/Caelestia/Config/tests/test_lockconfig.cpp
+++ b/plugin/src/Caelestia/Config/tests/test_lockconfig.cpp
@@ -1,0 +1,158 @@
+#include "lockconfig.hpp"
+
+#include <qjsonarray.h>
+#include <qjsonobject.h>
+#include <qtest.h>
+
+#include <utility>
+
+using namespace caelestia;
+using namespace caelestia::config;
+
+class TestConfig : public settings::ObjectNode {
+    CONFIG_NODE(TestConfig, settings::ObjectNode)
+
+    CONFIG_SUBOBJECT(LockConfig, lock)
+};
+
+class LockConfigTest : public QObject {
+    Q_OBJECT
+
+private:
+    static QStringList command(const LockConfig* config, const QString& field);
+
+private slots:
+    void decodesValidHooks();
+    void quarantinesInvalidHooks();
+    void resetsHooksOnSubsequentSync();
+    void retainsGlobalFallbackInOverlays();
+};
+
+QStringList LockConfigTest::command(const LockConfig* config, const QString& field) {
+    return field == QStringLiteral("onSecure") ? config->onSecure() : config->onRelease();
+}
+
+void LockConfigTest::decodesValidHooks() {
+    const QList<std::pair<QString, QStringList>> hooks{
+        { QStringLiteral("onSecure"), { QStringLiteral("hook"), QStringLiteral("secure") } },
+        { QStringLiteral("onRelease"), { QStringLiteral("hook"), QStringLiteral("release") } },
+    };
+
+    for (const auto& [field, expected] : hooks) {
+        TestConfig config;
+        auto* const lock = config.lock();
+        QList<settings::Diagnostic> diagnostics;
+
+        QVERIFY(lock->syncJson(QJsonObject{ { field, QJsonArray::fromStringList(expected) } }, diagnostics));
+        QCOMPARE(command(lock, field), expected);
+        QVERIFY(diagnostics.isEmpty());
+        QVERIFY(!lock->quarantine());
+
+        diagnostics.clear();
+        QVERIFY(lock->syncJson(QJsonObject{ { field, QJsonArray{} } }, diagnostics));
+        QCOMPARE(command(lock, field), QStringList());
+        QVERIFY(diagnostics.isEmpty());
+        QVERIFY(!lock->quarantine());
+    }
+
+    for (const auto& blank : { QStringList{ QStringLiteral("") }, QStringList{ QStringLiteral("   ") } }) {
+        for (const auto& field : { QStringLiteral("onSecure"), QStringLiteral("onRelease") }) {
+            TestConfig config;
+            auto* const lock = config.lock();
+            QList<settings::Diagnostic> diagnostics;
+
+            QVERIFY(lock->syncJson(QJsonObject{ { field, QJsonArray::fromStringList(blank) } }, diagnostics));
+            QCOMPARE(command(lock, field), blank);
+            QVERIFY(diagnostics.isEmpty());
+            QVERIFY(!lock->quarantine());
+        }
+    }
+}
+
+void LockConfigTest::quarantinesInvalidHooks() {
+    const QList<QJsonValue> invalidValues{
+        QJsonValue(QStringLiteral("hook")),
+        QJsonValue(QJsonObject{}),
+        QJsonValue(QJsonValue::Null),
+        QJsonValue(QJsonArray{ QStringLiteral("hook"), QJsonValue(1) }),
+    };
+
+    for (const auto& field : { QStringLiteral("onSecure"), QStringLiteral("onRelease") }) {
+        for (const auto& value : invalidValues) {
+            TestConfig config;
+            auto* const lock = config.lock();
+            QList<settings::Diagnostic> diagnostics;
+
+            QVERIFY(lock->syncJson(QJsonObject{ { field, value } }, diagnostics));
+            QCOMPARE(command(lock, field), QStringList());
+            QCOMPARE(diagnostics.size(), 1);
+            QCOMPARE(diagnostics.constFirst().type, settings::DiagnosticType::TypeMismatch);
+            QCOMPARE(diagnostics.constFirst().option, QStringLiteral("lock.%1").arg(field));
+            QVERIFY(lock->quarantine());
+            QCOMPARE(lock->toJson(false).toObject().value(field), value);
+        }
+    }
+}
+
+void LockConfigTest::resetsHooksOnSubsequentSync() {
+    for (const auto& field : { QStringLiteral("onSecure"), QStringLiteral("onRelease") }) {
+        TestConfig config;
+        auto* const lock = config.lock();
+        QList<settings::Diagnostic> diagnostics;
+
+        const auto oldCommand = QStringList{ QStringLiteral("hook"), QStringLiteral("old") };
+        const auto newCommand = QStringList{ QStringLiteral("hook"), QStringLiteral("new") };
+        QVERIFY(lock->syncJson(QJsonObject{ { field, QJsonArray::fromStringList(oldCommand) } }, diagnostics));
+        QCOMPARE(command(lock, field), oldCommand);
+
+        diagnostics.clear();
+        QVERIFY(lock->syncJson(QJsonObject{ { field, QJsonArray::fromStringList(newCommand) } }, diagnostics));
+        QCOMPARE(command(lock, field), newCommand);
+
+        diagnostics.clear();
+        QVERIFY(lock->syncJson(QJsonObject{}, diagnostics));
+        QCOMPARE(command(lock, field), QStringList());
+        QVERIFY(diagnostics.isEmpty());
+
+        diagnostics.clear();
+        QVERIFY(lock->syncJson(QJsonObject{ { field, QJsonArray::fromStringList(oldCommand) } }, diagnostics));
+        QCOMPARE(command(lock, field), oldCommand);
+
+        diagnostics.clear();
+        const auto malformed = QJsonObject{};
+        QVERIFY(lock->syncJson(QJsonObject{ { field, malformed } }, diagnostics));
+        QCOMPARE(command(lock, field), QStringList());
+        QCOMPARE(diagnostics.size(), 1);
+        QCOMPARE(diagnostics.constFirst().type, settings::DiagnosticType::TypeMismatch);
+        QVERIFY(lock->quarantine());
+        QCOMPARE(lock->toJson(false).toObject().value(field), QJsonValue(malformed));
+    }
+}
+
+void LockConfigTest::retainsGlobalFallbackInOverlays() {
+    for (const auto& field : { QStringLiteral("onSecure"), QStringLiteral("onRelease") }) {
+        TestConfig global;
+        auto* const globalLock = global.lock();
+        const auto globalCommand = QStringList{ QStringLiteral("hook"), QStringLiteral("global") };
+        QList<settings::Diagnostic> diagnostics;
+
+        QVERIFY(globalLock->syncJson(QJsonObject{ { field, QJsonArray::fromStringList(globalCommand) } }, diagnostics));
+        QVERIFY(diagnostics.isEmpty());
+
+        TestConfig overlay(&global);
+        auto* const overlayLock = overlay.lock();
+        diagnostics.clear();
+        const auto overlayValue = QJsonArray{ QStringLiteral("hook"), QStringLiteral("overlay") };
+        QVERIFY(overlayLock->syncJson(QJsonObject{ { field, overlayValue } }, diagnostics));
+        QCOMPARE(command(overlayLock, field), globalCommand);
+        QCOMPARE(diagnostics.size(), 1);
+        QCOMPARE(diagnostics.constFirst().type, settings::DiagnosticType::GlobalOption);
+        QCOMPARE(diagnostics.constFirst().option, QStringLiteral("lock.%1").arg(field));
+        QVERIFY(overlayLock->quarantine());
+        QCOMPARE(overlayLock->toJson(false).toObject().value(field), QJsonValue(overlayValue));
+    }
+}
+
+QTEST_APPLESS_MAIN(LockConfigTest)
+
+#include "test_lockconfig.moc"

--- a/plugin/src/Caelestia/Config/tests/test_locklifecycleqml.cpp
+++ b/plugin/src/Caelestia/Config/tests/test_locklifecycleqml.cpp
@@ -1,0 +1,3 @@
+#include <QtQuickTest/quicktest.h>
+
+QUICK_TEST_MAIN(locklifecycle)


### PR DESCRIPTION
## Summary

- Add global `lock.onSecure` and `lock.onRelease` direct-argv hooks using native `Caelestia.Settings` fields.
- Add a QtQuick-only lock lifecycle controller, with `Lock.qml` as the sole asynchronous `Quickshell.execDetached` dispatch site.
- Add focused Settings and Qt Quick CTest suites and document the public configuration.

Base: `origin/main` at `9e746756f59eed0d5caf4242372f02b83e6b00fa`.

## Configuration

```json
{
  "lock": {
    "onSecure": ["lock-lifecycle-hook", "secure"],
    "onRelease": ["lock-lifecycle-hook", "release"]
  }
}
```

Both options are global-only direct argv arrays. Missing or empty arrays disable the hook; Caelestia does not invoke a shell. Settings rejects non-array and non-string values with diagnostics and quarantine. A blank `argv[0]` is schema-valid, but is warned about and skipped by the lifecycle controller.

## Lifecycle

- `onSecure` is requested once per active lock cycle after `WlSessionLock` becomes secure.
- `onRelease` is requested once per active lock cycle only after `locked` changes from `true` to `false`, not when the unlock animation starts.
- A preserved secured lock after soft reload does not replay `onSecure`, but still produces its one release request.

## Scope

This adds no DPMS, idle, timer, suspend, Hyprland, or other compositor-specific policy.

## Validation

- Cleanly rebased to `origin/main` at `9e746756f59eed0d5caf4242372f02b83e6b00fa` before pushing.
- `nix develop -c cmake --build build`: passed after the rebase.
- `nix develop -c ctest --test-dir build --output-on-failure`: passed after the rebase, 2/2 `caelestia-lock-config` and `caelestia-lock-lifecycle-qml`.
- `git diff --check origin/main`: passed.
- Changed C++ formatting, changed-QML formatting, and focused QML lint also passed; the focused `qmllint` invocation produced zero output.

The unchanged QML convention script crashes under Python 3.14 before linting, and full-shell offscreen loading cannot provide a `PanelWindow` backend. A compositor-backed multi-output smoke test remains outstanding.

## Compatibility

There are no breaking changes. The additive options default to empty and preserve existing lock behavior.
