### PR TITLE
feat: add ability to display seconds on dashboard and bar clocks

### DIFF
--- a/modules/bar/components/Clock.qml
+++ b/modules/bar/components/Clock.qml
@@ -12,6 +12,14 @@ StyledRect {
     readonly property color colour: Colours.palette.m3tertiary
     readonly property int padding: Config.bar.clock.background ? Tokens.padding.medium : Tokens.padding.extraSmall
     readonly property var font: Tokens.font.body.builders.small.scale(1.1)
+    readonly property var timeFont: {
+        const value = root.font.width(105).letterSpacing(-0.25).build();
+        value.features = {
+            "tnum": 1
+        };
+        return value;
+    }
+    readonly property real timeCellWidth: widestMetrics.advanceWidth
 
     implicitWidth: Tokens.sizes.bar.innerWidth
     implicitHeight: layout.implicitHeight + root.padding * 2
@@ -56,7 +64,7 @@ StyledRect {
                 StyledText {
                     Layout.alignment: Qt.AlignHCenter
                     text: Time.format("d")
-                    font: root.font.scale(1.1).build()
+                    font: root.timeFont
                     color: root.colour
                 }
 
@@ -73,76 +81,61 @@ StyledRect {
         }
 
         StyledText {
+            Layout.preferredWidth: root.timeCellWidth
             Layout.alignment: Qt.AlignHCenter
+            horizontalAlignment: Text.AlignHCenter
             text: Time.hourStr
-            font: {
-                const scale = text === "11" ? 1.15 : Math.min(1.05, Math.max(hourMetrics.width, minMetrics.width) / hourMetrics.width);
-                return root.font.width(scale * 100).letterSpacing(scale).build();
-            }
+            font: root.timeFont
             color: root.colour
-
-            TextMetrics {
-                id: hourMetrics
-
-                font: root.font.build()
-                text: Time.hourStr
-            }
         }
 
         StyledText {
             Layout.topMargin: -parent.spacing - 4
+            Layout.preferredWidth: root.timeCellWidth
             Layout.alignment: Qt.AlignHCenter
+            horizontalAlignment: Text.AlignHCenter
             text: Time.minuteStr
-            font: {
-                const scale = text === "11" ? 1.15 : Math.min(1.05, Math.max(hourMetrics.width, minMetrics.width) / minMetrics.width);
-                return root.font.width(scale * 100).letterSpacing(scale).build();
-            }
+            font: root.timeFont
             color: root.colour
-
-            TextMetrics {
-                id: minMetrics
-
-                font: root.font.build()
-                text: Time.minuteStr
-            }
         }
 
         Loader {
             Layout.topMargin: -parent.spacing - 4
+            Layout.preferredWidth: root.timeCellWidth
             Layout.alignment: Qt.AlignHCenter
             asynchronous: true
             active: Config.bar.clock.showSeconds
             visible: active
 
             sourceComponent: StyledText {
+                horizontalAlignment: Text.AlignHCenter
                 text: Time.format("ss")
-                font: {
-                    const scale = text === "11" ? 1.15 : Math.min(1.05, Math.max(hourMetrics.width, minMetrics.width) / secMetrics.width);
-                    return root.font.width(scale * 100).letterSpacing(scale).build();
-                }
+                font: root.timeFont
                 color: root.colour
-
-                TextMetrics {
-                    id: secMetrics
-
-                    font: root.font.build()
-                    text: Time.format("ss")
-                }
             }
         }
 
         Loader {
             Layout.topMargin: -parent.spacing - 4
+            Layout.preferredWidth: root.timeCellWidth
             Layout.alignment: Qt.AlignHCenter
             asynchronous: true
             active: GlobalConfig.services.useTwelveHourClock
             visible: active
 
             sourceComponent: StyledText {
+                horizontalAlignment: Text.AlignHCenter
                 text: Time.amPmStr.toLowerCase()
                 font: Tokens.font.body.builders.small.scale(0.9).build()
                 color: root.colour
             }
         }
+    }
+
+    TextMetrics {
+        id: widestMetrics
+
+        font: root.font.build()
+        text: "88"
     }
 }

