### PR TITLE
fix(services): stop corrupting wifi profiles on connect

### DIFF
--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -27,6 +27,10 @@ Singleton {
     property var wifiConnectionQueue: []
     property int currentSsidQueryIndex: 0
     property var pendingConnection: null
+    // State for deleteProbeLeftovers, deferred by a few seconds because nmcli
+    // writes the incomplete profile after the failure is reported.
+    property string probeCleanupSsid: ""
+    property var probeCleanupProfiles: []
     property var wirelessDeviceDetails: null
     property var ethernetDeviceDetails: null
     property string ethernetDataUsage: ""
@@ -64,7 +68,6 @@ Singleton {
     readonly property string connectionParamIfname: "ifname"
     readonly property string connectionParamSsid: "ssid"
     readonly property string connectionParamPassword: "password"
-    readonly property string connectionParamBssid: "802-11-wireless.bssid"
     readonly property string connectionParamHidden: "802-11-wireless.hidden"
 
     signal connectionFailed(string ssid)
@@ -364,10 +367,59 @@ Singleton {
         });
     }
 
+    // Lists saved wifi profiles as {uuid, timestamp, name}.
+    function listWifiProfiles(callback: var): void {
+        executeCommand(["-t", "-f", "UUID,TYPE,TIMESTAMP,NAME", root.nmcliCommandConnection, "show"], result => {
+            const profiles = [];
+            if (result.success && result.output) {
+                for (const line of result.output.trim().split("\n")) {
+                    const parts = line.split(":");
+                    if (parts.length >= 4 && parts[1] === root.connectionTypeWireless)
+                        profiles.push({
+                            uuid: parts[0],
+                            timestamp: parts[2],
+                            name: parts.slice(3).join(":")
+                        });
+                }
+            }
+            if (callback)
+                callback(profiles);
+        });
+    }
+
+    // `nmcli device wifi connect` without a password still saves a profile
+    // before failing for missing secrets. That profile keeps autoconnect on and
+    // NetworkManager retries it forever, leaving the adapter in a loop of
+    // no-secrets failures. Remove only what the probe left behind: profiles that
+    // appeared after the probe, are not active and were never used, so a profile
+    // just created with the correct password is never touched.
+    function deleteProbeLeftovers(ssid: string, before: var): void {
+        executeCommand(["-t", "-f", "UUID", root.nmcliCommandConnection, "show", "--active"], activeResult => {
+            const active = (activeResult.output || "").trim().split("\n");
+            listWifiProfiles(after => {
+                for (const profile of after) {
+                    if (before.indexOf(profile.uuid) !== -1 || active.indexOf(profile.uuid) !== -1)
+                        continue;
+                    if (profile.timestamp !== "0")
+                        continue;
+                    if (profile.name !== ssid && profile.name.indexOf(ssid + " ") !== 0)
+                        continue;
+                    console.warn(lc, "Removing leftover profile from password probe: " + profile.name);
+                    executeCommand([root.nmcliCommandConnection, "delete", "uuid", profile.uuid], () => {});
+                }
+            });
+        });
+    }
+
     function connectToNetworkWithPasswordCheck(ssid: string, isSecure: bool, callback: var, bssid: string): void {
         if (isSecure) {
             const hasBssid = bssid !== undefined && bssid !== null && bssid.length > 0;
-            connectWireless(ssid, "", bssid, result => {
+            listWifiProfiles(existing => connectWireless(ssid, "", bssid, result => {
+                if (!result.success) {
+                    root.probeCleanupSsid = ssid;
+                    root.probeCleanupProfiles = existing.map(profile => profile.uuid);
+                    probeCleanupTimer.restart();
+                }
                 if (result.success) {
                     if (callback)
                         callback({
@@ -390,7 +442,7 @@ Singleton {
                     if (callback)
                         callback(result);
                 }
-            });
+            }));
         } else {
             connectWireless(ssid, "", bssid, callback);
         }
@@ -418,8 +470,7 @@ Singleton {
         }
 
         if (password && password.length > 0 && hasBssid) {
-            const bssidUpper = bssid.toUpperCase();
-            createConnectionWithPassword(ssid, bssidUpper, password, callback);
+            createConnectionWithPassword(ssid, password, callback);
             return;
         }
 
@@ -446,9 +497,17 @@ Singleton {
         });
     }
 
-    function createConnectionWithPassword(ssid: string, bssidUpper: string, password: string, callback: var): void {
+    function createConnectionWithPassword(ssid: string, password: string, callback: var): void {
         checkAndDeleteConnection(ssid, () => {
-            const cmd = [root.nmcliCommandConnection, "add", root.connectionParamType, root.deviceTypeWifi, root.connectionParamConName, ssid, root.connectionParamIfname, "*", root.connectionParamSsid, ssid, root.connectionParamBssid, bssidUpper, root.securityKeyMgmt, root.keyMgmtWpaPsk, root.securityPsk, password];
+            // No 802-11-wireless.bssid: pinning the profile to whichever access
+            // point happened to be in use at creation time makes it unusable as
+            // soon as the client associates with another AP on the same network
+            // (repeaters, mesh, or simply a closer AP). NetworkManager then does
+            // not consider the profile applicable, `nmcli device wifi connect`
+            // creates a new passwordless one instead, and the connection fails
+            // with no-secrets. The BSSID is still used to identify the network in
+            // the UI.
+            const cmd = [root.nmcliCommandConnection, "add", root.connectionParamType, root.deviceTypeWifi, root.connectionParamConName, ssid, root.connectionParamIfname, "*", root.connectionParamSsid, ssid, root.securityKeyMgmt, root.keyMgmtWpaPsk, root.securityPsk, password];
 
             executeCommand(cmd, result => {
                 if (result.success) {
@@ -1453,6 +1512,13 @@ Singleton {
         id: ethComp
 
         EthernetDevice {}
+    }
+
+    Timer {
+        id: probeCleanupTimer
+
+        interval: 3000
+        onTriggered: root.deleteProbeLeftovers(root.probeCleanupSsid, root.probeCleanupProfiles)
     }
 
     Timer {


### PR DESCRIPTION
Two issues in `services/Nmcli.qml` leave NetworkManager holding wifi profiles it cannot use. Both surface the same way: connecting to a secured network spins and then fails with `no-secrets`, even though the password is correct and `nmcli device wifi connect <ssid> password <pw>` works from a terminal.

### 1. The saved profile is pinned to one access point

`createConnectionWithPassword` sets `802-11-wireless.bssid` to whichever AP happened to be in range when the profile was created.

On any network with more than one AP — repeaters, mesh, or simply roaming to a closer one — NetworkManager no longer considers that profile applicable. `nmcli device wifi connect` then creates a **new, passwordless** profile instead of reusing the saved one, and the connection fails. The network looks "saved" in the UI but never connects again until the profile is deleted by hand.

The BSSID is dropped from the created profile. It is still used to identify the network in the UI, so nothing visible changes.

### 2. The password probe leaves broken profiles behind

`connectToNetworkWithPasswordCheck` probes a network by running `nmcli device wifi connect` with no password, to find out whether secrets are required. nmcli saves a profile *before* failing, so every probe leaves an incomplete profile behind — `SSID 1`, `SSID 2`, and so on — with autoconnect enabled. NetworkManager then retries these in a loop, which keeps the adapter busy failing.

They also confuse `hasSavedProfile`, which only checks whether a profile with that name exists, not whether it holds a key. That is the same trap #1869 addresses from the caller side.

Leftovers are now removed after the probe, matched conservatively: only profiles that appeared after the probe started, are not currently active, and have never been used (`timestamp 0`). A profile just created with the correct password is never touched. The cleanup is deferred by 3s because nmcli writes the profile after reporting the failure.

### Notes

- Removing the BSSID made the `bssidUpper` parameter and the `connectionParamBssid` property dead, so both are gone.
- In `connectWireless`, the branch that builds the profile by hand is still gated on `hasBssid`. Now that the BSSID does not end up in the profile, that condition discriminates on a value it no longer uses. Changing it would also affect the no-BSSID path, so I left it alone — flagging it in case you want it addressed separately.
- Tested on 2.3.0 against a WPA2 network with two APs, which is what surfaced both problems.

Independent of #1869: that one fixes the Nexus caller so the password prompt appears at all, this one fixes the profiles the service writes underneath. Both are needed to get a working connection on a multi-AP network.