### PR TITLE
fix(services): clear the selected candidate with the candidate list

### DIFF
--- a/plugin/src/Caelestia/Services/lyrics.cpp
+++ b/plugin/src/Caelestia/Services/lyrics.cpp
@@ -326,11 +326,22 @@ void Lyrics::appendCandidates(const QList<LyricCandidate>& add) {
 }
 
 void Lyrics::clearCandidates() {
-    if (m_candidates.isEmpty()) {
-        return;
+    // The selection has to go with the list it points into. Leaving it set
+    // means doLoad()'s restore of a saved backend/id hits
+    // setSelectedCandidate()'s dedup and returns having done nothing - and
+    // since doLoad() has already called setLoading(true) by then, nothing
+    // clears it again and the spinner stays up until the track changes.
+    // LyricCandidate compares by backend + id only, so it only takes leaving a
+    // track and coming back to it for the restored candidate to match whatever
+    // is still selected.
+    if (!m_candidates.isEmpty()) {
+        m_candidates.clear();
+        emit lyricCandidatesChanged();
     }
-    m_candidates.clear();
-    emit lyricCandidatesChanged();
+    if (m_selected.isValid()) {
+        m_selected = LyricCandidate();
+        emit selectedCandidateChanged();
+    }
 }
 
 void Lyrics::scheduleLoad() {


### PR DESCRIPTION


https://github.com/user-attachments/assets/849d81a0-c49c-41a2-bf9e-d4ff38904929




play a song that has lyrics, skip to one that doesn't, then go back to the first one the lyrics never load and "Loading lyrics..." just spins until you change songs again.

clearCandidates() clears the candidate list but leaves the selection pointing into it. doLoad() sets loading true and then restores the track's saved backend/id through setSelectedCandidate(), which dedups on equality and returns without doing anything if that candidate is already selected. nothing clears loading after that.

LyricCandidate compares by backend + id only, so leaving a track and coming back is enough for the restored candidate to still match what's selected. the song in between just has to not replace the selection, which one without lyrics doesn't.

selection is cleared along with the candidates now. saved preferences aren't affected, persistTrackPrefs() only writes backend/id when the selection is valid.