### PR TITLE
fix(services): prevent freezes on unreachable SMB mount

### DIFF
--- a/plugin/src/Caelestia/Services/CMakeLists.txt
+++ b/plugin/src/Caelestia/Services/CMakeLists.txt
@@ -20,6 +20,7 @@ qml_module(caelestia-services
         sessionmanager.cpp
     LIBRARIES
         Qt::DBus
+        Qt::Concurrent
         PkgConfig::Pipewire
         PkgConfig::Aubio
         PkgConfig::Cava

--- a/plugin/src/Caelestia/Services/storage.cpp
+++ b/plugin/src/Caelestia/Services/storage.cpp
@@ -103,8 +103,9 @@ QStringList resolveByDevt(uint major, uint minor, int depth) {
 } // namespace
 
 Storage::Storage(QObject* parent)
-    : TickingService(parent), m_volumeWatcher(new QFutureWatcher<QList<QStorageInfo>>(this)){
-    connect(m_volumeWatcher, &QFutureWatcher<QList<QStorageInfo>>::finished, this, [this]{
+    : TickingService(parent)
+    , m_volumeWatcher(new QFutureWatcher<QList<QStorageInfo>>(this)) {
+    connect(m_volumeWatcher, &QFutureWatcher<QList<QStorageInfo>>::finished, this, [this] {
         const auto volumes = m_volumeWatcher->result();
         m_volumeWatcherRunning = false;
         parseScannedVolumes(volumes);
@@ -214,8 +215,9 @@ QStringList Storage::resolveToPhysicalDisks(const QString& devicePath) {
     return resolveByDevt(major(st.st_rdev), minor(st.st_rdev));
 }
 
-void Storage::tick(){
-    if(m_volumeWatcherRunning) return;
+void Storage::tick() {
+    if (m_volumeWatcherRunning)
+        return;
 
     m_volumeWatcherRunning = true;
     m_volumeWatcher->setFuture(QtConcurrent::run([] {

--- a/plugin/src/Caelestia/Services/storage.cpp
+++ b/plugin/src/Caelestia/Services/storage.cpp
@@ -7,6 +7,11 @@
 #include <qfileinfo.h>
 #include <qhash.h>
 #include <qloggingcategory.h>
+
+// for async QStorageInfo::mountedVolumes() call
+#include <QtConcurrent/qtconcurrentrun.h>
+// included by hpp #include <qfuturewatcher.h>
+
 #include <qstorageinfo.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
@@ -98,7 +103,13 @@ QStringList resolveByDevt(uint major, uint minor, int depth) {
 } // namespace
 
 Storage::Storage(QObject* parent)
-    : TickingService(parent) {}
+    : TickingService(parent), m_volumeWatcher(new QFutureWatcher<QList<QStorageInfo>>(this)){
+    connect(m_volumeWatcher, &QFutureWatcher<QList<QStorageInfo>>::finished, this, [this]{
+        const auto volumes = m_volumeWatcher->result();
+        m_volumeWatcherRunning = false;
+        parseScannedVolumes(volumes);
+    });
+}
 
 qreal Storage::percentage() const {
     qreal totalUsed = 0.0;
@@ -203,7 +214,16 @@ QStringList Storage::resolveToPhysicalDisks(const QString& devicePath) {
     return resolveByDevt(major(st.st_rdev), minor(st.st_rdev));
 }
 
-void Storage::tick() {
+void Storage::tick(){
+    if(m_volumeWatcherRunning) return;
+
+    m_volumeWatcherRunning = true;
+    m_volumeWatcher->setFuture(QtConcurrent::run([] {
+        return QStorageInfo::mountedVolumes();
+    }));
+}
+
+void Storage::parseScannedVolumes(const QList<QStorageInfo>& mountedVols) {
     const qreal prevPercentage = percentage();
     QHash<QString, Accum> byDisk;
 
@@ -220,7 +240,8 @@ void Storage::tick() {
 
     QHash<QByteArray, DeviceEntry> byDevice;
 
-    const auto mountedVols = QStorageInfo::mountedVolumes();
+    // replaced this synchronous call with an asynchronous mountedVolumes evaluation to avoid blocking the main thread
+    // const auto mountedVols = QStorageInfo::mountedVolumes();
     for (const QStorageInfo& v : mountedVols) {
         if (!v.isReady() || !v.isValid() || v.bytesTotal() <= 0) {
             continue;

--- a/plugin/src/Caelestia/Services/storage.hpp
+++ b/plugin/src/Caelestia/Services/storage.hpp
@@ -8,6 +8,9 @@
 #include <qqmllist.h>
 #include <qvariant.h>
 
+#include <qfuturewatcher.h>
+#include <qstorageinfo.h>
+
 namespace caelestia::services {
 
 class Storage : public TickingService {
@@ -49,6 +52,11 @@ private:
 
     QList<DiskInfo*> m_disks;
     QPointer<DiskInfo> m_manualPrimaryDisk;
+
+    // for async QStorageInfo::mountedVolumes() call
+    void parseScannedVolumes(const QList<QStorageInfo>& mountedVols);
+    QFutureWatcher<QList<QStorageInfo>>* m_volumeWatcher;
+    bool m_volumeWatcherRunning = false;
 };
 
 } // namespace caelestia::services


### PR DESCRIPTION
QStorageInfo::mountedVolumes() may block while querying an unreachable
network filesystem, for example a disconnected CIFS/NAS mount.

Implementation changed that QStorageInfo::mountedVolumes() is run outside the GUI thread. Storage::tick() previously executed this call on the GUI thread, causing
the entire shell to freeze until the filesystem request returned.

The worker itself may still remain blocked, but the GUI event loop stays
responsive and subsequent timer ticks do not start additional scans.