### PR TITLE
fix(services): prevent duplicate and unknown keyboard layout notifications

### DIFF
--- a/services/Hypr.qml
+++ b/services/Hypr.qml
@@ -37,6 +37,7 @@ Singleton {
     readonly property alias devices: extras.devices
 
     property bool hadKeyboard
+    property string lastKbLayoutFull: ""
     property string lastSpecialWorkspace: ""
 
     signal configReloaded
@@ -131,8 +132,11 @@ Singleton {
     }
 
     onKbLayoutFullChanged: {
-        if (hadKeyboard && GlobalConfig.utilities.toasts.kbLayoutChanged)
+        if (hadKeyboard && kbLayoutFull && kbLayoutFull !== "Unknown" && kbLayoutFull !== lastKbLayoutFull && lastKbLayoutFull !== "" && GlobalConfig.utilities.toasts.kbLayoutChanged)
             Toaster.toast(qsTr("Keyboard layout changed"), qsTr("Layout changed to: %1").arg(kbLayoutFull), "keyboard");
+
+        if (kbLayoutFull && kbLayoutFull !== "Unknown")
+            lastKbLayoutFull = kbLayoutFull;
 
         hadKeyboard = !!keyboard;
     }

--- a/services/Hypr.qml
+++ b/services/Hypr.qml
@@ -132,7 +132,7 @@ Singleton {
     }
 
     onKbLayoutFullChanged: {
-        if (hadKeyboard && kbLayoutFull && kbLayoutFull !== "Unknown" && kbLayoutFull !== lastKbLayoutFull && lastKbLayoutFull !== "" && GlobalConfig.utilities.toasts.kbLayoutChanged)
+        if (hadKeyboard && kbLayoutFull && kbLayoutFull !== "Unknown" && kbLayoutFull !== lastKbLayoutFull && GlobalConfig.utilities.toasts.kbLayoutChanged)
             Toaster.toast(qsTr("Keyboard layout changed"), qsTr("Layout changed to: %1").arg(kbLayoutFull), "keyboard");
 
         if (kbLayoutFull && kbLayoutFull !== "Unknown")


### PR DESCRIPTION
### Summary
Fixes an issue where connecting a mouse, USB dongle, or external input device caused `Hypr.qml` to send false *"Keyboard layout changed: Layout changed to: Unknown"* or duplicate layout notifications.

### Changes
* Track previous keyboard layout with `lastKbLayoutFull` to ensure notifications only trigger when the layout name **actually** changes.
* Ignore transient `"Unknown"` layout states during device renegotiation.