### PR TITLE
fix(bar): support pasting into the wifi password field

### DIFF
--- a/modules/bar/popouts/WirelessPassword.qml
+++ b/modules/bar/popouts/WirelessPassword.qml
@@ -291,6 +291,20 @@ ColumnLayout {
                         connectButton.hasError = false;
                     }
 
+                    // Paste from the clipboard. This field is not a TextField:
+                    // the text is assembled by hand from event.text, so without
+                    // this branch Ctrl+V lands in the buffer as a control
+                    // character and the password silently comes out wrong.
+                    // Handles Ctrl+V and Shift+Insert.
+                    const isPaste = (event.key === Qt.Key_V && (event.modifiers & Qt.ControlModifier)) || (event.key === Qt.Key_Insert && (event.modifiers & Qt.ShiftModifier));
+                    if (isPaste) {
+                        const clip = Quickshell.clipboardText;
+                        if (clip)
+                            passwordBuffer += clip.replace(/[\r\n]+$/, "");
+                        event.accepted = true;
+                        return;
+                    }
+
                     if (event.key === Qt.Key_Enter || event.key === Qt.Key_Return) {
                         if (connectButton.enabled) {
                             connectButton.clicked();


### PR DESCRIPTION
The password field in the wifi popout (`modules/bar/popouts/WirelessPassword.qml`) is a `FocusScope` that builds its value by appending `event.text` on every key press, not a `TextField`, so it has never supported pasting.

Ctrl+V was appended to the buffer as a control character rather than being handled, so the connection then failed with a password that was wrong in a way nothing on screen explained. For anyone using a password manager, or any WPA2 key long enough not to be worth retyping, the popout is effectively unusable.

Ctrl+V and Shift+Insert are now handled explicitly, reading `Quickshell.clipboardText`. A trailing newline is stripped, since clipboard managers and password managers commonly include one and it would otherwise become part of the key.

Tested on 2.3.0 pasting from both `wl-paste` and a password manager.