### PR TITLE
fix(services): update more accurately the capslock state

### DIFF
--- a/services/Hypr.qml
+++ b/services/Hypr.qml
@@ -102,9 +102,9 @@ Singleton {
 
     function reloadDynamicConfs(): void {
         if (usingLua) {
-            extras.batchMessage(['eval hl.bind("Caps_Lock", hl.dsp.global("caelestia:refreshDevices"), { locked = true, non_consuming = true, ignore_mods = true, release = true })', 'eval hl.bind("Num_Lock", hl.dsp.global("caelestia:refreshDevices"), { locked = true, non_consuming = true, ignore_mods = true, release = true })']);
+            extras.batchMessage(['eval hl.bind("Caps_Lock", hl.dsp.global("caelestia:refreshDevices"), { locked = true, non_consuming = true, ignore_mods = true, release = true })', 'eval hl.bind("Num_Lock", hl.dsp.global("caelestia:refreshDevices"), { locked = true, non_consuming = true, ignore_mods = true, release = true })', 'eval hl.bind("Escape", hl.dsp.global("caelestia:refreshDevices"), { locked = true, non_consuming = true, ignore_mods = true, release = true })', 'eval hl.bind("Control_L", hl.dsp.global("caelestia:refreshDevices"), { locked = true, non_consuming = true, ignore_mods = true, release = true })']);
         } else {
-            extras.batchMessage(["keyword bindlni ,Caps_Lock,global,caelestia:refreshDevices", "keyword bindlni ,Num_Lock,global,caelestia:refreshDevices"]);
+            extras.batchMessage(["keyword bindlni ,Caps_Lock,global,caelestia:refreshDevices", "keyword bindlni ,Num_Lock,global,caelestia:refreshDevices", "keyword bindlni ,Escape,global,caelestia:refreshDevices", "keyword bindlni ,Control_L,global,caelestia:refreshDevices"]);
         }
     }
 


### PR DESCRIPTION
Fix capslock state not being updated with some kb_options (caps:escape_shifted_capslock and caps:ctrl_shifted_capslock)
(Fixes https://github.com/caelestia-dots/shell/issues/1898)

Those keyboard options put the caps lock input on the second level of your keyboard layout and put Escape or Control_L on the first level of the caps lock key so the current binds used to refresh the devices aren't triggered with those keyboard options, meaning that the state of capslock being changed isn't detected.

This commit fixes that by also binding Escape and Control_L to caelestia:refreshDevices to detect capslock being activated or disabled with those options.