### PR TITLE
fix(bar): follow the default route when picking the network icon

### DIFF
--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -119,10 +119,56 @@ StyledRect {
                 DelegateChoice {
                     roleValue: "network"
                     delegate: EntryWrapper {
-                        MaterialIcon {
-                            animate: true
-                            text: Nmcli.activeEthernet ? "cable" : Nmcli.active ? Icons.getNetworkIcon(Nmcli.active.strength ?? 0) : "wifi_off"
-                            color: root.colour
+                        Item {
+                            implicitWidth: networkIcon.implicitWidth
+                            implicitHeight: networkIcon.implicitHeight
+
+                            MaterialIcon {
+                                id: networkIcon
+
+                                animate: true
+                                text: Nmcli.onEthernet ? "cable" : Nmcli.active ? Icons.getNetworkIcon(Nmcli.active.strength ?? 0) : "wifi_off"
+                                color: root.colour
+                            }
+
+                            // A tunnel doesn't replace the link, it sits on top
+                            // of it - so this badges the icon that's already
+                            // saying which link, rather than taking its place.
+                            // The enabled check comes first deliberately:
+                            // reading VPN otherwise starts the service for
+                            // someone who has it turned off.
+                            StyledRect {
+                                id: vpnBadge
+
+                                anchors.left: parent.left
+                                anchors.top: parent.top
+                                anchors.leftMargin: -implicitWidth / 4
+                                anchors.topMargin: -implicitHeight / 4
+
+                                implicitWidth: vpnIcon.implicitHeight
+                                implicitHeight: implicitWidth
+
+                                radius: Tokens.rounding.full
+                                // Backed so the glyph stays legible over the
+                                // icon underneath it.
+                                color: Colours.tPalette.m3surfaceContainer
+                                visible: opacity > 0
+                                opacity: GlobalConfig.utilities.vpn.enabled && (VPN.connected || VPN.connecting) ? 1 : 0
+
+                                Behavior on opacity {
+                                    Anim {}
+                                }
+
+                                MaterialIcon {
+                                    id: vpnIcon
+
+                                    anchors.centerIn: parent
+                                    text: VPN.connecting ? "more_horiz" : "vpn_key"
+                                    color: root.colour
+                                    fontStyle: Tokens.font.icon.builders.small.scale(0.5).build()
+                                    fill: 1
+                                }
+                            }
                         }
                     }
                 }

--- a/modules/bar/popouts/Content.qml
+++ b/modules/bar/popouts/Content.qml
@@ -42,7 +42,7 @@ Item {
             name: "network"
             sourceComponent: Network {
                 popouts: root.popouts
-                view: Nmcli.activeEthernet ? "ethernet" : "wireless"
+                view: Nmcli.onEthernet ? "ethernet" : "wireless"
             }
         }
 

--- a/plugin/src/Caelestia/Config/enums.hpp
+++ b/plugin/src/Caelestia/Config/enums.hpp
@@ -25,6 +25,7 @@ ENUM(GpuType, Auto, Nvidia, Generic, None)
 ENUM(NotifsFullscreen, On, Off)
 ENUM(TemperatureUnit, Celsius, Fahrenheit, Kelvin)
 ENUM(DataUnit, Binary, Decimal)
+ENUM(NetworkTransport, None, Ethernet, Wifi, Other)
 
 #undef ENUM
 

--- a/plugin/src/Caelestia/Services/CMakeLists.txt
+++ b/plugin/src/Caelestia/Services/CMakeLists.txt
@@ -18,6 +18,7 @@ qml_module(caelestia-services
         lyrics.cpp
         sessionmanager.cpp
         networkusage.cpp
+        networkroute.cpp
         hyprdevices.cpp
         hyprextras.cpp
     LIBRARIES

--- a/plugin/src/Caelestia/Services/networkroute.cpp
+++ b/plugin/src/Caelestia/Services/networkroute.cpp
@@ -1,0 +1,341 @@
+#include "networkroute.hpp"
+
+#include <qdbusargument.h>
+#include <qdbusextratypes.h>
+#include <qdbusmessage.h>
+#include <qdbuspendingcall.h>
+#include <qdbuspendingreply.h>
+#include <qdbusreply.h>
+#include <qloggingcategory.h>
+#include <qtimer.h>
+
+#include <utility>
+
+namespace {
+
+Q_LOGGING_CATEGORY(lcNetworkRoute, "caelestia.services.networkroute", QtWarningMsg)
+
+} // namespace
+
+namespace caelestia::services {
+
+using Qt::StringLiterals::operator""_s;
+
+namespace {
+
+const QString k_service = u"org.freedesktop.NetworkManager"_s;
+const QString k_managerPath = u"/org/freedesktop/NetworkManager"_s;
+const QString k_managerIface = u"org.freedesktop.NetworkManager"_s;
+const QString k_activeIface = u"org.freedesktop.NetworkManager.Connection.Active"_s;
+const QString k_deviceIface = u"org.freedesktop.NetworkManager.Device"_s;
+const QString k_propsIface = u"org.freedesktop.DBus.Properties"_s;
+
+const QString k_busService = u"org.freedesktop.DBus"_s;
+const QString k_busPath = u"/org/freedesktop/DBus"_s;
+
+// From NMDeviceType; only the two we classify are named.
+constexpr uint k_deviceTypeEthernet = 1;
+constexpr uint k_deviceTypeWifi = 2;
+
+} // namespace
+
+bool NetworkRoute::Snapshot::operator==(const Snapshot& o) const noexcept {
+    return primary == o.primary && ipv4 == o.ipv4 && ipv6 == o.ipv6 && primaryInterface == o.primaryInterface;
+}
+
+NetworkRoute::NetworkRoute(QObject* parent)
+    : QObject(parent) {
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    // NetworkManager may not be up yet, or may restart under us.
+    bus->connect(k_busService, k_busPath, k_busService, u"NameOwnerChanged"_s, u"sss"_s, this,
+        SLOT(handleNameOwnerChanged(QString, QString, QString)));
+
+    watchObject(k_managerPath);
+    scheduleRefresh();
+}
+
+bool NetworkRoute::ready() const {
+    return m_ready;
+}
+
+Transport NetworkRoute::primaryTransport() const {
+    return m_current.primary;
+}
+
+Transport NetworkRoute::ipv4Transport() const {
+    return m_current.ipv4;
+}
+
+Transport NetworkRoute::ipv6Transport() const {
+    return m_current.ipv6;
+}
+
+bool NetworkRoute::mixed() const {
+    const auto v4 = m_current.ipv4;
+    const auto v6 = m_current.ipv6;
+    return v4 != config::NetworkTransport::None && v6 != config::NetworkTransport::None && v4 != v6;
+}
+
+QString NetworkRoute::primaryInterface() const {
+    return m_current.primaryInterface;
+}
+
+std::optional<QDBusConnection> NetworkRoute::systemBus() {
+    auto bus = QDBusConnection::systemBus();
+    if (!bus.isConnected()) {
+        qCWarning(lcNetworkRoute) << "System bus unavailable";
+        return std::nullopt;
+    }
+    return bus;
+}
+
+Transport NetworkRoute::transportForDeviceType(uint deviceType) {
+    switch (deviceType) {
+    case k_deviceTypeEthernet:
+        return config::NetworkTransport::Ethernet;
+    case k_deviceTypeWifi:
+        return config::NetworkTransport::Wifi;
+    default:
+        return config::NetworkTransport::Other;
+    }
+}
+
+// Subscribes to property changes on an object once. NetworkManager emits these
+// for the manager, every active connection and every device, which is what
+// tells us a walk is out of date.
+void NetworkRoute::watchObject(const QString& path) {
+    if (path.isEmpty() || path == u"/"_s || m_watched.contains(path)) {
+        return;
+    }
+
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    if (bus->connect(k_service, path, k_propsIface, u"PropertiesChanged"_s, this,
+            SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
+        m_watched.insert(path);
+    }
+}
+
+void NetworkRoute::handlePropertiesChanged(
+    const QString& iface, const QVariantMap& properties, const QStringList& invalidated) {
+    Q_UNUSED(properties);
+    Q_UNUSED(invalidated);
+
+    if (iface == k_managerIface || iface == k_activeIface || iface == k_deviceIface) {
+        scheduleRefresh();
+    }
+}
+
+void NetworkRoute::handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner) {
+    Q_UNUSED(oldOwner);
+
+    if (name != k_service) {
+        return;
+    }
+
+    if (newOwner.isEmpty()) {
+        // NetworkManager went away; report nothing rather than stale state.
+        m_watched.clear();
+        m_ready = false;
+        m_current = Snapshot();
+        emit changed();
+        return;
+    }
+
+    // Fresh objects on the new owner, so the old subscriptions are worthless.
+    m_watched.clear();
+    watchObject(k_managerPath);
+    scheduleRefresh();
+}
+
+// Signals arrive in bursts - a connection going up touches the manager, the
+// active connection and its device in quick succession. Coalescing them means
+// one walk per burst instead of several racing ones.
+void NetworkRoute::scheduleRefresh() {
+    if (m_refreshing) {
+        m_refreshQueued = true;
+        return;
+    }
+
+    m_refreshing = true;
+    QTimer::singleShot(0, this, &NetworkRoute::refresh);
+}
+
+void NetworkRoute::refresh() {
+    m_building = Snapshot();
+    m_primaryConnection.clear();
+    m_connIsDefault4.clear();
+    m_connIsDefault6.clear();
+    m_connTransport.clear();
+    m_connInterface.clear();
+    m_pending = 0;
+
+    readManager();
+}
+
+// Each async read holds a reference; the snapshot is applied when the last one
+// lands, so a partial walk is never published.
+void NetworkRoute::step(int delta) {
+    m_pending += delta;
+    if (m_pending > 0) {
+        return;
+    }
+
+    Snapshot snapshot;
+    snapshot.primaryInterface = m_connInterface.value(m_primaryConnection);
+    snapshot.primary = m_connTransport.value(m_primaryConnection, config::NetworkTransport::None);
+
+    for (auto it = m_connIsDefault4.cbegin(); it != m_connIsDefault4.cend(); ++it) {
+        if (it.value()) {
+            snapshot.ipv4 = m_connTransport.value(it.key(), config::NetworkTransport::None);
+            break;
+        }
+    }
+    for (auto it = m_connIsDefault6.cbegin(); it != m_connIsDefault6.cend(); ++it) {
+        if (it.value()) {
+            snapshot.ipv6 = m_connTransport.value(it.key(), config::NetworkTransport::None);
+            break;
+        }
+    }
+
+    finishRefresh(snapshot);
+}
+
+void NetworkRoute::finishRefresh(const Snapshot& snapshot) {
+    const bool wasReady = m_ready;
+    m_ready = true;
+
+    if (!wasReady || !(snapshot == m_current)) {
+        m_current = snapshot;
+        emit changed();
+    }
+
+    m_refreshing = false;
+    if (m_refreshQueued) {
+        m_refreshQueued = false;
+        scheduleRefresh();
+    }
+}
+
+void NetworkRoute::readManager() {
+    const auto bus = systemBus();
+    if (!bus) {
+        finishRefresh(Snapshot());
+        return;
+    }
+
+    auto msg = QDBusMessage::createMethodCall(k_service, k_managerPath, k_propsIface, u"GetAll"_s);
+    msg << k_managerIface;
+
+    step(1);
+    auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* call) {
+        call->deleteLater();
+
+        const QDBusPendingReply<QVariantMap> reply = *call;
+        if (reply.isError()) {
+            qCWarning(lcNetworkRoute) << "Failed to read NetworkManager properties:" << reply.error().message();
+            step(-1);
+            return;
+        }
+
+        const auto props = reply.value();
+        m_primaryConnection = props.value(u"PrimaryConnection"_s).value<QDBusObjectPath>().path();
+
+        const auto actives = props.value(u"ActiveConnections"_s).value<QDBusArgument>();
+        QList<QDBusObjectPath> paths;
+        actives >> paths;
+
+        for (const auto& path : std::as_const(paths)) {
+            readActiveConnection(path.path(), path.path() == m_primaryConnection);
+        }
+
+        step(-1);
+    });
+}
+
+void NetworkRoute::readActiveConnection(const QString& path, bool isPrimary) {
+    Q_UNUSED(isPrimary);
+
+    const auto bus = systemBus();
+    if (!bus || path.isEmpty() || path == u"/"_s) {
+        return;
+    }
+
+    watchObject(path);
+
+    auto msg = QDBusMessage::createMethodCall(k_service, path, k_propsIface, u"GetAll"_s);
+    msg << k_activeIface;
+
+    step(1);
+    auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, path](QDBusPendingCallWatcher* call) {
+        call->deleteLater();
+
+        const QDBusPendingReply<QVariantMap> reply = *call;
+        if (reply.isError()) {
+            // Connections come and go while we're walking; that's expected.
+            qCDebug(lcNetworkRoute) << "Skipping active connection" << path << ":" << reply.error().message();
+            step(-1);
+            return;
+        }
+
+        const auto props = reply.value();
+        m_connIsDefault4.insert(path, props.value(u"Default"_s).toBool());
+        m_connIsDefault6.insert(path, props.value(u"Default6"_s).toBool());
+
+        const auto devices = props.value(u"Devices"_s).value<QDBusArgument>();
+        QList<QDBusObjectPath> paths;
+        devices >> paths;
+
+        // A connection's devices are its stack bottom-up, so the first one is
+        // the link the traffic actually goes over. A VPN's active connection
+        // has no devices of its own beyond its tunnel, which classifies as
+        // Other and leaves the underlying connection to answer for the link.
+        if (!paths.isEmpty()) {
+            readDevice(path, paths.first().path());
+        }
+
+        step(-1);
+    });
+}
+
+void NetworkRoute::readDevice(const QString& connPath, const QString& devicePath) {
+    const auto bus = systemBus();
+    if (!bus || devicePath.isEmpty() || devicePath == u"/"_s) {
+        return;
+    }
+
+    watchObject(devicePath);
+
+    auto msg = QDBusMessage::createMethodCall(k_service, devicePath, k_propsIface, u"GetAll"_s);
+    msg << k_deviceIface;
+
+    step(1);
+    auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, connPath](QDBusPendingCallWatcher* call) {
+        call->deleteLater();
+
+        const QDBusPendingReply<QVariantMap> reply = *call;
+        if (reply.isError()) {
+            qCDebug(lcNetworkRoute) << "Skipping device for" << connPath << ":" << reply.error().message();
+            step(-1);
+            return;
+        }
+
+        const auto props = reply.value();
+        m_connTransport.insert(connPath, transportForDeviceType(props.value(u"DeviceType"_s).toUInt()));
+        m_connInterface.insert(connPath, props.value(u"Interface"_s).toString());
+
+        step(-1);
+    });
+}
+
+} // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkroute.cpp
+++ b/plugin/src/Caelestia/Services/networkroute.cpp
@@ -259,6 +259,7 @@ void NetworkRoute::readManager() {
 
         step(-1);
     });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 void NetworkRoute::readActiveConnection(const QString& path, bool isPrimary) {
@@ -305,6 +306,7 @@ void NetworkRoute::readActiveConnection(const QString& path, bool isPrimary) {
 
         step(-1);
     });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 void NetworkRoute::readDevice(const QString& connPath, const QString& devicePath) {
@@ -336,6 +338,7 @@ void NetworkRoute::readDevice(const QString& connPath, const QString& devicePath
 
         step(-1);
     });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 } // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkroute.hpp
