### PR TITLE
feat(nexus): build the Colours page

### DIFF
--- a/modules/nexus/common/SchemeCard.qml
+++ b/modules/nexus/common/SchemeCard.qml
@@ -1,0 +1,95 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Caelestia.Config
+import qs.components
+import qs.components.controls
+import qs.services
+
+// Mirrors WallItem.qml's structure (square preview + label + StateLayer
+// click ripple) so the Colours grid matches the existing Wallpapers grid's
+// look and animations -- just a 3-way primary/secondary/tertiary colour
+// swatch instead of an Image.
+Item {
+    id: root
+
+    required property string name
+    required property string flavour
+    required property var colours
+    property bool current: false
+
+    signal clicked
+
+    Layout.fillWidth: true
+    implicitHeight: layout.implicitHeight
+
+    ColumnLayout {
+        id: layout
+
+        anchors.fill: parent
+        spacing: Tokens.spacing.small
+
+        StyledClippingRect {
+            id: swatch
+
+            Layout.fillWidth: true
+            implicitHeight: width
+            radius: Tokens.rounding.largeIncreased
+            color: `#${root.colours.surface}`
+            border.width: root.current ? 3 : 0
+            border.color: Colours.palette.m3primary
+
+            Row {
+                anchors.fill: parent
+
+                Rectangle {
+                    width: parent.width / 3
+                    height: parent.height
+                    color: `#${root.colours.primary}`
+                }
+
+                Rectangle {
+                    width: parent.width / 3
+                    height: parent.height
+                    color: `#${root.colours.secondary}`
+                }
+
+                Rectangle {
+                    width: parent.width / 3
+                    height: parent.height
+                    color: `#${root.colours.tertiary}`
+                }
+            }
+        }
+
+        Row {
+            Layout.bottomMargin: Tokens.padding.small
+            Layout.alignment: Qt.AlignHCenter
+            spacing: Tokens.spacing.extraSmall
+
+            StyledText {
+                text: root.flavour === "default" ? root.name : `${root.name} ${root.flavour}`
+                color: Colours.palette.m3onSurfaceVariant
+                font: Tokens.font.label.builders.small.weight(Font.Medium).build()
+                elide: Text.ElideRight
+            }
+
+            Loader {
+                active: root.current
+                asynchronous: true
+                anchors.verticalCenter: parent.verticalCenter
+
+                sourceComponent: MaterialIcon {
+                    text: "check"
+                    color: Colours.palette.m3primary
+                    fontStyle: Tokens.font.icon.large
+                }
+            }
+        }
+    }
+
+    StateLayer {
+        onClicked: root.clicked()
+    }
+}

--- a/modules/nexus/pages/wallandstyle/ColourSelect.qml
+++ b/modules/nexus/pages/wallandstyle/ColourSelect.qml
@@ -1,46 +1,120 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Layouts
+import Quickshell
+import Quickshell.Io
+import Caelestia.Components
 import Caelestia.Config
 import qs.components
