### PR TITLE
fix(services): resolve usingLua detection for Hyprland Lua parser

### DIFF
--- a/plugin/src/Caelestia/Services/hyprextras.cpp
+++ b/plugin/src/Caelestia/Services/hyprextras.cpp
@@ -38,6 +38,14 @@ HyprExtras::HyprExtras(QObject* parent)
     m_requestSocket = hyprDir + "/.socket.sock";
     m_eventSocket = hyprDir + "/.socket2.sock";
 
+    const auto hyprConfig = qEnvironmentVariable("HYPRLAND_CONFIG");
+    if (!hyprConfig.isEmpty()) {
+        m_usingLua = hyprConfig.endsWith(QLatin1String(".lua"));
+    } else {
+        const QString home = QDir::homePath();
+        m_usingLua = QFile::exists(home + QLatin1String("/.config/hypr/hyprland.lua"));
+    }
+
     refreshOptions();
     refreshDevices();
 

--- a/services/Hypr.qml
+++ b/services/Hypr.qml
@@ -14,7 +14,7 @@ Singleton {
     readonly property var toplevels: Hyprland.toplevels
     readonly property var workspaces: Hyprland.workspaces
     readonly property var monitors: Hyprland.monitors
-    readonly property bool usingLua: Hyprland.usingLua
+    readonly property bool usingLua: extras.usingLua
 
     readonly property HyprlandToplevel activeToplevel: {
         const t = Hyprland.activeToplevel;
@@ -208,7 +208,5 @@ Singleton {
 
     HyprExtras {
         id: extras
-
-        usingLua: Hyprland.usingLua
     }
 }


### PR DESCRIPTION
**Summary**

    Fixes `usingLua` detection so that dynamic configuration options (such as Game Mode and dynamic colors) execute via   `eval hl.config(...)` on Hyprland Lua setups instead of being rejected as legacy `keyword` commands.
  
**Changes**

    - Auto-detects Lua configuration in `HyprExtras` by checking `$HYPRLAND_CONFIG` and `~/.config/hypr/hyprland.lua`.    
    - Binds `usingLua: extras.usingLua` in `services/Hypr.qml`.
    - Ensures `HyprExtras::applyOptions()` reliably sends `eval hl.config(...)` when Lua is active.
  
**Notes**

    - Tested with Hyprland Lua (Game Mode options apply live).
    - Fully backwards-compatible with legacy `.conf` setups.
    - Passes all formatting and convention checks (0 violations).
  
  

https://github.com/user-attachments/assets/b96ecf75-ad23-45e4-9382-2240da616a12

### Additional note
you cant quite see the workspace change as its the same terminal twice in game mode, watch twice and youll understand