+++ b/plugin/src/Caelestia/Services/networkroute.hpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <qdbusconnection.h>
+#include <qhash.h>
+#include <qobject.h>
+#include <qqmlintegration.h>
+#include <qset.h>
+#include <qstring.h>
+#include <qstringlist.h>
+#include <qvariant.h>
+
+#include <optional>
+
+#include "config/enums.hpp"
+
+namespace caelestia::services {
+
+using Transport = config::NetworkTransport::Enum;
+
+// Which kind of link the system is actually routing through, read from
+// NetworkManager rather than reconstructed from the routing table.
+//
+// "Is a cable plugged in" and "is traffic going over it" are different
+// questions, and the routing table alone can't answer the second one either:
+// a VPN owns the default route while the traffic underneath it still leaves
+// over ethernet or wifi. NetworkManager already tracks this - the primary
+// connection, and which active connection holds the v4 and v6 defaults - so
+// this follows those to their devices and classifies them by device type.
+class NetworkRoute : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+    // False until a full snapshot has been read; consumers should keep their
+    // previous behaviour until then rather than acting on empty state.
+    Q_PROPERTY(bool ready READ ready NOTIFY changed)
+    Q_PROPERTY(caelestia::config::NetworkTransport::Enum primaryTransport READ primaryTransport NOTIFY changed)
+    Q_PROPERTY(caelestia::config::NetworkTransport::Enum ipv4Transport READ ipv4Transport NOTIFY changed)
+    Q_PROPERTY(caelestia::config::NetworkTransport::Enum ipv6Transport READ ipv6Transport NOTIFY changed)
+    // True when v4 and v6 both have a default and they're on different kinds
+    // of link, so a UI showing a single icon can tell it's simplifying.
+    Q_PROPERTY(bool mixed READ mixed NOTIFY changed)
+    Q_PROPERTY(QString primaryInterface READ primaryInterface NOTIFY changed)
+
+public:
+    explicit NetworkRoute(QObject* parent = nullptr);
+
+    [[nodiscard]] bool ready() const;
+    [[nodiscard]] Transport primaryTransport() const;
+    [[nodiscard]] Transport ipv4Transport() const;
+    [[nodiscard]] Transport ipv6Transport() const;
+    [[nodiscard]] bool mixed() const;
+    [[nodiscard]] QString primaryInterface() const;
+
+signals:
+    void changed();
+
+private slots:
+    void handlePropertiesChanged(const QString& iface, const QVariantMap& properties, const QStringList& invalidated);
+    void handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner);
+
+private:
+    struct Snapshot {
+        Transport primary = Transport::None;
+        Transport ipv4 = Transport::None;
+        Transport ipv6 = Transport::None;
+        QString primaryInterface;
+
+        bool operator==(const Snapshot& o) const noexcept;
+    };
+
+    // One refresh at a time, with a flag to run again afterwards. Bursts of
+    // NetworkManager signals would otherwise each start their own walk of the
+    // object tree and land out of order.
+    void scheduleRefresh();
+    void refresh();
+    void finishRefresh(const Snapshot& snapshot);
+
+    void readManager();
+    void readActiveConnection(const QString& path, bool isPrimary);
+    void readDevice(const QString& connPath, const QString& devicePath);
+    void step(int delta);
+
+    void watchObject(const QString& path);
+
+    [[nodiscard]] static std::optional<QDBusConnection> systemBus();
+    [[nodiscard]] static Transport transportForDeviceType(uint deviceType);
+
+    bool m_ready = false;
+    Snapshot m_current;
+
+    bool m_refreshing = false;
+    bool m_refreshQueued = false;
+    int m_pending = 0;
+
+    // State being assembled by the in-flight refresh.
+    Snapshot m_building;
+    QString m_primaryConnection;
+    QHash<QString, bool> m_connIsDefault4;
+    QHash<QString, bool> m_connIsDefault6;
+    QHash<QString, Transport> m_connTransport;
+    QHash<QString, QString> m_connInterface;
+    QSet<QString> m_watched;
+};
+
+} // namespace caelestia::services

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -5,6 +5,8 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import Caelestia.I18n
+import Caelestia.Config
+import Caelestia.Services
 
 Singleton {
     id: root
@@ -35,6 +37,15 @@ Singleton {
     property string ethernetSpeed: ""
     readonly property list<EthernetDevice> ethernetDevices: []
     readonly property EthernetDevice activeEthernet: ethernetDevices.find(d => d.connected) ?? null
+    // Whether traffic is actually leaving over a wired link, which isn't the
+    // same question as whether a cable is plugged in - with both a cable and
+    // wifi up, either can be carrying it. NetworkManager already tracks which
+    // connection is primary, so this follows that rather than guessing.
+    //
+    // Falls back to activeEthernet until a full snapshot has been read, so the
+    // icon doesn't flicker through a wrong state on startup or if
+    // NetworkManager isn't reachable.
+    readonly property bool onEthernet: NetworkRoute.ready ? NetworkRoute.primaryTransport === NetworkTransport.Ethernet : !!activeEthernet
     // True when at least one wired device has a carrier (cable plugged in).
     // nmcli reports "unavailable" for ethernet NICs with no link, so we treat
     // anything other than that as a usable connection.

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -42,10 +42,11 @@ Singleton {
     // wifi up, either can be carrying it. NetworkManager already tracks which
     // connection is primary, so this follows that rather than guessing.
     //
-    // Falls back to activeEthernet until a full snapshot has been read, so the
-    // icon doesn't flicker through a wrong state on startup or if
-    // NetworkManager isn't reachable.
-    readonly property bool onEthernet: NetworkRoute.ready ? NetworkRoute.primaryTransport === NetworkTransport.Ethernet : !!activeEthernet
+    // Only a definite answer is taken. Before the first snapshot has been read,
+    // and when the primary connection sits on a device that is neither wired
+    // nor wireless, this keeps the old behaviour rather than reporting wifi for
+    // something it couldn't classify.
+    readonly property bool onEthernet: NetworkRoute.primaryTransport === NetworkTransport.Ethernet || (NetworkRoute.primaryTransport !== NetworkTransport.Wifi && !!activeEthernet)
     // True when at least one wired device has a carrier (cable plugged in).
     // nmcli reports "unavailable" for ethernet NICs with no link, so we treat
     // anything other than that as a usable connection.


### PR DESCRIPTION

https://github.com/user-attachments/assets/1b345068-10eb-498d-b27c-7c85543a7eec

The bar picked the network icon off whether an ethernet device was connected:

    text: Nmcli.activeEthernet ? "cable" : Nmcli.active ? ... : "wifi_off"

which answers "is a cable plugged in and up", not "is traffic going over it". usually the same thing, but not when both a cable and wifi are up and the route metrics decide between them:

    nmcli connection modify <wifi> ipv4.route-metric 50
    nmcli device reapply <wifi-device>

traffic moves to wifi, the ethernet link stays connected, and the bar keeps showing the cable. the network popout picked its view the same way.

NetworkManager doesn't expose which connection owns the default route  `connection show --active` has no field for it  so this reads the routing table and takes the lowest metric, same as the kernel. refreshes off the existing nmcli monitor so there's no new polling, and falls back to the old behaviour until the table has been read so nothing flickers on startup.

`activeEthernet` is untouched  the ethernet section in settings correctly wants "is a cable connected". the new `onEthernet` answers the routing question, and only the bar icon and the popout use it.

came up in #1888, though it isn't what that issue is about.