--- a/modules/bar/components/Clock.qml
+++ b/modules/bar/components/Clock.qml
@@ -111,7 +111,7 @@ StyledRect {
             Layout.topMargin: -parent.spacing - 4
             Layout.alignment: Qt.AlignHCenter
             asynchronous: true
-            active: GlobalConfig.bar.clock.showSeconds
+            active: Config.bar.clock.showSeconds
             visible: active
 
             sourceComponent: StyledText {

--- a/modules/bar/components/Clock.qml
+++ b/modules/bar/components/Clock.qml
@@ -111,6 +111,30 @@ StyledRect {
             Layout.topMargin: -parent.spacing - 4
             Layout.alignment: Qt.AlignHCenter
             asynchronous: true
+            active: GlobalConfig.bar.clock.showSeconds
+            visible: active
+
+            sourceComponent: StyledText {
+                text: Time.format("ss")
+                font: {
+                    const scale = text === "11" ? 1.15 : Math.min(1.05, Math.max(hourMetrics.width, minMetrics.width) / secMetrics.width);
+                    return root.font.width(scale * 100).letterSpacing(scale).build();
+                }
+                color: root.colour
+
+                TextMetrics {
+                    id: secMetrics
+
+                    font: root.font.build()
+                    text: Time.format("ss")
+                }
+            }
+        }
+
+        Loader {
+            Layout.topMargin: -parent.spacing - 4
+            Layout.alignment: Qt.AlignHCenter
+            asynchronous: true
             active: GlobalConfig.services.useTwelveHourClock
             visible: active
 

--- a/modules/dashboard/dash/DateTime.qml
+++ b/modules/dashboard/dash/DateTime.qml
@@ -9,6 +9,15 @@ import qs.services
 Item {
     id: root
 
+    readonly property var separatorFont: Tokens.font.clock.size(28 * 0.9).build()
+    readonly property var timeFont: {
+        const value = Tokens.font.clock.size(28).weight(Font.DemiBold).build();
+        value.features = {
+            "tnum": 1
+        };
+        return value;
+    }
+
     anchors.top: parent.top
     anchors.bottom: parent.bottom
     implicitWidth: Tokens.sizes.dashboard.dateTimeWidth
@@ -21,26 +30,29 @@ Item {
 
         StyledText {
             Layout.bottomMargin: -(font.pointSize * 0.4)
-            Layout.alignment: Qt.AlignHCenter
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
             text: Time.hourStr
             color: Colours.palette.m3secondary
-            font: Tokens.font.clock.size(28).weight(Font.DemiBold).build()
+            font: root.timeFont
         }
 
         StyledText {
-            Layout.alignment: Qt.AlignHCenter
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
             text: "•••"
             color: Colours.palette.m3primary
-            font: Tokens.font.clock.size(28 * 0.9).build()
+            font: root.separatorFont
         }
 
         StyledText {
             Layout.topMargin: -(font.pointSize * 0.4)
             Layout.bottomMargin: Config.dashboard.showClockSeconds ? -(font.pointSize * 0.4) : 0
-            Layout.alignment: Qt.AlignHCenter
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
             text: Time.minuteStr
             color: Colours.palette.m3secondary
-            font: Tokens.font.clock.size(28).weight(Font.DemiBold).build()
+            font: root.timeFont
         }
 
         Loader {
@@ -54,18 +66,20 @@ Item {
                 spacing: 0
 
                 StyledText {
-                    Layout.alignment: Qt.AlignHCenter
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
                     text: "•••"
                     color: Colours.palette.m3primary
-                    font: Tokens.font.clock.size(28 * 0.9).build()
+                    font: root.separatorFont
                 }
 
                 StyledText {
-                    Layout.topMargin: -(28 * 0.4)
-                    Layout.alignment: Qt.AlignHCenter
+                    Layout.topMargin: -(font.pointSize * 0.4)
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
                     text: Time.format("ss")
                     color: Colours.palette.m3secondary
-                    font: Tokens.font.clock.size(28).weight(Font.DemiBold).build()
+                    font: root.timeFont
                 }
             }
         }

--- a/modules/dashboard/dash/DateTime.qml
+++ b/modules/dashboard/dash/DateTime.qml
@@ -36,10 +36,40 @@ Item {
 
         StyledText {
             Layout.topMargin: -(font.pointSize * 0.4)
+            Layout.bottomMargin: GlobalConfig.dashboard.showClockSeconds ? -(font.pointSize * 0.4) : 0
             Layout.alignment: Qt.AlignHCenter
             text: Time.minuteStr
             color: Colours.palette.m3secondary
             font: Tokens.font.clock.size(28).weight(Font.DemiBold).build()
+        }
+
+        Loader {
+            asynchronous: true
+            Layout.alignment: Qt.AlignHCenter
+
+            active: GlobalConfig.dashboard.showClockSeconds
+            visible: active
+
+            sourceComponent: StyledText {
+                text: "•••"
+                color: Colours.palette.m3primary
+                font: Tokens.font.clock.size(28 * 0.9).build()
+            }
+        }
+
+        Loader {
+            asynchronous: true
+            Layout.alignment: Qt.AlignHCenter
+            Layout.topMargin: -(28 * 0.4)
+
+            active: GlobalConfig.dashboard.showClockSeconds
+            visible: active
+
+            sourceComponent: StyledText {
+                text: Time.format("ss")
+                color: Colours.palette.m3secondary
+                font: Tokens.font.clock.size(28).weight(Font.DemiBold).build()
+            }
         }
 
         Loader {

--- a/modules/dashboard/dash/DateTime.qml
+++ b/modules/dashboard/dash/DateTime.qml
@@ -36,7 +36,7 @@ Item {
 
         StyledText {
             Layout.topMargin: -(font.pointSize * 0.4)
-            Layout.bottomMargin: GlobalConfig.dashboard.showClockSeconds ? -(font.pointSize * 0.4) : 0
+            Layout.bottomMargin: Config.dashboard.showClockSeconds ? -(font.pointSize * 0.4) : 0
             Layout.alignment: Qt.AlignHCenter
             text: Time.minuteStr
             color: Colours.palette.m3secondary
@@ -47,7 +47,7 @@ Item {
             asynchronous: true
             Layout.alignment: Qt.AlignHCenter
 
-            active: GlobalConfig.dashboard.showClockSeconds
+            active: Config.dashboard.showClockSeconds
             visible: active
 
             sourceComponent: StyledText {
@@ -62,7 +62,7 @@ Item {
             Layout.alignment: Qt.AlignHCenter
             Layout.topMargin: -(28 * 0.4)
 
-            active: GlobalConfig.dashboard.showClockSeconds
+            active: Config.dashboard.showClockSeconds
             visible: active
 
             sourceComponent: StyledText {

--- a/modules/dashboard/dash/DateTime.qml
+++ b/modules/dashboard/dash/DateTime.qml
@@ -50,25 +50,23 @@ Item {
             active: Config.dashboard.showClockSeconds
             visible: active
 
-            sourceComponent: StyledText {
-                text: "•••"
-                color: Colours.palette.m3primary
-                font: Tokens.font.clock.size(28 * 0.9).build()
-            }
-        }
+            sourceComponent: ColumnLayout {
+                spacing: 0
 
-        Loader {
-            asynchronous: true
-            Layout.alignment: Qt.AlignHCenter
-            Layout.topMargin: -(28 * 0.4)
+                StyledText {
+                    Layout.alignment: Qt.AlignHCenter
+                    text: "•••"
+                    color: Colours.palette.m3primary
+                    font: Tokens.font.clock.size(28 * 0.9).build()
+                }
 
-            active: Config.dashboard.showClockSeconds
-            visible: active
-
-            sourceComponent: StyledText {
-                text: Time.format("ss")
-                color: Colours.palette.m3secondary
-                font: Tokens.font.clock.size(28).weight(Font.DemiBold).build()
+                StyledText {
+                    Layout.topMargin: -(28 * 0.4)
+                    Layout.alignment: Qt.AlignHCenter
+                    text: Time.format("ss")
+                    color: Colours.palette.m3secondary
+                    font: Tokens.font.clock.size(28).weight(Font.DemiBold).build()
+                }
             }
         }
 

--- a/modules/nexus/pages/panels/DashboardPanel.qml
+++ b/modules/nexus/pages/panels/DashboardPanel.qml
@@ -39,6 +39,14 @@ PageBase {
             onToggled: GlobalConfig.dashboard.showOnHover = checked
         }
 
+        ToggleRow {
+            last: true
+            text: qsTr("Show clock seconds")
+            subtext: qsTr("Display seconds for the clock in the main panel")
+            checked: Config.dashboard.showClockSeconds
+            onToggled: GlobalConfig.dashboard.showClockSeconds = checked
+        }
+
         // Tabs
         SectionHeader {
             text: Tr.tr("Tabs")

--- a/modules/nexus/pages/panels/taskbar/BarClock.qml
+++ b/modules/nexus/pages/panels/taskbar/BarClock.qml
@@ -36,5 +36,12 @@ PageBase {
             checked: Config.bar.clock.showIcon
             onToggled: GlobalConfig.bar.clock.showIcon = checked
         }
+
+        ToggleRow {
+            last: true
+            text: qsTr("Show seconds")
+            checked: Config.bar.clock.showSeconds
+            onToggled: GlobalConfig.bar.clock.showSeconds = checked
+        }
     }
 }

--- a/plugin/src/Caelestia/Config/barconfig.hpp
+++ b/plugin/src/Caelestia/Config/barconfig.hpp
@@ -84,6 +84,7 @@ class BarClock : public settings::ObjectNode {
     CONFIG_PROPERTY(bool, background, false)
     CONFIG_PROPERTY(bool, showDate, false)
     CONFIG_PROPERTY(bool, showIcon, true)
+    CONFIG_PROPERTY(bool, showSeconds, false)
 };
 
 class BarConfig : public settings::ObjectNode {

--- a/plugin/src/Caelestia/Config/dashboardconfig.hpp
+++ b/plugin/src/Caelestia/Config/dashboardconfig.hpp
@@ -25,6 +25,7 @@ class DashboardConfig : public settings::ObjectNode {
     CONFIG_PROPERTY(bool, showMedia, true)
     CONFIG_PROPERTY(bool, showPerformance, true)
     CONFIG_PROPERTY(bool, showWeather, true)
+    CONFIG_PROPERTY(bool, showClockSeconds, false)
     CONFIG_GLOBAL_PROPERTY(int, mediaUpdateInterval, 500)
     CONFIG_GLOBAL_PROPERTY(int, resourceUpdateInterval, 1000)
     CONFIG_PROPERTY(int, dragThreshold, 50)


### PR DESCRIPTION
## Summary

Adds options to display seconds on the clock for both the taskbar and dashboard. This is a re-implementation of #1094, adapted to the new config and dashboard structures (so hopefully Evertiro's TDL can be spared from one more item). I've also added these options to nexus in their respective categories.

Fixes #990, closes #1094

## Testing

- Builds successfully
- Passed `qmlformat` and linting checks
- Displays seconds accurately on both clocks
- Toggles in nexus apply the changes to `shell.json` and show/hide the seconds values
- Tested with both 12-hour and 24-hour formats