### PR TITLE
launcher: preserve scroll position on model refresh

### DIFF
--- a/modules/launcher/AppList.qml
+++ b/modules/launcher/AppList.qml
@@ -56,8 +56,9 @@ StyledListView {
 
     model: ScriptModel {
         values: root.resultsForText(root.displayText)
-        onValuesChanged: root.currentIndex = 0
     }
+
+    onDisplayTextChanged: root.currentIndex = 0
 
     spacing: Tokens.spacing.small
     orientation: Qt.Vertical


### PR DESCRIPTION
## Description

The launcher resets to the first item whenever the application model
changes, even when the search text has not changed.

This happens because `AppList.qml` resets `currentIndex` from
`ScriptModel.onValuesChanged`. Application database refreshes can update
the model while the launcher is open, which unexpectedly moves the user
back to the top of the list.

Move the reset to `onDisplayTextChanged` so the list resets only when the
search text changes. Model refreshes now preserve the current scroll
position.

## Testing

- `qmlformat modules/launcher/AppList.qml | diff -u modules/launcher/AppList.qml -`
- `python scripts/qml-lint-conventions.py`
- CMake/Ninja build completed successfully
- Manually reproduced the issue with the launcher list and application
  model refresh