### PR TITLE
Add hyprland globalshortcut to open the wallpaper selector

### DIFF
--- a/modules/Shortcuts.qml
+++ b/modules/Shortcuts.qml
@@ -108,6 +108,22 @@ Scope {
         }
     }
 
+    //qmllint disable unresolved-type
+    CustomShortcut {
+        // qmllint enable unresolved-type
+        name: "wallpaper"
+        description: "Toggle wallpaper selector"
+        onPressed: {
+            const v = ShellState.forActive();
+            if (!v.launcher) {
+                ShellState.shellRoot.requestWallpaperPicker = true;
+                v.launcher = true;
+            } else {
+                v.launcher = false;
+            }
+        }
+    }
+
     IpcHandler {
         function toggle(drawer: string): void {
             if (list().split("\n").includes(drawer)) {

--- a/modules/launcher/Content.qml
+++ b/modules/launcher/Content.qml
@@ -106,7 +106,14 @@ Item {
             }
         }
 
-        Component.onCompleted: forceActiveFocus()
+        Component.onCompleted: {
+            forceActiveFocus();
+            if (ShellState.shellRoot.requestWallpaperPicker) {
+                search.text = GlobalConfig.launcher.actionPrefix + "wallpaper ";
+                // Reset the global flag
+                ShellState.shellRoot.requestWallpaperPicker = false;
+            }
+        }
 
         Connections {
             function onLauncherChanged(): void {

--- a/shell.qml
+++ b/shell.qml
@@ -17,6 +17,7 @@ ShellRoot {
     id: root
 
     settings.watchFiles: true
+    property bool requestWallpaperPicker: false
 
     Binding {
         target: ShellState

--- a/shell.qml
+++ b/shell.qml
@@ -16,8 +16,9 @@ import qs.services
 ShellRoot {
     id: root
 
-    settings.watchFiles: true
     property bool requestWallpaperPicker: false
+
+    settings.watchFiles: true
 
     Binding {
         target: ShellState


### PR DESCRIPTION
Just an annoyance I had, used to have a shortcut to open a wallpaper selector. 

Wanted to add the possibility to open the wallpaper selector without downloading another program for it when there's one available.

My first time working with QML so it might not be very beautiful, however I couldn't figure out a good way to do this without using the Launcher to open and inject the ">wallpaper" string (using the GlobalConfig.launcher.actionPrefix, so it works even if changed).

Wouldn't mind any feedback on another way or preferred way to do this.  But it might require some work de-coupling the wallpaper selector and launcher.