### PR TITLE
fix(idle): IdleMonitors never sees the Keep Awake toggle state

### DIFF
--- a/modules/IdleMonitors.qml
+++ b/modules/IdleMonitors.qml
@@ -7,15 +7,17 @@ import Quickshell.Wayland
 import Quickshell.Services.UPower
 import Caelestia.Config
 import Caelestia.Services
-import qs.services
+import qs.services as Services
 
 Scope {
     id: root
 
     required property Lock lock
-    readonly property bool hasPlayer: Players.list.some(p => p.isPlaying)
+    readonly property bool hasPlayer: Services.Players.list.some(p => p.isPlaying)
     readonly property bool isCharging: !UPower.onBattery
     readonly property bool enabled: {
+        if (Services.IdleInhibitor.enabled)
+            return false;
         if (GlobalConfig.general.idle.inhibitWhenAudio && hasPlayer)
             return false;
         if (GlobalConfig.general.idle.inhibitWhenCharging && isCharging)
@@ -32,7 +34,7 @@ Scope {
         else if (action === "unlock")
             lock.lock.locked = false;
         else if (typeof action === "string")
-            Hypr.dispatch(Hypr.usingLua && ["dpms off", "dpms on"].includes(action) ? `hl.dsp.dpms({ action = "${action === "dpms off" ? "disable" : "enable"}" })` : action);
+            Services.Hypr.dispatch(Services.Hypr.usingLua && ["dpms off", "dpms on"].includes(action) ? `hl.dsp.dpms({ action = "${action === "dpms off" ? "disable" : "enable"}" })` : action);
         else if (!SessionManager.exec(action))
             Quickshell.execDetached(action);
     }


### PR DESCRIPTION
## What

Keep Awake could show **ON** in the UI while the screen still locked and went DPMS-off right on schedule, as reported in #1835.

## Root cause

`IdleMonitors.qml` imports both `Quickshell.Wayland` (whose `qmldir` re-exports the C++ `IdleInhibitor` type) and `qs.services` (which exports the `IdleInhibitor` *singleton* that actually backs the Keep Awake button). The unqualified `IdleInhibitor.enabled` reference in this file resolved to the C++ type, not the singleton — so the idle monitors' `enabled` binding never actually reacted to the toggle. Only the Wayland `zwp_idle_inhibitor` chain was ever protecting anything from the button's perspective; the button state itself was never consulted.

This is layer 1 of the two-layer bug @vicentesepulvedag root-caused and verified against real idle-timeout logs in #1835 (diagnosis + a verified fix included there, but no PR had been opened for it — this PR applies it).

## Fix

Alias the import (`import qs.services as Services`) and qualify every reference through it (`Services.Players`, `Services.Hypr`, and the new `Services.IdleInhibitor.enabled` check that short-circuits `enabled` to `false`), so name resolution can no longer silently pick the wrong `IdleInhibitor`.

## Scope / what this does *not* fix

#1835 describes a **second**, separate layer: the `zwp_idle_inhibitor` Wayland surface itself sometimes fails to register with Hyprland after a monitor hotplug/lock cycle (visible in the issue's `hyprctl layers` log — no inhibitor surface present even while the IPC state reads `true`). That's a different bug living in `IdleInhibitor.qml`'s `PanelWindow` handling, and I haven't been able to reproduce the hotplug-correlated conditions to verify a fix for it here, so I'm leaving that part of #1835 open rather than claiming this closes it outright.

## Testing

Ran `python3 scripts/qml-lint-conventions.py` clean (0 violations across all 282 files). Manually re-read the full file after the change to confirm no other unqualified `qs.services` references were missed (`SessionManager` is unaffected — it comes from the separate `Caelestia.Services` import).