### PR TITLE
feat(lock): add configurable profile picture shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,7 +698,8 @@ For example, to automatically hide the bar on the monitor named `DP-1`:
         "enableHowdy": true,
         "maxHowdyTries": 3,
         "triggerHowdyOnWake": true,
-        "hideNotifs": false
+        "hideNotifs": false,
+        "pfpShape": "ClamShell"
     },
     "nexus": {
         "wallpapersPerRow": 4,

--- a/modules/lock/center/ProfilePic.qml
+++ b/modules/lock/center/ProfilePic.qml
@@ -15,9 +15,21 @@ Item {
     required property int centerWidth
     readonly property color bgColour: Colours.tPalette.m3surfaceContainerHighest
 
+    function resolveShape(name: string): int {
+        if (!name)
+            return MaterialShape.ClamShell;
+
+        if (name !== "Custom" && typeof MaterialShape[name] === "number" && MaterialShape[name] >= 0)
+            return MaterialShape[name];
+
+        console.warn(`[ProfilePic] Unknown shape "${name}", falling back to ClamShell`);
+        return MaterialShape.ClamShell;
+    }
+
     implicitWidth: Math.round(centerWidth * 0.7)
     implicitHeight: {
-        shape.height; // Force update when shape height changes
+        shape.height;
+        shape.shape; // Force update when shape changes
         return shape.pathBounds().height;
     }
 
@@ -27,7 +39,7 @@ Item {
         anchors.centerIn: parent
         implicitSize: root.implicitWidth
 
-        shape: MaterialShape.ClamShell
+        shape: root.resolveShape(Config.lock.pfpShape)
         color: Qt.alpha(root.bgColour, 1)
         opacity: root.bgColour.a
         layer.enabled: true

--- a/modules/lock/center/ProfilePic.qml
+++ b/modules/lock/center/ProfilePic.qml
@@ -64,7 +64,7 @@ Item {
             maskSource: shape
         }
     }
-    
+
     LoggingCategory {
         id: lc
 

--- a/modules/lock/center/ProfilePic.qml
+++ b/modules/lock/center/ProfilePic.qml
@@ -16,20 +16,19 @@ Item {
     readonly property color bgColour: Colours.tPalette.m3surfaceContainerHighest
 
     function resolveShape(name: string): int {
-        if (!name)
-            return MaterialShape.ClamShell;
-
-        if (name !== "Custom" && typeof MaterialShape[name] === "number" && MaterialShape[name] >= 0)
+        if (typeof MaterialShape[name] === "number" && MaterialShape[name] >= 0)
             return MaterialShape[name];
 
-        console.warn(`[ProfilePic] Unknown shape "${name}", falling back to ClamShell`);
+        console.warn(lc, `Unknown shape "${name}" for pfpShape; falling back to "ClamShell"`);
         return MaterialShape.ClamShell;
     }
 
     implicitWidth: Math.round(centerWidth * 0.7)
     implicitHeight: {
+        // Force update when the shape or its height changes
         shape.height;
-        shape.shape; // Force update when shape changes
+        shape.shape;
+        shape.morphProgress;
         return shape.pathBounds().height;
     }
 
@@ -64,5 +63,12 @@ Item {
         layer.effect: Mask {
             maskSource: shape
         }
+    }
+    
+    LoggingCategory {
+        id: lc
+
+        name: "caelestia.qml.lock"
+        defaultLogLevel: LoggingCategory.Info
     }
 }

--- a/plugin/src/Caelestia/Config/lockconfig.hpp
+++ b/plugin/src/Caelestia/Config/lockconfig.hpp
@@ -5,6 +5,8 @@
 
 namespace caelestia::config {
 
+using Qt::StringLiterals::operator""_s;
+
 class LockConfig : public settings::ObjectNode {
     CONFIG_NODE(LockConfig, settings::ObjectNode)
 
@@ -17,7 +19,7 @@ class LockConfig : public settings::ObjectNode {
     CONFIG_GLOBAL_PROPERTY(int, maxHowdyTries, 3)
     CONFIG_GLOBAL_PROPERTY(bool, triggerHowdyOnWake, true)
     CONFIG_PROPERTY(bool, hideNotifs, false)
-    CONFIG_PROPERTY(QString, pfpShape, QStringLiteral("ClamShell"))
+    CONFIG_PROPERTY(QString, pfpShape, u"ClamShell"_s)
 };
 
 } // namespace caelestia::config

--- a/plugin/src/Caelestia/Config/lockconfig.hpp
+++ b/plugin/src/Caelestia/Config/lockconfig.hpp
@@ -17,6 +17,7 @@ class LockConfig : public settings::ObjectNode {
     CONFIG_GLOBAL_PROPERTY(int, maxHowdyTries, 3)
     CONFIG_GLOBAL_PROPERTY(bool, triggerHowdyOnWake, true)
     CONFIG_PROPERTY(bool, hideNotifs, false)
+    CONFIG_PROPERTY(QString, pfpShape, QStringLiteral("ClamShell"))
 };
 
 } // namespace caelestia::config


### PR DESCRIPTION
### Summary
Allows configuration of the pfp shape on the lockscreen, set via shell.json. Default is ClamShell like before.
Resolves #1821

### Changes
config: add pfpShape property to LockConfig

lock: resolve shape in ProfilePic with ClamShell fallback

docs: add pfpShape in README.md example config

### How to Use
in the shell.json add:
```json
    {
        "lock": {
            "pfpShape": "diamond"
        }
    }
```
supports a bunch of shapes, here is a full list and some examples:
<details>
    <summary><b>Shapes</b></summary>
    `Circle`, `Square`, `Slanted`, `Arch`, `Fan`, `Arrow`, `SemiCircle`, `Oval`, `Pill`, `Triangle`, `Diamond`, `ClamShell`, `Pentagon`, `Gem`, `Sunny`, `VerySunny`, `Cookie4Sided`, `Cookie6Sided`, `Cookie7Sided`, `Cookie9Sided`, `Cookie12Sided`,
  `Ghostish`, `Clover4Leaf`, `Clover8Leaf`, `Burst`, `SoftBurst`, `Boom`, `SoftBoom`, `Flower`, `Puffy`, `PuffyDiamond`, `PixelCircle`, `PixelTriangle`, `Bun`, `Heart`
</details>
<img width="522" height="622" alt="20260825172409" src="https://github.com/user-attachments/assets/35605ccc-ea23-46bf-97a4-72d6275f1c00" />
<img width="474" height="565" alt="20260825172356" src="https://github.com/user-attachments/assets/8db1e6b1-4ec3-47cc-a607-2a7697e02396" />
<img width="541" height="575" alt="20260825172342" src="https://github.com/user-attachments/assets/80484da7-2f87-494b-a4d2-9fe0b65c396d" />
