### PR TITLE
feat(lock): add toggleable password revealing

### DIFF
--- a/modules/lock/center/InputField.qml
+++ b/modules/lock/center/InputField.qml
@@ -13,6 +13,7 @@ Item {
 
     required property real centerScale
     required property Pam pam
+    property bool revealPassword: false
     readonly property alias placeholder: placeholder
     readonly property alias placeholderWidth: nonAnimPlaceholder.width
     property string buffer
@@ -78,6 +79,23 @@ Item {
         }
     }
 
+    StyledText {
+        anchors.centerIn: parent
+        anchors.horizontalCenterOffset: implicitWidth > root.width ? -(implicitWidth - root.width) / 2 : 0
+        text: root.buffer
+        color: Colours.palette.m3onSurface
+        font: placeholder.font
+
+        opacity: root.revealPassword ? 1 : 0
+        visible: opacity > 0
+
+        Behavior on opacity {
+            Anim {
+                type: Anim.DefaultEffects
+            }
+        }
+    }
+
     ListView {
         id: charList
 
@@ -103,6 +121,8 @@ Item {
         orientation: Qt.Horizontal
         spacing: Tokens.spacing.extraSmall
         interactive: false
+        opacity: root.revealPassword ? 0 : 1
+        visible: opacity > 0
 
         model: ScriptModel {
             values: root.buffer.split("")
@@ -114,6 +134,12 @@ Item {
             id: imWidthBehavior
 
             Anim {}
+        }
+
+        Behavior on opacity {
+            Anim {
+                type: Anim.DefaultEffects
+            }
         }
     }
 

--- a/modules/lock/center/PasswordInput.qml
+++ b/modules/lock/center/PasswordInput.qml
@@ -15,6 +15,23 @@ StyledRect {
     required property int centerWidth
     required property var lock
 
+    property bool revealPassword
+    readonly property string leadingIcon: {
+        if (revealPassword)
+            return "visibility";
+
+        if (lock.pam.fprint.tries >= GlobalConfig.lock.maxFprintTries) {
+            if (lock.pam.howdy.canAttempt)
+                return "face";
+            return "fingerprint_off";
+        }
+        if (lock.pam.fprint.active)
+            return "fingerprint";
+        if (lock.pam.howdy.canAttempt)
+            return "face";
+        return "lock";
+    }
+
     implicitWidth: {
         const w = centerWidth * 0.8;
         return lock.pam.buffer ? w : Math.min(w, inputField.placeholderWidth + iconWrapper.implicitWidth + enterButton.implicitWidth + input.spacing * 2 + Tokens.padding.medium * 2);
@@ -44,6 +61,15 @@ StyledRect {
         Anim {}
     }
 
+    Connections {
+        function onBufferChanged(): void {
+            if (!root.lock.pam.buffer)
+                root.revealPassword = false;
+        }
+
+        target: root.lock.pam
+    }
+
     StateLayer {
         hoverEnabled: false
         cursorShape: Qt.IBeamCursor
@@ -60,13 +86,16 @@ StyledRect {
         Item {
             id: iconWrapper
 
+            readonly property bool isPasswordIcon: root.leadingIcon === "lock" || root.leadingIcon === "visibility"
+            readonly property bool isPamLoading: root.lock.pam.passwd.active || root.lock.pam.howdy.active
+
             Layout.fillHeight: true
             implicitWidth: height
 
             AnimLoader {
                 anchors.centerIn: parent
                 anchors.verticalCenterOffset: sourceComponent === iconComp ? 1 : 0
-                sourceComp: root.lock.pam.passwd.active || root.lock.pam.howdy.active ? loadingComp : iconComp
+                sourceComp: iconWrapper.isPamLoading ? loadingComp : iconComp
             }
 
             Component {
@@ -74,21 +103,17 @@ StyledRect {
 
                 MaterialIcon {
                     animate: true
-                    text: {
-                        if (root.lock.pam.fprint.tries >= GlobalConfig.lock.maxFprintTries) {
-                            if (root.lock.pam.howdy.canAttempt)
-                                return "face";
-                            return "fingerprint_off";
-                        }
-                        if (root.lock.pam.fprint.active)
-                            return "fingerprint";
-                        if (root.lock.pam.howdy.canAttempt)
-                            return "face";
-                        return "lock";
-                    }
+                    text: root.leadingIcon
                     color: !root.lock.pam.howdy.canAttempt && root.lock.pam.fprint.tries >= GlobalConfig.lock.maxFprintTries ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
                     fontStyle: Tokens.font.icon.builders.medium.scale(root.centerScale).build()
                     fill: text === "face"
+                    scale: iconWrapper.isPasswordIcon && visibilityLayer.containsMouse ? 1.1 : 1
+
+                    Behavior on scale {
+                        Anim {
+                            type: Anim.FastSpatial
+                        }
+                    }
                 }
             }
 
@@ -97,6 +122,20 @@ StyledRect {
 
                 LoadingIndicator {
                     implicitSize: iconWrapper.height - Tokens.padding.small * 2
+                }
+            }
+
+            StateLayer {
+                id: visibilityLayer
+
+                anchors.fill: parent
+                radius: root.radius
+                visible: !iconWrapper.isPamLoading && iconWrapper.isPasswordIcon
+                cursorShape: Qt.PointingHandCursor
+
+                onClicked: {
+                    root.revealPassword = !root.revealPassword;
+                    root.forceActiveFocus();
                 }
             }
         }
@@ -109,6 +148,7 @@ StyledRect {
 
             centerScale: root.centerScale
             pam: root.lock.pam
+            revealPassword: root.revealPassword
         }
 
         Item {


### PR DESCRIPTION
## Summary

Introduces a show/hide password toggle for the lock screen's input field.

Clicking the leading icon (when it's the password-related `lock` icon) now reveals the text input buffer, changing the icon to an eye (`visibility`). Clicking the icon again masks the input and reverts the icon back to `lock`. Password hiding is automatically re-enabled if the input field is cleared.

This allows users to verify their entered credentials easier.

Closes #1582.

## Testing

- Builds successfully
- Passed `qmlformat` and linting checks
- Properly shows/hides the input and changes the icon when clicking on it
- Re-enables password hiding when the input field is cleared