### PR TITLE
fix(config): include subconfig headers in rootnodes.hpp

### DIFF
--- a/plugin/src/Caelestia/Config/rootnodes.hpp
+++ b/plugin/src/Caelestia/Config/rootnodes.hpp
@@ -7,26 +7,25 @@
 #include "settings/rootnode.hpp"
 #include "common.hpp"
 
-namespace caelestia::config {
+#include "appearanceconfig.hpp"
+#include "backgroundconfig.hpp"
+#include "barconfig.hpp"
+#include "borderconfig.hpp"
+#include "dashboardconfig.hpp"
+#include "generalconfig.hpp"
+#include "launcherconfig.hpp"
+#include "lockconfig.hpp"
+#include "nexusconfig.hpp"
+#include "notifsconfig.hpp"
+#include "osdconfig.hpp"
+#include "serviceconfig.hpp"
+#include "sessionconfig.hpp"
+#include "sidebarconfig.hpp"
+#include "tokens.hpp"
+#include "userpaths.hpp"
+#include "utilitiesconfig.hpp"
 
-class AppearanceConfig;
-class AppearanceTokens;
-class BackgroundConfig;
-class BarConfig;
-class BorderConfig;
-class DashboardConfig;
-class GeneralConfig;
-class LauncherConfig;
-class LockConfig;
-class NexusConfig;
-class NotifsConfig;
-class OsdConfig;
-class ServiceConfig;
-class SessionConfig;
-class SidebarConfig;
-class SizeTokens;
-class UserPaths;
-class UtilitiesConfig;
+namespace caelestia::config {
 
 Q_MOC_INCLUDE("appearanceconfig.hpp")
 Q_MOC_INCLUDE("backgroundconfig.hpp")

--- a/plugin/src/Caelestia/Config/rootnodes.hpp
+++ b/plugin/src/Caelestia/Config/rootnodes.hpp
@@ -5,12 +5,11 @@
 
 #include "settings/layerregistry.hpp"
 #include "settings/rootnode.hpp"
-#include "common.hpp"
-
 #include "appearanceconfig.hpp"
 #include "backgroundconfig.hpp"
 #include "barconfig.hpp"
 #include "borderconfig.hpp"
+#include "common.hpp"
 #include "dashboardconfig.hpp"
 #include "generalconfig.hpp"
 #include "launcherconfig.hpp"


### PR DESCRIPTION
### What this PR does
Restores `#include` directives for subconfig headers in `rootnodes.hpp` instead of forward declarations.

### Why
The forward declarations introduced in `rootnodes.hpp` break compilation for external translation units including it (such as `tokensattached.cpp`). The `CONFIG_SUBOBJECT` macro expands to `makeSubobject<T>()`, which invokes `new T(...)` and fails on incomplete types.

<details>
<summary>Compiler error log</summary>

FAILED: [code=1] plugin/src/Caelestia/Config/CMakeFiles/caelestia-config.dir/tokensattached.cpp.o 
In file included from plugin/src/Caelestia/Config/common.hpp:6,
                 from plugin/src/Caelestia/Config/appearanceconfig.hpp:8,
                 from plugin/src/Caelestia/Config/tokensattached.hpp:8,
                 from plugin/src/Caelestia/Config/tokensattached.cpp:1:
build/plugin/src/Caelestia/Settings/include/settings/macros.hpp: In instantiation of 'T* caelestia::settings::detail::makeSubobject(Args&& ...) [with T = caelestia::config::GeneralConfig; Args = {caelestia::config::GeneralConfig*, caelestia::config::ConfigRoot*, bool}]':
plugin/src/Caelestia/Config/rootnodes.hpp:55:5:   required from here
  120 |         caelestia::settings::detail::makeSubobject<Type>(fallbackValue(&Self::m_##name, nullptr), this, global);       \
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
build/plugin/src/Caelestia/Settings/include/settings/macros.hpp:40:12: error: invalid use of incomplete type 'class caelestia::config::GeneralConfig'
   40 |     return new T(std::forward<Args>(args)...);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from plugin/src/Caelestia/Config/tokensattached.hpp:10:
plugin/src/Caelestia/Config/rootnodes.hpp:18:7: note: forward declaration of 'class caelestia::config::GeneralConfig'
   18 | class GeneralConfig;
      |       ^~~~~~~~~~~~~      