### PR TITLE
feat(nexus): remember externally-picked wallpapers in a recent list

### DIFF
--- a/modules/nexus/pages/wallandstyle/WallpaperSelect.qml
+++ b/modules/nexus/pages/wallandstyle/WallpaperSelect.qml
@@ -83,6 +83,39 @@ PageBase {
 
         StyledText {
             Layout.topMargin: Tokens.spacing.large
+            text: qsTr("Recently used")
+            font: Tokens.font.title.small
+            visible: recentWalls.count > 0
+        }
+
+        GridLayout {
+            Layout.fillWidth: true
+            visible: recentWalls.count > 0
+
+            columns: Config.nexus.wallpapersPerRow
+            rowSpacing: Tokens.spacing.medium
+            columnSpacing: Tokens.spacing.large
+
+            Repeater {
+                id: recentWalls
+
+                model: Wallpapers.recent
+
+                WallItem {
+                    required property var modelData
+
+                    source: String(modelData.path)
+                    text: String(modelData.name)
+                    onClicked: {
+                        Wallpapers.setWallpaper(modelData.path);
+                        root.nState.closeSubPage();
+                    }
+                }
+            }
+        }
+
+        StyledText {
+            Layout.topMargin: Tokens.spacing.large
             text: qsTr("Local wallpapers")
             font: Tokens.font.title.small
         }

--- a/services/Wallpapers.qml
+++ b/services/Wallpapers.qml
@@ -21,6 +21,7 @@ Searcher {
     property string actualCurrent
     property bool previewColourLock
     property bool pendingPreviewClear
+    property var recent: []
 
     function getCategoryFor(w: FileSystemEntry): string {
         let category = w.parentDir.slice(Paths.wallsdir.length + 1);
@@ -35,7 +36,23 @@ Searcher {
 
     function setWallpaper(path: string): void {
         actualCurrent = path;
+        recordRecent(path);
         Quickshell.execDetached(["caelestia", "wallpaper", "-f", path, ...smartArg]);
+    }
+
+    function recordRecent(path: string): void {
+        if (path.startsWith(`${Paths.wallsdir}/`))
+            return;
+
+        const name = path.slice(path.lastIndexOf("/") + 1);
+        const filtered = root.recent.filter(e => e.path !== path);
+        root.recent = [
+            {
+                path,
+                name
+            },
+            ...filtered].slice(0, 12);
+        recentStorage.setText(JSON.stringify(root.recent));
     }
 
     function preview(path: string): void {
@@ -100,6 +117,22 @@ Searcher {
             root.actualCurrent = root.fallback;
             root.previewColourLock = false;
             Quickshell.execDetached(["caelestia", "wallpaper", "-f", root.fallback, ...root.smartArg]);
+        }
+    }
+
+    FileView {
+        id: recentStorage
+
+        path: `${Paths.state}/wallpaper/recent.json`
+        printErrors: false
+        onLoaded: {
+            root.recent = JSON.parse(text());
+        }
+        onLoadFailed: err => {
+            if (err === FileViewError.FileNotFound) {
+                root.recent = [];
+                Qt.callLater(() => setText("[]"));
+            }
         }
     }
 


### PR DESCRIPTION
The "Local wallpapers" grid only ever scans `Paths.wallsdir`, so a wallpaper picked via Browse from anywhere else applies fine but never reappears in the grid to be reselected. This tracks such picks in a small persisted MRU list (same FileView+JSON pattern `services/Notifs.qml` already uses for `notifs.json`) and renders it as its own "Recently used" section above "Local wallpapers", without touching the folder-scan behavior itself.

Verified locally: `qmlformat`, the repo's `qml-lint-conventions.py`, and `qmllint --import disable` (against a real local build's import paths) all pass clean on both changed files.