### PR TITLE
launcher: preserve scroll position on app refresh

### DIFF
--- a/modules/launcher/AppList.qml
+++ b/modules/launcher/AppList.qml
@@ -56,8 +56,9 @@ StyledListView {
 
     model: ScriptModel {
         values: root.resultsForText(root.displayText)
-        onValuesChanged: root.currentIndex = 0
     }
+
+    onDisplayTextChanged: root.currentIndex = 0
 
     spacing: Tokens.spacing.small
     orientation: Qt.Vertical

--- a/modules/launcher/AppList.qml
+++ b/modules/launcher/AppList.qml
@@ -17,6 +17,8 @@ StyledListView {
     required property ScreenState screenState
 
     property string displayText
+    property var displayResults: []
+    property var queueIds: []
 
     readonly property string requestedState: stateForText(search.text)
     readonly property string displayState: stateForText(displayText)
@@ -54,11 +56,27 @@ StyledListView {
         }
     }
 
-    model: ScriptModel {
-        values: root.resultsForText(root.displayText)
+    function refreshResults(): void {
+        const results = root.resultsForText(root.displayText);
+        root.queueIds = root.displayState === "apps" ? results.map(entry => entry.id) : [];
+        root.displayResults = results;
+        root.currentIndex = 0;
     }
 
-    onDisplayTextChanged: root.currentIndex = 0
+    function rebindAppResults(): void {
+        if (root.displayState !== "apps" || root.queueIds.length === 0)
+            return;
+
+        const byId = new Map(DesktopEntries.applications.values.map(entry => [entry.id, entry]));
+        root.displayResults = root.queueIds.filter(id => byId.has(id)).map(id => byId.get(id));
+    }
+
+    model: ScriptModel {
+        values: root.displayResults
+        objectProp: root.displayState === "apps" ? "id" : ""
+    }
+
+    onDisplayTextChanged: root.refreshResults()
 
     spacing: Tokens.spacing.small
     orientation: Qt.Vertical
@@ -90,7 +108,10 @@ StyledListView {
             Schemes.reload();
     }
 
-    Component.onCompleted: displayText = search.text
+    Component.onCompleted: {
+        displayText = search.text;
+        refreshResults();
+    }
 
     states: [
         State {
@@ -299,8 +320,20 @@ StyledListView {
     Connections {
         function onLauncherChanged() {
             root.syncDisplayText();
+            if (root.screenState.launcher) {
+                root.displayText = root.search.text;
+                root.refreshResults();
+            }
         }
 
         target: root.screenState
+    }
+
+    Connections {
+        function onApplicationsChanged(): void {
+            root.rebindAppResults();
+        }
+
+        target: DesktopEntries
     }
 }


### PR DESCRIPTION
## Problem

Refreshing the desktop application database could reorder launcher results and move the visible list back to the top. In some cases, stale DesktopEntry objects also caused missing icons after a refresh.

## Changes

- Preserve a stable application ID queue while the launcher is open.
- Avoid rebuilding the queue based on refreshed sorting results.
- Rebind displayed applications to the current DesktopEntries objects by ID.
- Preserve the current list order and scroll position across application database refreshes.
- Keep non-application launcher states unchanged.

## Testing

- `cmake --build build`
- `qmlformat modules/launcher/AppList.qml`
- `python scripts/qml-lint-conventions.py`
- Manually tested launcher refreshes locally.