### PR TITLE
build: split out m3shapes

### DIFF
--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -29,7 +29,7 @@ jobs:
               sudo -u builder git clone https://aur.archlinux.org/yay-bin.git /home/builder/yay-bin && \
               cd /home/builder/yay-bin && \
               sudo -u builder makepkg -si --noconfirm && \
-              sudo -u builder yay -S --noconfirm quickshell-git libcava && \
+              sudo -u builder yay -S --noconfirm quickshell-git libcava qt6-m3shapes-git && \
               sudo -u builder yay -Yc --noconfirm && \
               pacman -Rns --noconfirm yay-bin && \
               sed -i '/builder ALL=(ALL) NOPASSWD:ALL/d' /etc/sudoers && \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 
 set(DISTRIBUTOR "Unset" CACHE STRING "Distributor")
-set(ENABLE_MODULES "extras;plugin;shell;m3shapes" CACHE STRING "Modules to build/install")
+set(ENABLE_MODULES "extras;plugin;shell" CACHE STRING "Modules to build/install")
 set(INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/caelestia" CACHE STRING "Library install dir")
 set(INSTALL_QMLDIR "${CMAKE_INSTALL_LIBDIR}/qt6/qml" CACHE STRING "QML install dir")
 set(INSTALL_QSCONFDIR "${CMAKE_INSTALL_SYSCONFDIR}/xdg/quickshell/caelestia" CACHE STRING "Quickshell config install dir")
@@ -77,23 +77,4 @@ if("shell" IN_LIST ENABLE_MODULES)
     install(FILES "${CMAKE_BINARY_DIR}/qml/shell.qml" DESTINATION "${INSTALL_QSCONFDIR}")
 
     install(FILES LICENSE DESTINATION "${INSTALL_QSCONFDIR}")
-endif()
-
-if("m3shapes" IN_LIST ENABLE_MODULES)
-    message(STATUS "Fetching M3Shapes module")
-    include(FetchContent)
-    set(M3SHAPES_REV bdc327b29f95394a732baf3c9b19658ba23755b6)
-    FetchContent_Declare(
-        m3shapes_external
-        GIT_REPOSITORY https://github.com/soramanew/m3shapes.git
-        GIT_TAG        ${M3SHAPES_REV}
-        SOURCE_DIR     "${CMAKE_BINARY_DIR}/_deps/m3shapes-${M3SHAPES_REV}"
-    )
-    FetchContent_MakeAvailable(m3shapes_external)
-    message(STATUS "Done fetching M3Shapes module")
-
-    # Fix m3shapes wrong rpath
-    if(TARGET m3shapesplugin)
-        set_target_properties(m3shapesplugin PROPERTIES INSTALL_RPATH "$ORIGIN")
-    endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Dependencies:
 -   `qt6-base`
 -   `qt6-declarative`
 -   `qt6-imageformats`
+-   [`qt6-m3shapes-git`](https://github.com/soramanew/m3shapes)
 -   [`swappy`](https://github.com/jtheoof/swappy)
 -   [`fish`](https://github.com/fish-shell/fish-shell)
 -   [`bash`](https://www.gnu.org/software/bash)

--- a/flake.lock
+++ b/flake.lock
@@ -22,19 +22,23 @@
       }
     },
     "m3shapes": {
-      "flake": false,
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1781017666,
-        "narHash": "sha256-kfHyzZaPHgqZML48OA+5JwBOsLdQJ2ci/aGPShvUB4Y=",
+        "lastModified": 1787906858,
+        "narHash": "sha256-YZelgEZflFNwGutX4/tIzBdbOeghJgE2oDw0uWYGxns=",
         "owner": "soramanew",
         "repo": "m3shapes",
-        "rev": "bdc327b29f95394a732baf3c9b19658ba23755b6",
+        "rev": "32ad9ce328bb77ed349b40a3be10ee9ea610b8ab",
         "type": "github"
       },
       "original": {
         "owner": "soramanew",
         "repo": "m3shapes",
-        "rev": "bdc327b29f95394a732baf3c9b19658ba23755b6",
+        "rev": "32ad9ce328bb77ed349b40a3be10ee9ea610b8ab",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,8 @@
     };
 
     m3shapes = {
-      url = "github:soramanew/m3shapes/bdc327b29f95394a732baf3c9b19658ba23755b6";
-      flake = false;
+      url = "github:soramanew/m3shapes/32ad9ce328bb77ed349b40a3be10ee9ea610b8ab";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
@@ -38,7 +38,6 @@
       pkgs = pkgsOf.${system};
     in rec {
       caelestia-shell = pkgs.callPackage ./nix {
-        inherit (inputs) m3shapes;
         rev = self.rev or self.dirtyRev;
         stdenv = pkgs.clangStdenv;
         quickshell = inputs.quickshell.packages.${system}.default.override {
@@ -46,6 +45,7 @@
           withI3 = false;
         };
         caelestia-cli = inputs.caelestia-cli.packages.${system}.default;
+        m3shapes = inputs.m3shapes.packages.${system}.default;
       };
       with-cli = caelestia-shell.override {withCli = true;};
       debug = caelestia-shell.override {debug = true;};
@@ -59,7 +59,7 @@
         mkShell = pkgs.mkShell.override {stdenv = shell.stdenv;};
       in
         mkShell {
-          inputsFrom = [shell shell.plugin shell.extras shell.m3shapesModule];
+          inputsFrom = [shell shell.plugin shell.extras];
           packages = with pkgs; [clazy material-symbols rubik nerd-fonts.caskaydia-cove];
           CAELESTIA_XKB_RULES_PATH = "${pkgs.xkeyboard-config}/share/xkeyboard-config-2/rules/base.lst";
         };

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -35,7 +35,7 @@
 }: let
   version = "1.0.0";
 
-  qs = quickshell.withModules [qt6.qtimageformats];
+  qs = quickshell.withModules [qt6.qtimageformats m3shapes];
 
   runtimeDeps =
     [
@@ -67,9 +67,6 @@
     (lib.cmakeFeature "GIT_REVISION" rev)
     (lib.cmakeFeature "DISTRIBUTOR" "nix-flake")
   ];
-
-  # The build sandbox has no network access so add it as a flake input instead
-  m3shapesFlag = lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_M3SHAPES_EXTERNAL" "${m3shapes}";
 
   extras = stdenv.mkDerivation {
     inherit cmakeBuildType;
@@ -108,27 +105,6 @@
       ]
       ++ cmakeVersionFlags;
   };
-
-  m3shapesModule = stdenv.mkDerivation {
-    inherit cmakeBuildType;
-    name = "caelestia-m3shapes${lib.optionalString debug "-debug"}";
-    src = lib.fileset.toSource {
-      root = ./..;
-      fileset = ./../CMakeLists.txt;
-    };
-
-    nativeBuildInputs = [cmake ninja];
-    buildInputs = [qt6.qtbase qt6.qtdeclarative];
-
-    dontWrapQtApps = true;
-    cmakeFlags =
-      [
-        (lib.cmakeFeature "ENABLE_MODULES" "m3shapes")
-        (lib.cmakeFeature "INSTALL_QMLDIR" qt6.qtbase.qtQmlPrefix)
-        m3shapesFlag
-      ]
-      ++ cmakeVersionFlags;
-  };
 in
   stdenv.mkDerivation {
     inherit version cmakeBuildType;
@@ -136,7 +112,7 @@ in
     src = ./..;
 
     nativeBuildInputs = [cmake ninja makeWrapper qt6.wrapQtAppsHook];
-    buildInputs = [qs extras plugin m3shapesModule xkeyboard-config qt6.qtbase];
+    buildInputs = [qs extras plugin xkeyboard-config qt6.qtbase];
     propagatedBuildInputs = runtimeDeps;
 
     cmakeFlags =
@@ -168,7 +144,7 @@ in
     '';
 
     passthru = {
-      inherit plugin extras m3shapesModule;
+      inherit plugin extras;
     };
 
     meta = {


### PR DESCRIPTION
Don't bundle m3shapes with the shell, require it as a dependency instead.
This PR is mainly Nix related changes to update the m3shapes handling to use its flake instead.