+import qs.components.controls
 import qs.services
 import qs.modules.nexus.common
 
 PageBase {
     id: root
 
+    property var schemeList: []
+
     title: qsTr("Colours")
     isSubPage: true
 
-    Item {
+    Component.onCompleted: getSchemes.running = true
+
+    ColumnLayout {
         anchors.horizontalCenter: parent.horizontalCenter
-        implicitHeight: {
-            const f = parent.parent as Flickable;
-            return f.height - f.topMargin - f.bottomMargin;
+        anchors.top: parent.top
+        width: root.cappedWidth
+        spacing: Tokens.spacing.small
+
+        // Non-visual helper -- PageBase (unlike a plain Item/Layout)
+        // overrides its default property to a QQuickItem-only list, so this
+        // can't live directly under the PageBase root. ColumnLayout doesn't
+        // have that restriction. Kept self-contained here (rather than
+        // reusing modules/launcher/services/Schemes.qml, which fetches the
+        // same list) since that singleton is coupled to the launcher's
+        // Searcher/search-bar machinery, which doesn't apply on a Nexus
+        // page -- the current-scheme highlight below instead just binds
+        // live to Colours.scheme/flavour, which is already reactive
+        // (Colours.qml watches scheme.json directly), so no separate
+        // "get current" process or manual bookkeeping is needed here.
+        Process {
+            id: getSchemes
+
+            command: ["caelestia", "scheme", "list"]
+            stdout: StdioCollector {
+                onStreamFinished: {
+                    const data = JSON.parse(text);
+                    const flat = [];
+                    for (const name in data)
+                        for (const flavour in data[name])
+                            flat.push({
+                                name,
+                                flavour,
+                                colours: data[name][flavour]
+                            });
+                    flat.sort((a, b) => (a.name + a.flavour).localeCompare(b.name + b.flavour));
+                    root.schemeList = flat;
+                }
+            }
         }
 
-        ColumnLayout {
-            anchors.centerIn: parent
-            spacing: Tokens.padding.extraSmall
+        ButtonRow {
+            Layout.bottomMargin: Tokens.spacing.medium
+            Layout.alignment: Qt.AlignHCenter
+            spacing: Tokens.spacing.small
 
-            MaterialIcon {
-                Layout.alignment: Qt.AlignHCenter
-                text: "handyman"
-                color: Colours.palette.m3outlineVariant
-                fontStyle: Tokens.font.icon.extraLarge
-            }
-
-            StyledText {
-                Layout.alignment: Qt.AlignHCenter
-                text: qsTr("Page under construction")
-                color: Colours.palette.m3outlineVariant
-                font: Tokens.font.title.large
-            }
-
-            StyledText {
-                Layout.alignment: Qt.AlignHCenter
-                text: qsTr("This page will be available in a future update.")
-                color: Colours.palette.m3outlineVariant
+            IconTextButton {
+                icon: "wallpaper"
+                text: qsTr("Follow wallpaper")
                 font: Tokens.font.body.large
+                isRound: true
+                shapeMorph: true
+                horizontalPadding: Tokens.padding.extraLarge
+                verticalPadding: Tokens.padding.medium
+                onClicked: Quickshell.execDetached(["caelestia", "scheme", "set", "--notify", "-n", "dynamic"])
+            }
+
+            IconTextButton {
+                icon: "shuffle"
+                text: qsTr("Random")
+                font: Tokens.font.body.large
+                isRound: true
+                shapeMorph: true
+                horizontalPadding: Tokens.padding.extraLarge
+                verticalPadding: Tokens.padding.medium
+                type: IconTextButton.Tonal
+                onClicked: Quickshell.execDetached(["caelestia", "scheme", "set", "--notify", "-r"])
+            }
+        }
+
+        StyledText {
+            Layout.topMargin: Tokens.spacing.large
+            text: qsTr("Palettes")
+            font: Tokens.font.title.small
+        }
+
+        GridLayout {
+            Layout.fillWidth: true
+            visible: root.schemeList.length > 0
+
+            columns: Config.nexus.wallpapersPerRow
+            rowSpacing: Tokens.spacing.medium
+            columnSpacing: Tokens.spacing.large
+
+            Repeater {
+                model: root.schemeList
+
+                SchemeCard {
+                    required property var modelData
+
+                    name: modelData.name
+                    flavour: modelData.flavour
+                    colours: modelData.colours
+                    current: modelData.name === Colours.scheme && modelData.flavour === Colours.flavour
+
+                    onClicked: Quickshell.execDetached(["caelestia", "scheme", "set", "--notify", "-n", modelData.name, "-f", modelData.flavour])
+                }
             }
         }
     }


### PR DESCRIPTION
## What

Nexus's Wallpaper & Style page already has a working "Colours" button (`WallpaperAndStyle.qml`) wired to a subpage — but that subpage is just a literal "Page under construction" placeholder. Filled it in. Fixes the gap reported in #1670, which asked for exactly this (a UI to change the scheme without hand-editing `scheme.json`).

## How

Mirrors the existing, working Wallpaper page's structure/components rather than introducing a new visual pattern:

- **`modules/nexus/common/SchemeCard.qml`** (new): mirrors `WallItem.qml`'s square-preview + label + `StateLayer` click layout. The "preview" is a 3-way primary/secondary/tertiary colour swatch instead of an image, with a primary-coloured border + `check` icon on whichever tile is active.
- **`modules/nexus/pages/wallandstyle/ColourSelect.qml`**: mirrors `WallpaperSelect.qml`'s structure (quick-action `ButtonRow` + `GridLayout` of cards, reusing `Config.nexus.wallpapersPerRow` for column count so it's consistent with the Wallpaper grid rather than adding a new config key). "Follow wallpaper" sets the `dynamic` scheme, "Random" rolls one via `caelestia scheme set -r`, and the grid lists every scheme name+flavour combination from `caelestia scheme list` — the same data source `modules/launcher/services/Schemes.qml` uses for the launcher's `>scheme` picker. I kept the fetch self-contained here rather than reusing that singleton directly, since it's coupled to the launcher's `Searcher`/search-bar machinery which doesn't apply on a Nexus page. The active tile's checkmark binds live to `Colours.scheme`/`Colours.flavour` instead of tracking its own "current" state — `Colours.qml` already watches `scheme.json` reactively, so no extra process or manual bookkeeping is needed after a click.

## Testing

Ran `python3 scripts/qml-lint-conventions.py` clean (0 violations across all 283 files). I don't have a way to run this shell's actual `qmllint`/`qmlformat` locally — as noted on #1870, both crash silently even against pristine unmodified upstream files here, which points at a local Qt/tooling mismatch rather than anything specific to these changes. Happy to fix up formatting per CI feedback if it flags anything I couldn't catch locally.

Built on top of #1889 in git history (both branched from current `main`) but they're independent — this doesn't depend on that PR's change, they just happened to be adjacent work from the same investigation.