### PR TITLE
feat(utilities): add duration dial to Keep Awake toggle

### DIFF
--- a/modules/utilities/cards/IdleInhibit.qml
+++ b/modules/utilities/cards/IdleInhibit.qml
@@ -8,13 +8,55 @@ import qs.services
 StyledRect {
     id: root
 
-    readonly property real nonAnimHeight: layout.implicitHeight + (IdleInhibitor.enabled ? activeChip.implicitHeight + activeChip.anchors.topMargin : 0) + Tokens.padding.extraLargeIncreased
+    property bool manualOpen: false
+
+    // Live countdown state, driven by IdleInhibitor.until (persisted, so
+    // this correctly resumes mid-countdown across a shell reload).
+    readonly property bool countingDown: IdleInhibitor.enabled && IdleInhibitor.until.getTime() > 0
+    readonly property real totalMs: Math.max(1, IdleInhibitor.until.getTime() - IdleInhibitor.enabledSince.getTime())
+    readonly property real remainingMs: countingDown ? Math.max(0, IdleInhibitor.until.getTime() - liveNow) : 0
+    readonly property real ringFraction: remainingMs / totalMs
+    readonly property int remainingMinutes: Math.max(0, Math.ceil(remainingMs / 60000))
+    // The duration originally picked on the dial, recovered from
+    // until/enabledSince rather than needing its own persisted state --
+    // this is what the ring's fill fraction was at the moment Start was
+    // pressed, so the ring depletes back down to it exactly. Note:
+    // dialMinMinutes/dialMaxMinutes must match KeepAwakeDial's own
+    // minMinutes/maxMinutes defaults -- can't reference them directly, an
+    // id inside a Loader's sourceComponent isn't visible out here.
+    readonly property real dialMinMinutes: 15
+    readonly property real dialMaxMinutes: 240
+    readonly property real originalMinutes: totalMs / 60000
+    readonly property real startValue: Math.max(0, Math.min(1, (originalMinutes - dialMinMinutes) / (dialMaxMinutes - dialMinMinutes)))
+    readonly property real ringValue: startValue * ringFraction
+
+    readonly property bool showDial: manualOpen || countingDown
+
+    property real liveNow: Date.now()
+
+    readonly property real chipHeight: activeChip.item ? activeChip.item.implicitHeight + activeChip.anchors.topMargin : 0
+
+    readonly property real dialHeight: dial.item ? dial.item.implicitHeight + Tokens.padding.large * 2 : 0
+
+    readonly property bool showChip: IdleInhibitor.enabled && !countingDown
+
+    readonly property real nonAnimHeight: layout.implicitHeight + (showChip ? chipHeight : 0) + (showDial ? dialHeight : 0) + Tokens.padding.extraLargeIncreased
 
     implicitHeight: nonAnimHeight
 
     radius: Tokens.rounding.large
+
     color: Colours.tPalette.m3surfaceContainer
+
     clip: true
+
+    Timer {
+        interval: 1000
+        repeat: true
+        running: root.countingDown
+        triggeredOnStart: true
+        onTriggered: root.liveNow = Date.now()
+    }
 
     RowLayout {
         id: layout
@@ -55,16 +97,87 @@ StyledRect {
 
             StyledText {
                 Layout.fillWidth: true
-                text: IdleInhibitor.enabled ? qsTr("Preventing sleep mode") : qsTr("Normal power management")
+                text: IdleInhibitor.enabled ? (root.countingDown ? qsTr("Preventing sleep until %1").arg(Qt.formatTime(IdleInhibitor.until, GlobalConfig.services.useTwelveHourClock ? "hh:mm a" : "hh:mm")) : qsTr("Preventing sleep mode")) : qsTr("Normal power management")
                 color: Colours.palette.m3onSurfaceVariant
                 font: Tokens.font.body.small
                 elide: Text.ElideRight
             }
         }
 
+        IconButton {
+            icon: "schedule"
+            isToggle: true
+            checked: root.manualOpen
+            disabled: root.countingDown
+            onClicked: root.manualOpen = !root.manualOpen
+        }
+
         StyledSwitch {
             checked: IdleInhibitor.enabled
-            onToggled: IdleInhibitor.enabled = checked
+            onToggled: {
+                IdleInhibitor.enabled = checked;
+                if (checked)
+                    root.manualOpen = false;
+            }
+        }
+    }
+
+    Loader {
+        id: dial
+
+        asynchronous: true
+        anchors.top: layout.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.topMargin: root.showDial ? Tokens.padding.large : -implicitHeight
+        anchors.leftMargin: Tokens.padding.large
+        anchors.rightMargin: Tokens.padding.large
+
+        opacity: root.showDial ? 1 : 0
+        scale: root.showDial ? 1 : 0.9
+
+        Component.onCompleted: active = Qt.binding(() => opacity > 0)
+
+        sourceComponent: ColumnLayout {
+            spacing: Tokens.spacing.medium
+
+            KeepAwakeDial {
+                id: keepAwakeDial
+
+                Layout.alignment: Qt.AlignHCenter
+
+                readOnly: root.countingDown
+                overrideValue: root.ringValue
+                overrideMinutes: root.remainingMinutes
+                hintText: qsTr("until %1").arg(Qt.formatTime(IdleInhibitor.until, GlobalConfig.services.useTwelveHourClock ? "hh:mm a" : "hh:mm"))
+            }
+
+            IconTextButton {
+                Layout.alignment: Qt.AlignHCenter
+                visible: !root.countingDown
+                icon: "coffee"
+                text: qsTr("Start")
+                type: IconTextButton.Filled
+
+                onClicked: {
+                    IdleInhibitor.enableFor(keepAwakeDial.minutes);
+                    root.manualOpen = false;
+                }
+            }
+        }
+
+        Behavior on anchors.topMargin {
+            Anim {}
+        }
+
+        Behavior on opacity {
+            Anim {
+                type: Anim.StandardSmall
+            }
+        }
+
+        Behavior on scale {
+            Anim {}
         }
     }
 
@@ -72,14 +185,14 @@ StyledRect {
         id: activeChip
 
         asynchronous: true
-        anchors.bottom: parent.bottom
+        anchors.top: dial.bottom
         anchors.left: parent.left
-        anchors.topMargin: Tokens.spacing.large
-        anchors.bottomMargin: IdleInhibitor.enabled ? Tokens.padding.large : -implicitHeight
+        anchors.topMargin: root.showChip ? Tokens.spacing.large : -implicitHeight
+        anchors.bottomMargin: root.showChip ? Tokens.padding.large : 0
         anchors.leftMargin: Tokens.padding.large
 
-        opacity: IdleInhibitor.enabled ? 1 : 0
-        scale: IdleInhibitor.enabled ? 1 : 0.5
+        opacity: root.showChip ? 1 : 0
+        scale: root.showChip ? 1 : 0.5
 
         Component.onCompleted: active = Qt.binding(() => opacity > 0)
 
@@ -100,7 +213,7 @@ StyledRect {
             }
         }
 
-        Behavior on anchors.bottomMargin {
+        Behavior on anchors.topMargin {
             Anim {}
         }
 

--- a/modules/utilities/cards/KeepAwakeDial.qml
+++ b/modules/utilities/cards/KeepAwakeDial.qml
@@ -1,0 +1,108 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+
+// A circular drag-to-set duration dial for the Keep Awake card. One full
+// lap of the ring maps from minMinutes to maxMinutes; the current
+// selection is echoed as "Xh Ym" text in the centre, matching the ring's
+// themed colours (CircularProgress, already used elsewhere in this shell).
+Item {
+    id: root
+
+    property int minMinutes: 15
+    property int maxMinutes: 240
+    property int stepMinutes: 15
+    property int minutes: 60
+
+    // Read-only countdown mode: the ring/text are driven by overrideValue
+    // and overrideMinutes (computed live by the parent from
+    // IdleInhibitor.until) instead of drag/scroll input.
+    property bool readOnly: false
+    property real overrideValue: 0
+    property int overrideMinutes: 0
+    property string hintText: qsTr("until")
+
+    readonly property real value: readOnly ? overrideValue : (minutes - minMinutes) / (maxMinutes - minMinutes)
+
+    readonly property int displayMinutes: readOnly ? overrideMinutes : minutes
+
+    signal confirmed(minutes: int)
+
+    function angleToMinutes(mx: real, my: real): int {
+        const cx = width / 2;
+        const cy = height / 2;
+        let angle = Math.atan2(my - cy, mx - cx) * 180 / Math.PI + 90;
+        if (angle < 0)
+            angle += 360;
+        const frac = angle / 360;
+        const raw = minMinutes + frac * (maxMinutes - minMinutes);
+        const stepped = Math.round(raw / stepMinutes) * stepMinutes;
+        return Math.max(minMinutes, Math.min(maxMinutes, stepped));
+    }
+
+    implicitWidth: 180
+    implicitHeight: 180
+
+    CircularProgress {
+        id: ring
+
+        anchors.fill: parent
+        value: root.value
+        startAngle: -90
+        sweepAngle: 360
+        strokeWidth: 12
+        fgColour: Colours.palette.m3primary
+        bgColour: Colours.palette.m3secondaryContainer
+        hasEndIndicator: true
+
+        Behavior on value {
+            Anim {}
+        }
+    }
+
+    ColumnLayout {
+        anchors.centerIn: parent
+        spacing: 0
+
+        StyledText {
+            Layout.alignment: Qt.AlignHCenter
+            text: {
+                const h = Math.floor(root.displayMinutes / 60);
+                const m = root.displayMinutes % 60;
+                return (h > 0 ? qsTr("%1h ").arg(h) : "") + qsTr("%1m").arg(m);
+            }
+            font: Tokens.font.headline.medium
+            color: Colours.palette.m3primary
+        }
+
+        StyledText {
+            Layout.alignment: Qt.AlignHCenter
+            text: root.readOnly ? root.hintText : qsTr("drag or scroll")
+            font: Tokens.font.body.small
+            color: Colours.palette.m3onSurfaceVariant
+        }
+    }
+
+    CustomMouseArea {
+        function onWheel(event: WheelEvent): void {
+            const delta = event.angleDelta.y > 0 ? root.stepMinutes : -root.stepMinutes;
+            root.minutes = Math.max(root.minMinutes, Math.min(root.maxMinutes, root.minutes + delta));
+        }
+
+        anchors.fill: parent
+        enabled: !root.readOnly
+        preventStealing: true
+        cursorShape: Qt.PointingHandCursor
+
+        onPressed: mouse => root.minutes = root.angleToMinutes(mouse.x, mouse.y)
+        onPositionChanged: mouse => {
+            if (pressed)
+                root.minutes = root.angleToMinutes(mouse.x, mouse.y);
+        }
+    }
+}

--- a/services/IdleInhibitor.qml
+++ b/services/IdleInhibitor.qml
@@ -1,5 +1,6 @@
 pragma Singleton
 
+import QtQuick
 import Quickshell
 import Quickshell.Io
 import Quickshell.Wayland
@@ -9,10 +10,19 @@ Singleton {
 
     property alias enabled: props.enabled
     readonly property alias enabledSince: props.enabledSince
+    readonly property alias until: props.until
+
+    function enableFor(minutes: real): void {
+        props.until = new Date(Date.now() + minutes * 60000);
+        props.enabled = true;
+    }
 
     onEnabledChanged: {
-        if (enabled)
+        if (enabled) {
             props.enabledSince = new Date();
+        } else {
+            props.until = new Date(0);
+        }
     }
 
     PersistentProperties {
@@ -20,8 +30,18 @@ Singleton {
 
         property bool enabled
         property date enabledSince
+        property date until
 
         reloadableId: "idleInhibitor"
+    }
+
+    // Auto-disables when a duration set via enableFor() runs out. Recomputed
+    // whenever `enabled`/`until` change, so this also correctly resumes a
+    // countdown that was still in progress across a shell reload/restart.
+    Timer {
+        running: props.enabled && props.until.getTime() > Date.now()
+        interval: Math.max(0, props.until.getTime() - Date.now())
+        onTriggered: props.enabled = false
     }
 
     IdleInhibitor {
@@ -49,6 +69,14 @@ Singleton {
 
         function disable(): void {
             props.enabled = false;
+        }
+
+        function enableFor(minutes: real): void {
+            root.enableFor(minutes);
+        }
+
+        function until(): string {
+            return props.until.toISOString();
         }
 
         target: "idleInhibitor"


### PR DESCRIPTION
## What

The Keep Awake card's switch only ever supported an indefinite on/off. This adds a circular drag/scroll dial (15min–4h) that starts a *timed* session instead — reusing the existing `CircularProgress` component so it's themed consistently with the rest of the shell, no new visual language introduced.

While a timed session is running, the ring stays visible in a read-only mode and **live-depletes back to empty in real time** (ticking every second) instead of just sitting static with no feedback until it silently switches off — you can watch it count down, and it shows both the remaining time and the actual end time ("until HH:MM").

## How

- `services/IdleInhibitor.qml`: adds `enableFor(minutes)`, a persisted `until`, and a `Timer` that disables the toggle when `until` passes. The timer's `interval` is recomputed from `Date.now()` on every `enabled`/`until` change rather than started once, so a countdown still in progress correctly resumes across a shell reload instead of losing track of itself. `enableFor`/`until` are also exposed on the existing `idleInhibitor` IPC target for scripting.
- `modules/utilities/cards/KeepAwakeDial.qml` (new): a circular drag/scroll duration picker built on `CircularProgress` + `CustomMouseArea`, mapping angle-around-circle to minutes. Also serves as the live countdown display via a `readOnly` mode (`overrideValue`/`overrideMinutes`/`hintText` props), so the same component covers both jobs rather than needing two.
- `modules/utilities/cards/IdleInhibit.qml`: adds a `schedule`-icon button that reveals the dial; "Start" calls `IdleInhibitor.enableFor(dial.minutes)`. A 1s repeating `Timer` drives the live countdown display. No new persisted state was needed for this — the originally-picked duration (needed to compute the ring's starting fill fraction, so it depletes back down to exactly where it started) is recovered algebraically from `until − enabledSince` rather than storing it separately. The old "Active since HH:MM" chip now only shows for an indefinite (no-duration) toggle; a timed one shows the live dial instead.

## Testing

Manually verified end-to-end on a live shell session: dial renders and drags/scrolls correctly, Start engages `enableFor`, the auto-off timer fires precisely on schedule (checked with short durations via `qs ipc`), and the live countdown ring/text track real elapsed time correctly (confirmed numerically against `until`/`Date.now()` as well as visually).

Ran `python3 scripts/qml-lint-conventions.py` clean (0 violations across all 284 files). I wasn't able to get a clean run out of local `qmllint`/`qmlformat` — both crash silently (no stdout/stderr, exit 1) even on the pristine, unmodified `main` version of `IdleInhibitor.qml`, so that looks like a local Qt/tooling version mismatch rather than anything specific to this change; happy to fix up formatting per CI feedback if it flags anything I couldn't catch locally.

Open to feedback on the UX/placement — e.g. whether the schedule button should stay clickable during a countdown to let you adjust the duration early rather than needing to cancel and restart.