### PR TITLE
chore: add clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,6 +15,7 @@ Checks: >
   -modernize-use-trailing-return-type,
   -readability-braces-around-statements,
   -readability-identifier-length,
+  -readability-implicit-bool-conversion,
   -readability-magic-numbers,
   -readability-math-missing-parentheses,
   -readability-redundant-access-specifiers,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,6 +17,7 @@ Checks: >
   -readability-identifier-length,
   -readability-magic-numbers,
   -readability-math-missing-parentheses,
+  -readability-redundant-access-specifiers,
   -readability-uppercase-literal-suffix
 
 ExcludeHeaderFilterRegex: 'build/.*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -bugprone-macro-parentheses,
   -bugprone-throwing-static-initialization,
+  -misc-include-cleaner,
   -misc-multiple-inheritance,
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,59 @@
+---
+Checks: >
+  bugprone-*,
+  clang-analyzer-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  readability-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-throwing-static-initialization,
+  -misc-non-private-member-variables-in-classes,
+  -misc-no-recursion,
+  -modernize-avoid-c-arrays,
+  -modernize-use-trailing-return-type,
+  -readability-braces-around-statements,
+  -readability-identifier-length,
+  -readability-magic-numbers,
+  -readability-math-missing-parentheses,
+  -readability-uppercase-literal-suffix
+
+ExcludeHeaderFilterRegex: 'build/.*'
+WarningsAsErrors: ''
+FormatStyle: file
+
+CheckOptions:
+  readability-identifier-naming.NamespaceCase: lower_case
+  # Q_NAMESPACE enum scopes exposed to QML are CamelCase by design
+  readability-identifier-naming.NamespaceIgnoredRegexp: '^[A-Z][A-Za-z0-9]*$'
+  readability-identifier-naming.ClassCase: CamelCase
+  readability-identifier-naming.StructCase: CamelCase
+  readability-identifier-naming.EnumCase: CamelCase
+  readability-identifier-naming.EnumConstantCase: CamelCase
+  readability-identifier-naming.FunctionCase: camelBack
+  readability-identifier-naming.MethodCase: camelBack
+  readability-identifier-naming.VariableCase: camelBack
+  readability-identifier-naming.ParameterCase: camelBack
+  readability-identifier-naming.PrivateMemberPrefix: m_
+  readability-identifier-naming.PrivateMemberCase: camelBack
+  readability-identifier-naming.ProtectedMemberPrefix: m_
+  readability-identifier-naming.ProtectedMemberCase: camelBack
+  readability-identifier-naming.ClassMemberPrefix: s_
+  readability-identifier-naming.ClassMemberCase: camelBack
+  readability-identifier-naming.GlobalVariablePrefix: g_
+  readability-identifier-naming.GlobalVariableCase: camelBack
+  readability-identifier-naming.StaticVariablePrefix: s_
+  readability-identifier-naming.StaticVariableCase: camelBack
+  readability-identifier-naming.ConstexprVariablePrefix: k_
+  readability-identifier-naming.ConstexprVariableCase: camelBack
+  readability-identifier-naming.GlobalConstantPrefix: k_
+  readability-identifier-naming.GlobalConstantCase: camelBack
+  readability-identifier-naming.ClassConstantPrefix: k_
+  readability-identifier-naming.ClassConstantCase: camelBack
+  readability-identifier-naming.StaticConstantPrefix: k_
+  readability-identifier-naming.StaticConstantCase: camelBack
+  readability-identifier-naming.MacroDefinitionCase: UPPER_CASE
+  readability-identifier-naming.TypeAliasCase: CamelCase
+  readability-identifier-naming.TemplateParameterCase: CamelCase
+  readability-implicit-bool-conversion.AllowPointerConditions: true
+  modernize-use-default-member-init.UseAssignment: true

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: >
   misc-*,
   modernize-*,
   performance-*,
+  portability-restrict-system-includes,
   readability-*,
   -bugprone-easily-swappable-parameters,
   -bugprone-throwing-static-initialization,
@@ -57,3 +58,5 @@ CheckOptions:
   readability-identifier-naming.TemplateParameterCase: CamelCase
   readability-implicit-bool-conversion.AllowPointerConditions: true
   modernize-use-default-member-init.UseAssignment: true
+  # Ban Q* (e.g. Qt module includes or Qt module prefixes)
+  portability-restrict-system-includes.Includes: '*,-Q*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -bugprone-macro-parentheses,
   -bugprone-throwing-static-initialization,
+  -misc-multiple-inheritance,
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
   -modernize-avoid-c-arrays,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -63,5 +63,7 @@ CheckOptions:
   readability-identifier-naming.TypeAliasCase: CamelCase
   readability-identifier-naming.TemplateParameterCase: CamelCase
   readability-implicit-bool-conversion.AllowPointerConditions: true
+  # Qt logging macros expand to for loops, so ignore them (we don't really use other macros)
+  readability-function-cognitive-complexity.IgnoreMacros: true
   # Ban Q* (e.g. Qt module includes or Qt module prefixes)
   portability-restrict-system-includes.Includes: '*,-Q*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,7 @@ Checks: >
   portability-restrict-system-includes,
   readability-*,
   -bugprone-easily-swappable-parameters,
+  -bugprone-macro-parentheses,
   -bugprone-throwing-static-initialization,
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: >
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
   -modernize-avoid-c-arrays,
+  -modernize-use-default-member-init,
   -modernize-use-trailing-return-type,
   -readability-braces-around-statements,
   -readability-identifier-length,
@@ -59,6 +60,5 @@ CheckOptions:
   readability-identifier-naming.TypeAliasCase: CamelCase
   readability-identifier-naming.TemplateParameterCase: CamelCase
   readability-implicit-bool-conversion.AllowPointerConditions: true
-  modernize-use-default-member-init.UseAssignment: true
   # Ban Q* (e.g. Qt module includes or Qt module prefixes)
   portability-restrict-system-includes.Includes: '*,-Q*'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Configure
         run: |
-          cmake -B build -G Ninja -DCMAKE_CXX_COMPILER=clang++ \
+          cmake -B build -G Ninja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -DVERSION= -DGIT_REVISION=
 
       - name: Lint C++

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,8 @@ on:
   pull_request:
 
 jobs:
-  lint:
+  lint-qml:
     runs-on: ubuntu-latest
-
     container:
       image: ghcr.io/${{ github.repository_owner }}/shell-arch-env:latest
 
@@ -43,3 +42,22 @@ jobs:
           # Lint
           set -l lint_out (/usr/lib/qt6/bin/qmllint --import disable $args $qml_files 2>&1 | tee /dev/stderr)
           test -z "$lint_out" || exit 1
+
+  lint-cpp:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/shell-arch-env:latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure
+        run: |
+          cmake -B build -G Ninja -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -DVERSION= -DGIT_REVISION=
+
+      - name: Lint C++
+        run: |
+          clang-tidy --version
+          run-clang-tidy -p build -quiet -j "$(nproc)" -warnings-as-errors='*' \
+            -source-filter='^(?!build/).*\.cpp$'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,4 +60,4 @@ jobs:
         run: |
           clang-tidy --version
           run-clang-tidy -p build -quiet -j "$(nproc)" -warnings-as-errors='*' \
-            -source-filter='^(?!build/).*\.cpp$'
+            -source-filter='^(?!.*/build/).*\.cpp$'

--- a/extras/version.cpp
+++ b/extras/version.cpp
@@ -5,22 +5,22 @@ int main(int argc, char* argv[]) {
         std::string arg = argv[1];
 
         if (arg == "-t" || arg == "--terse") {
-            std::cout << PROJECT_NAME << std::endl;
-            std::cout << VERSION << std::endl;
-            std::cout << GIT_REVISION << std::endl;
-            std::cout << DISTRIBUTOR << std::endl;
+            std::cout << PROJECT_NAME << '\n';
+            std::cout << VERSION << '\n';
+            std::cout << GIT_REVISION << '\n';
+            std::cout << DISTRIBUTOR << '\n';
         } else if (arg == "-s" || arg == "--short") {
             std::cout << PROJECT_NAME << " " << VERSION << ", revision " << GIT_REVISION
-                      << ", distributed by: " << DISTRIBUTOR << std::endl;
+                      << ", distributed by: " << DISTRIBUTOR << '\n';
         } else {
-            std::cout << "Usage: " << argv[0] << " [-t | --terse] [-s | --short]" << std::endl;
+            std::cout << "Usage: " << argv[0] << " [-t | --terse] [-s | --short]" << '\n';
             return arg != "-h" && arg != "--help";
         }
     } else {
-        std::cout << "Project: " << PROJECT_NAME << std::endl;
-        std::cout << "Version: " << VERSION << std::endl;
-        std::cout << "Git revision: " << GIT_REVISION << std::endl;
-        std::cout << "Distributor: " << DISTRIBUTOR << std::endl;
+        std::cout << "Project: " << PROJECT_NAME << '\n';
+        std::cout << "Version: " << VERSION << '\n';
+        std::cout << "Git revision: " << GIT_REVISION << '\n';
+        std::cout << "Distributor: " << DISTRIBUTOR << '\n';
     }
 
     return 0;

--- a/extras/version.cpp
+++ b/extras/version.cpp
@@ -2,7 +2,7 @@
 
 int main(int argc, char* argv[]) {
     if (argc > 1) {
-        std::string arg = argv[1];
+        const std::string arg = argv[1];
 
         if (arg == "-t" || arg == "--terse") {
             std::cout << PROJECT_NAME << '\n';

--- a/plugin/src/Caelestia/Blobs/blobgroup.cpp
+++ b/plugin/src/Caelestia/Blobs/blobgroup.cpp
@@ -13,6 +13,10 @@ BlobGroup::~BlobGroup() {
         static_cast<BlobShape*>(m_invertedRect)->m_group = nullptr;
 }
 
+qreal BlobGroup::smoothing() const {
+    return m_smoothing;
+}
+
 void BlobGroup::setSmoothing(qreal s) {
     if (qFuzzyCompare(m_smoothing, s))
         return;
@@ -21,12 +25,20 @@ void BlobGroup::setSmoothing(qreal s) {
     markDirty();
 }
 
+QColor BlobGroup::color() const {
+    return m_color;
+}
+
 void BlobGroup::setColor(const QColor& c) {
     if (m_color == c)
         return;
     m_color = c;
     emit colorChanged();
     markDirty();
+}
+
+bool BlobGroup::cornerFill() const {
+    return m_cornerFill;
 }
 
 void BlobGroup::setCornerFill(bool e) {
@@ -61,6 +73,14 @@ void BlobGroup::clearInvertedRect(BlobInvertedRect* rect) {
         return;
     m_invertedRect = nullptr;
     markDirty();
+}
+
+const QList<BlobShape*>& BlobGroup::shapes() const {
+    return m_shapes;
+}
+
+BlobInvertedRect* BlobGroup::invertedRect() const {
+    return m_invertedRect;
 }
 
 void BlobGroup::markDirty() {

--- a/plugin/src/Caelestia/Blobs/blobgroup.hpp
+++ b/plugin/src/Caelestia/Blobs/blobgroup.hpp
@@ -19,16 +19,13 @@ public:
     explicit BlobGroup(QObject* parent = nullptr);
     ~BlobGroup() override;
 
-    [[nodiscard]] qreal smoothing() const { return m_smoothing; }
-
+    [[nodiscard]] qreal smoothing() const;
     void setSmoothing(qreal s);
 
-    [[nodiscard]] QColor color() const { return m_color; }
-
+    [[nodiscard]] QColor color() const;
     void setColor(const QColor& c);
 
-    [[nodiscard]] bool cornerFill() const { return m_cornerFill; }
-
+    [[nodiscard]] bool cornerFill() const;
     void setCornerFill(bool e);
 
     void addShape(BlobShape* shape);
@@ -37,9 +34,8 @@ public:
     void setInvertedRect(BlobInvertedRect* rect);
     void clearInvertedRect(BlobInvertedRect* rect);
 
-    [[nodiscard]] const QList<BlobShape*>& shapes() const { return m_shapes; }
-
-    [[nodiscard]] BlobInvertedRect* invertedRect() const { return m_invertedRect; }
+    [[nodiscard]] const QList<BlobShape*>& shapes() const;
+    [[nodiscard]] BlobInvertedRect* invertedRect() const;
 
     void markDirty();
     void markShapeDirty(BlobShape* source);

--- a/plugin/src/Caelestia/Blobs/blobgroup.hpp
+++ b/plugin/src/Caelestia/Blobs/blobgroup.hpp
@@ -19,15 +19,15 @@ public:
     explicit BlobGroup(QObject* parent = nullptr);
     ~BlobGroup() override;
 
-    qreal smoothing() const { return m_smoothing; }
+    [[nodiscard]] qreal smoothing() const { return m_smoothing; }
 
     void setSmoothing(qreal s);
 
-    QColor color() const { return m_color; }
+    [[nodiscard]] QColor color() const { return m_color; }
 
     void setColor(const QColor& c);
 
-    bool cornerFill() const { return m_cornerFill; }
+    [[nodiscard]] bool cornerFill() const { return m_cornerFill; }
 
     void setCornerFill(bool e);
 
@@ -37,9 +37,9 @@ public:
     void setInvertedRect(BlobInvertedRect* rect);
     void clearInvertedRect(BlobInvertedRect* rect);
 
-    const QList<BlobShape*>& shapes() const { return m_shapes; }
+    [[nodiscard]] const QList<BlobShape*>& shapes() const { return m_shapes; }
 
-    BlobInvertedRect* invertedRect() const { return m_invertedRect; }
+    [[nodiscard]] BlobInvertedRect* invertedRect() const { return m_invertedRect; }
 
     void markDirty();
     void markShapeDirty(BlobShape* source);

--- a/plugin/src/Caelestia/Blobs/blobinvertedrect.cpp
+++ b/plugin/src/Caelestia/Blobs/blobinvertedrect.cpp
@@ -43,7 +43,9 @@ static void setFrameIndices(quint16* idx) {
     idx[23] = 7;
 }
 
-QSGNode* BlobInvertedRect::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData*) {
+QSGNode* BlobInvertedRect::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* data) {
+    Q_UNUSED(data);
+
     if (!m_group) {
         delete oldNode;
         return nullptr;

--- a/plugin/src/Caelestia/Blobs/blobinvertedrect.cpp
+++ b/plugin/src/Caelestia/Blobs/blobinvertedrect.cpp
@@ -123,7 +123,7 @@ QSGNode* BlobInvertedRect::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData
     memcpy(material->m_invertedOuter, m_cachedInvertedOuter, sizeof(m_cachedInvertedOuter));
     memcpy(material->m_invertedInner, m_cachedInvertedInner, sizeof(m_cachedInvertedInner));
 
-    const int count = static_cast<int>(qMin(m_cachedRects.size(), qsizetype(16)));
+    const int count = static_cast<int>(qMin(m_cachedRects.size(), static_cast<qsizetype>(16)));
     material->m_rectCount = count;
     for (int i = 0; i < count; ++i)
         material->m_rects[i] = m_cachedRects[i];

--- a/plugin/src/Caelestia/Blobs/blobinvertedrect.cpp
+++ b/plugin/src/Caelestia/Blobs/blobinvertedrect.cpp
@@ -12,7 +12,9 @@
 BlobInvertedRect::BlobInvertedRect(QQuickItem* parent)
     : BlobShape(parent) {}
 
-static void setFrameIndices(quint16* idx) {
+namespace {
+
+void setFrameIndices(quint16* idx) {
     // Top strip: 0-1-4, 1-5-4
     idx[0] = 0;
     idx[1] = 1;
@@ -42,6 +44,8 @@ static void setFrameIndices(quint16* idx) {
     idx[22] = 4;
     idx[23] = 7;
 }
+
+} // namespace
 
 QSGNode* BlobInvertedRect::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* data) {
     Q_UNUSED(data);

--- a/plugin/src/Caelestia/Blobs/blobinvertedrect.cpp
+++ b/plugin/src/Caelestia/Blobs/blobinvertedrect.cpp
@@ -3,7 +3,6 @@
 #include <qsggeometry.h>
 #include <qsgnode.h>
 
-#include <algorithm>
 #include <cstring>
 
 #include "blobgroup.hpp"

--- a/plugin/src/Caelestia/Blobs/blobinvertedrect.cpp
+++ b/plugin/src/Caelestia/Blobs/blobinvertedrect.cpp
@@ -144,6 +144,10 @@ BlobInvertedRect::~BlobInvertedRect() {
         m_group->clearInvertedRect(this);
 }
 
+qreal BlobInvertedRect::borderLeft() const {
+    return m_borderLeft;
+}
+
 void BlobInvertedRect::setBorderLeft(qreal v) {
     if (qFuzzyCompare(m_borderLeft, v))
         return;
@@ -151,6 +155,10 @@ void BlobInvertedRect::setBorderLeft(qreal v) {
     emit borderLeftChanged();
     if (m_group)
         m_group->markDirty();
+}
+
+qreal BlobInvertedRect::borderRight() const {
+    return m_borderRight;
 }
 
 void BlobInvertedRect::setBorderRight(qreal v) {
@@ -162,6 +170,10 @@ void BlobInvertedRect::setBorderRight(qreal v) {
         m_group->markDirty();
 }
 
+qreal BlobInvertedRect::borderTop() const {
+    return m_borderTop;
+}
+
 void BlobInvertedRect::setBorderTop(qreal v) {
     if (qFuzzyCompare(m_borderTop, v))
         return;
@@ -171,6 +183,10 @@ void BlobInvertedRect::setBorderTop(qreal v) {
         m_group->markDirty();
 }
 
+qreal BlobInvertedRect::borderBottom() const {
+    return m_borderBottom;
+}
+
 void BlobInvertedRect::setBorderBottom(qreal v) {
     if (qFuzzyCompare(m_borderBottom, v))
         return;
@@ -178,6 +194,10 @@ void BlobInvertedRect::setBorderBottom(qreal v) {
     emit borderBottomChanged();
     if (m_group)
         m_group->markDirty();
+}
+
+bool BlobInvertedRect::isInvertedRect() const {
+    return true;
 }
 
 void BlobInvertedRect::registerWithGroup() {

--- a/plugin/src/Caelestia/Blobs/blobinvertedrect.cpp
+++ b/plugin/src/Caelestia/Blobs/blobinvertedrect.cpp
@@ -55,7 +55,7 @@ QSGNode* BlobInvertedRect::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData
         return nullptr;
     }
 
-    const float pad = static_cast<float>(m_group->smoothing());
+    const auto pad = static_cast<float>(m_group->smoothing());
 
     // Compute inner hole boundary in local coords
     // Inset past the inner border edge by 2x smoothing to cover the blend zone
@@ -92,8 +92,8 @@ QSGNode* BlobInvertedRect::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData
     }
 
     // Outer bounds (local coords)
-    const float x0 = static_cast<float>(m_localPaddedRect.x());
-    const float y0 = static_cast<float>(m_localPaddedRect.y());
+    const auto x0 = static_cast<float>(m_localPaddedRect.x());
+    const auto y0 = static_cast<float>(m_localPaddedRect.y());
     const float x1 = x0 + static_cast<float>(m_localPaddedRect.width());
     const float y1 = y0 + static_cast<float>(m_localPaddedRect.height());
     const float w = x1 - x0;

--- a/plugin/src/Caelestia/Blobs/blobinvertedrect.cpp
+++ b/plugin/src/Caelestia/Blobs/blobinvertedrect.cpp
@@ -128,7 +128,7 @@ QSGNode* BlobInvertedRect::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData
     memcpy(material->m_invertedOuter, m_cachedInvertedOuter, sizeof(m_cachedInvertedOuter));
     memcpy(material->m_invertedInner, m_cachedInvertedInner, sizeof(m_cachedInvertedInner));
 
-    const int count = static_cast<int>(qMin(m_cachedRects.size(), static_cast<qsizetype>(16)));
+    const int count = static_cast<int>(m_cachedRects.size());
     material->m_rectCount = count;
     for (int i = 0; i < count; ++i)
         material->m_rects[i] = m_cachedRects[i];

--- a/plugin/src/Caelestia/Blobs/blobinvertedrect.hpp
+++ b/plugin/src/Caelestia/Blobs/blobinvertedrect.hpp
@@ -41,7 +41,7 @@ signals:
 protected:
     bool isInvertedRect() const override { return true; }
 
-    QSGNode* updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData*) override;
+    QSGNode* updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* data) override;
 
     void registerWithGroup() override;
     void unregisterFromGroup() override;

--- a/plugin/src/Caelestia/Blobs/blobinvertedrect.hpp
+++ b/plugin/src/Caelestia/Blobs/blobinvertedrect.hpp
@@ -16,19 +16,19 @@ public:
     explicit BlobInvertedRect(QQuickItem* parent = nullptr);
     ~BlobInvertedRect() override;
 
-    qreal borderLeft() const { return m_borderLeft; }
+    [[nodiscard]] qreal borderLeft() const { return m_borderLeft; }
 
     void setBorderLeft(qreal v);
 
-    qreal borderRight() const { return m_borderRight; }
+    [[nodiscard]] qreal borderRight() const { return m_borderRight; }
 
     void setBorderRight(qreal v);
 
-    qreal borderTop() const { return m_borderTop; }
+    [[nodiscard]] qreal borderTop() const { return m_borderTop; }
 
     void setBorderTop(qreal v);
 
-    qreal borderBottom() const { return m_borderBottom; }
+    [[nodiscard]] qreal borderBottom() const { return m_borderBottom; }
 
     void setBorderBottom(qreal v);
 
@@ -39,7 +39,7 @@ signals:
     void borderBottomChanged();
 
 protected:
-    bool isInvertedRect() const override { return true; }
+    [[nodiscard]] bool isInvertedRect() const override { return true; }
 
     QSGNode* updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* data) override;
 

--- a/plugin/src/Caelestia/Blobs/blobinvertedrect.hpp
+++ b/plugin/src/Caelestia/Blobs/blobinvertedrect.hpp
@@ -16,20 +16,16 @@ public:
     explicit BlobInvertedRect(QQuickItem* parent = nullptr);
     ~BlobInvertedRect() override;
 
-    [[nodiscard]] qreal borderLeft() const { return m_borderLeft; }
-
+    [[nodiscard]] qreal borderLeft() const;
     void setBorderLeft(qreal v);
 
-    [[nodiscard]] qreal borderRight() const { return m_borderRight; }
-
+    [[nodiscard]] qreal borderRight() const;
     void setBorderRight(qreal v);
 
-    [[nodiscard]] qreal borderTop() const { return m_borderTop; }
-
+    [[nodiscard]] qreal borderTop() const;
     void setBorderTop(qreal v);
 
-    [[nodiscard]] qreal borderBottom() const { return m_borderBottom; }
-
+    [[nodiscard]] qreal borderBottom() const;
     void setBorderBottom(qreal v);
 
 signals:
@@ -39,7 +35,7 @@ signals:
     void borderBottomChanged();
 
 protected:
-    [[nodiscard]] bool isInvertedRect() const override { return true; }
+    [[nodiscard]] bool isInvertedRect() const override;
 
     QSGNode* updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* data) override;
 

--- a/plugin/src/Caelestia/Blobs/blobmaterial.cpp
+++ b/plugin/src/Caelestia/Blobs/blobmaterial.cpp
@@ -82,7 +82,7 @@ bool BlobMaterialShader::updateUniformData(RenderState& state, QSGMaterial* newM
     memcpy(buf->data() + 144, mat->m_invertedInner, 16);
 
     // Rect data (offset 160, each rect = 5 vec4s = 80 bytes)
-    const int count = qMin(mat->m_rectCount, 16);
+    const int count = qMin(mat->m_rectCount, k_maxRects);
     for (int i = 0; i < count; ++i) {
         const auto& r = mat->m_rects[i];
         const int base = 160 + i * 80;

--- a/plugin/src/Caelestia/Blobs/blobmaterial.cpp
+++ b/plugin/src/Caelestia/Blobs/blobmaterial.cpp
@@ -59,10 +59,10 @@ bool BlobMaterialShader::updateUniformData(RenderState& state, QSGMaterial* newM
 
     // Color as vec4 (offset 96, 16 bytes)
     const float color[4] = {
-        static_cast<float>(mat->m_color.redF()),
-        static_cast<float>(mat->m_color.greenF()),
-        static_cast<float>(mat->m_color.blueF()),
-        static_cast<float>(mat->m_color.alphaF()),
+        mat->m_color.redF(),
+        mat->m_color.greenF(),
+        mat->m_color.blueF(),
+        mat->m_color.alphaF(),
     };
     memcpy(buf->data() + 96, color, 16);
 

--- a/plugin/src/Caelestia/Blobs/blobmaterial.cpp
+++ b/plugin/src/Caelestia/Blobs/blobmaterial.cpp
@@ -10,7 +10,8 @@ QSGMaterialType* BlobMaterial::type() const {
     return &s_type;
 }
 
-QSGMaterialShader* BlobMaterial::createShader(QSGRendererInterface::RenderMode) const {
+QSGMaterialShader* BlobMaterial::createShader(QSGRendererInterface::RenderMode mode) const {
+    Q_UNUSED(mode);
     return new BlobMaterialShader;
 }
 

--- a/plugin/src/Caelestia/Blobs/blobmaterial.hpp
+++ b/plugin/src/Caelestia/Blobs/blobmaterial.hpp
@@ -4,6 +4,9 @@
 #include <qsgmaterial.h>
 #include <qsgmaterialshader.h>
 
+// Max rects the shader smins over; must match the loop bounds in blob.frag
+inline constexpr int k_maxRects = 16;
+
 struct BlobRectData {
     float cx = 0, cy = 0, hw = 0, hh = 0;
     float offsetX = 0, offsetY = 0;
@@ -37,7 +40,7 @@ public:
     float m_invertedRadius = 0;
     float m_invertedOuter[4] = {};
     float m_invertedInner[4] = {};
-    BlobRectData m_rects[16] = {};
+    BlobRectData m_rects[k_maxRects] = {};
 };
 
 class BlobMaterialShader : public QSGMaterialShader {

--- a/plugin/src/Caelestia/Blobs/blobmaterial.hpp
+++ b/plugin/src/Caelestia/Blobs/blobmaterial.hpp
@@ -21,8 +21,8 @@ struct BlobRectData {
 
 class BlobMaterial : public QSGMaterial {
 public:
-    QSGMaterialType* type() const override;
-    QSGMaterialShader* createShader(QSGRendererInterface::RenderMode mode) const override;
+    [[nodiscard]] QSGMaterialType* type() const override;
+    [[nodiscard]] QSGMaterialShader* createShader(QSGRendererInterface::RenderMode mode) const override;
     int compare(const QSGMaterial* other) const override;
 
     float m_paddedX = 0;

--- a/plugin/src/Caelestia/Blobs/blobmaterial.hpp
+++ b/plugin/src/Caelestia/Blobs/blobmaterial.hpp
@@ -22,7 +22,7 @@ struct BlobRectData {
 class BlobMaterial : public QSGMaterial {
 public:
     QSGMaterialType* type() const override;
-    QSGMaterialShader* createShader(QSGRendererInterface::RenderMode) const override;
+    QSGMaterialShader* createShader(QSGRendererInterface::RenderMode mode) const override;
     int compare(const QSGMaterial* other) const override;
 
     float m_paddedX = 0;

--- a/plugin/src/Caelestia/Blobs/blobrect.cpp
+++ b/plugin/src/Caelestia/Blobs/blobrect.cpp
@@ -217,19 +217,15 @@ void BlobRect::cornerRadii(float out[4]) const {
 }
 
 bool BlobRect::isExcluded(const BlobShape* other) const {
-    for (const auto& ptr : m_exclude) {
-        if (ptr == other)
-            return true;
-    }
-    return false;
+    return std::ranges::any_of(m_exclude, [other](const auto& ptr) {
+        return ptr == other;
+    });
 }
 
 bool BlobRect::isCornerExcluded(const BlobShape* other) const {
-    for (const auto& ptr : m_excludeCorners) {
-        if (ptr == other)
-            return true;
-    }
-    return false;
+    return std::ranges::any_of(m_excludeCorners, [other](const auto& ptr) {
+        return ptr == other;
+    });
 }
 
 QQmlListProperty<BlobRect> BlobRect::exclude() {

--- a/plugin/src/Caelestia/Blobs/blobrect.cpp
+++ b/plugin/src/Caelestia/Blobs/blobrect.cpp
@@ -18,8 +18,8 @@ void BlobRect::updatePolish() {
 
     if (m_physicsActive) {
         // Check if deformation is visually imperceptible
-        float totalDelta = std::abs(m_dm00 - 1.0f) + std::abs(m_dm01) + std::abs(m_dm11 - 1.0f);
-        float totalVel = std::abs(m_dmVel00) + std::abs(m_dmVel01) + std::abs(m_dmVel11);
+        const float totalDelta = std::abs(m_dm00 - 1.0f) + std::abs(m_dm01) + std::abs(m_dm11 - 1.0f);
+        const float totalVel = std::abs(m_dmVel00) + std::abs(m_dmVel01) + std::abs(m_dmVel11);
 
         if (totalDelta < 0.004f && totalVel < 0.05f) {
             // Snap to rest, no visible deformation

--- a/plugin/src/Caelestia/Blobs/blobrect.cpp
+++ b/plugin/src/Caelestia/Blobs/blobrect.cpp
@@ -122,6 +122,43 @@ void BlobRect::updatePhysics() {
     checkAtRest(speed);
 }
 
+qreal BlobRect::stiffness() const {
+    return m_stiffness;
+}
+
+void BlobRect::setStiffness(qreal s) {
+    if (!qFuzzyCompare(m_stiffness, s)) {
+        m_stiffness = s;
+        emit stiffnessChanged();
+    }
+}
+
+qreal BlobRect::damping() const {
+    return m_damping;
+}
+
+void BlobRect::setDamping(qreal d) {
+    if (!qFuzzyCompare(m_damping, d)) {
+        m_damping = d;
+        emit dampingChanged();
+    }
+}
+
+qreal BlobRect::deformScale() const {
+    return m_deformScale;
+}
+
+void BlobRect::setDeformScale(qreal s) {
+    if (!qFuzzyCompare(m_deformScale, s)) {
+        m_deformScale = s;
+        emit deformScaleChanged();
+    }
+}
+
+qreal BlobRect::topLeftRadius() const {
+    return m_topLeftRadius;
+}
+
 void BlobRect::setTopLeftRadius(qreal r) {
     if (!qFuzzyCompare(m_topLeftRadius, r)) {
         m_topLeftRadius = r;
@@ -129,6 +166,10 @@ void BlobRect::setTopLeftRadius(qreal r) {
         if (m_group)
             m_group->markDirty();
     }
+}
+
+qreal BlobRect::topRightRadius() const {
+    return m_topRightRadius;
 }
 
 void BlobRect::setTopRightRadius(qreal r) {
@@ -140,6 +181,10 @@ void BlobRect::setTopRightRadius(qreal r) {
     }
 }
 
+qreal BlobRect::bottomLeftRadius() const {
+    return m_bottomLeftRadius;
+}
+
 void BlobRect::setBottomLeftRadius(qreal r) {
     if (!qFuzzyCompare(m_bottomLeftRadius, r)) {
         m_bottomLeftRadius = r;
@@ -147,6 +192,10 @@ void BlobRect::setBottomLeftRadius(qreal r) {
         if (m_group)
             m_group->markDirty();
     }
+}
+
+qreal BlobRect::bottomRightRadius() const {
+    return m_bottomRightRadius;
 }
 
 void BlobRect::setBottomRightRadius(qreal r) {

--- a/plugin/src/Caelestia/Blobs/blobrect.cpp
+++ b/plugin/src/Caelestia/Blobs/blobrect.cpp
@@ -76,15 +76,15 @@ void BlobRect::updatePhysics() {
 
     // Compute target deformation matrix from velocity
     // R(θ) * diag(stretch, compress) * R(θ)^T
-    const auto kStretchFactor = static_cast<float>(m_deformScale);
-    constexpr float kMaxStretch = 0.35f;
+    const auto stretchFactor = static_cast<float>(m_deformScale);
+    constexpr float k_maxStretch = 0.35f;
 
     float target00 = 1.0f;
     float target01 = 0.0f;
     float target11 = 1.0f;
 
     if (speed > 5.0f) {
-        const float targetStretch = 1.0f + std::min(speed * kStretchFactor, kMaxStretch);
+        const float targetStretch = 1.0f + std::min(speed * stretchFactor, k_maxStretch);
         const float targetCompress = 1.0f / targetStretch;
 
         const float cosA = velX / speed;
@@ -102,17 +102,17 @@ void BlobRect::updatePhysics() {
     // (the friction term uses the new velocity, solved in closed form) so the 1/(1 + c*dt)
     // factor stays in (0, 1) for any dt; an explicit -c*v*dt term would flip sign and inject
     // energy once c*dt > 1 (here dt > ~62ms), making the deformation diverge on slow frames.
-    const auto kStiffness = static_cast<float>(m_stiffness);
-    const auto kDamping = static_cast<float>(m_damping);
-    const float invDamp = 1.0f / (1.0f + kDamping * dt);
+    const auto stiffness = static_cast<float>(m_stiffness);
+    const auto damping = static_cast<float>(m_damping);
+    const float invDamp = 1.0f / (1.0f + damping * dt);
 
-    m_dmVel00 = (m_dmVel00 - kStiffness * (m_dm00 - target00) * dt) * invDamp;
+    m_dmVel00 = (m_dmVel00 - stiffness * (m_dm00 - target00) * dt) * invDamp;
     m_dm00 += m_dmVel00 * dt;
 
-    m_dmVel01 = (m_dmVel01 - kStiffness * (m_dm01 - target01) * dt) * invDamp;
+    m_dmVel01 = (m_dmVel01 - stiffness * (m_dm01 - target01) * dt) * invDamp;
     m_dm01 += m_dmVel01 * dt;
 
-    m_dmVel11 = (m_dmVel11 - kStiffness * (m_dm11 - target11) * dt) * invDamp;
+    m_dmVel11 = (m_dmVel11 - stiffness * (m_dm11 - target11) * dt) * invDamp;
     m_dm11 += m_dmVel11 * dt;
 
     m_deformMatrix = QMatrix4x4(m_dm00, m_dm01, 0, 0, m_dm01, m_dm11, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
@@ -331,10 +331,10 @@ void BlobRect::excludeCornersRemoveLast(QQmlListProperty<BlobRect>* prop) {
 }
 
 void BlobRect::checkAtRest(float speed) {
-    constexpr float kEpsilon = 0.002f;
-    const bool atRest = std::abs(m_dm00 - 1.0f) < kEpsilon && std::abs(m_dm01) < kEpsilon &&
-                        std::abs(m_dm11 - 1.0f) < kEpsilon && std::abs(m_dmVel00) < kEpsilon &&
-                        std::abs(m_dmVel01) < kEpsilon && std::abs(m_dmVel11) < kEpsilon && speed < 5.0f;
+    constexpr float k_epsilon = 0.002f;
+    const bool atRest = std::abs(m_dm00 - 1.0f) < k_epsilon && std::abs(m_dm01) < k_epsilon &&
+                        std::abs(m_dm11 - 1.0f) < k_epsilon && std::abs(m_dmVel00) < k_epsilon &&
+                        std::abs(m_dmVel01) < k_epsilon && std::abs(m_dmVel11) < k_epsilon && speed < 5.0f;
 
     if (atRest) {
         m_dm00 = 1.0f;

--- a/plugin/src/Caelestia/Blobs/blobrect.cpp
+++ b/plugin/src/Caelestia/Blobs/blobrect.cpp
@@ -76,7 +76,7 @@ void BlobRect::updatePhysics() {
 
     // Compute target deformation matrix from velocity
     // R(θ) * diag(stretch, compress) * R(θ)^T
-    const float kStretchFactor = static_cast<float>(m_deformScale);
+    const auto kStretchFactor = static_cast<float>(m_deformScale);
     constexpr float kMaxStretch = 0.35f;
 
     float target00 = 1.0f;
@@ -102,8 +102,8 @@ void BlobRect::updatePhysics() {
     // (the friction term uses the new velocity, solved in closed form) so the 1/(1 + c*dt)
     // factor stays in (0, 1) for any dt; an explicit -c*v*dt term would flip sign and inject
     // energy once c*dt > 1 (here dt > ~62ms), making the deformation diverge on slow frames.
-    const float kStiffness = static_cast<float>(m_stiffness);
-    const float kDamping = static_cast<float>(m_damping);
+    const auto kStiffness = static_cast<float>(m_stiffness);
+    const auto kDamping = static_cast<float>(m_damping);
     const float invDamp = 1.0f / (1.0f + kDamping * dt);
 
     m_dmVel00 = (m_dmVel00 - kStiffness * (m_dm00 - target00) * dt) * invDamp;
@@ -184,13 +184,13 @@ bool BlobRect::isCornerExcluded(const BlobShape* other) const {
 }
 
 QQmlListProperty<BlobRect> BlobRect::exclude() {
-    return QQmlListProperty<BlobRect>(
-        this, nullptr, &excludeAppend, &excludeCount, &excludeAt, &excludeClear, &excludeReplace, &excludeRemoveLast);
+    return { this, nullptr, &excludeAppend, &excludeCount, &excludeAt, &excludeClear, &excludeReplace,
+        &excludeRemoveLast };
 }
 
 QQmlListProperty<BlobRect> BlobRect::excludeCorners() {
-    return QQmlListProperty<BlobRect>(this, nullptr, &excludeCornersAppend, &excludeCornersCount, &excludeCornersAt,
-        &excludeCornersClear, &excludeCornersReplace, &excludeCornersRemoveLast);
+    return { this, nullptr, &excludeCornersAppend, &excludeCornersCount, &excludeCornersAt, &excludeCornersClear,
+        &excludeCornersReplace, &excludeCornersRemoveLast };
 }
 
 void BlobRect::excludeAppend(QQmlListProperty<BlobRect>* prop, BlobRect* rect) {

--- a/plugin/src/Caelestia/Blobs/blobrect.hpp
+++ b/plugin/src/Caelestia/Blobs/blobrect.hpp
@@ -25,32 +25,14 @@ public:
     explicit BlobRect(QQuickItem* parent = nullptr);
     ~BlobRect() override;
 
-    [[nodiscard]] qreal stiffness() const { return m_stiffness; }
+    [[nodiscard]] qreal stiffness() const;
+    void setStiffness(qreal s);
 
-    void setStiffness(qreal s) {
-        if (!qFuzzyCompare(m_stiffness, s)) {
-            m_stiffness = s;
-            emit stiffnessChanged();
-        }
-    }
+    [[nodiscard]] qreal damping() const;
+    void setDamping(qreal d);
 
-    [[nodiscard]] qreal damping() const { return m_damping; }
-
-    void setDamping(qreal d) {
-        if (!qFuzzyCompare(m_damping, d)) {
-            m_damping = d;
-            emit dampingChanged();
-        }
-    }
-
-    [[nodiscard]] qreal deformScale() const { return m_deformScale; }
-
-    void setDeformScale(qreal s) {
-        if (!qFuzzyCompare(m_deformScale, s)) {
-            m_deformScale = s;
-            emit deformScaleChanged();
-        }
-    }
+    [[nodiscard]] qreal deformScale() const;
+    void setDeformScale(qreal s);
 
     QQmlListProperty<BlobRect> exclude();
     QQmlListProperty<BlobRect> excludeCorners();
@@ -59,20 +41,16 @@ public:
     bool isCornerExcluded(const BlobShape* other) const override;
     void cornerRadii(float out[4]) const override;
 
-    [[nodiscard]] qreal topLeftRadius() const { return m_topLeftRadius; }
-
+    [[nodiscard]] qreal topLeftRadius() const;
     void setTopLeftRadius(qreal r);
 
-    [[nodiscard]] qreal topRightRadius() const { return m_topRightRadius; }
-
+    [[nodiscard]] qreal topRightRadius() const;
     void setTopRightRadius(qreal r);
 
-    [[nodiscard]] qreal bottomLeftRadius() const { return m_bottomLeftRadius; }
-
+    [[nodiscard]] qreal bottomLeftRadius() const;
     void setBottomLeftRadius(qreal r);
 
-    [[nodiscard]] qreal bottomRightRadius() const { return m_bottomRightRadius; }
-
+    [[nodiscard]] qreal bottomRightRadius() const;
     void setBottomRightRadius(qreal r);
 
 signals:

--- a/plugin/src/Caelestia/Blobs/blobrect.hpp
+++ b/plugin/src/Caelestia/Blobs/blobrect.hpp
@@ -37,10 +37,6 @@ public:
     QQmlListProperty<BlobRect> exclude();
     QQmlListProperty<BlobRect> excludeCorners();
 
-    bool isExcluded(const BlobShape* other) const override;
-    bool isCornerExcluded(const BlobShape* other) const override;
-    void cornerRadii(float out[4]) const override;
-
     [[nodiscard]] qreal topLeftRadius() const;
     void setTopLeftRadius(qreal r);
 
@@ -67,6 +63,10 @@ signals:
 protected:
     void updatePolish() override;
     void updatePhysics() override;
+
+    [[nodiscard]] bool isExcluded(const BlobShape* other) const override;
+    [[nodiscard]] bool isCornerExcluded(const BlobShape* other) const override;
+    void cornerRadii(float out[4]) const override;
 
 private:
     void checkAtRest(float speed);

--- a/plugin/src/Caelestia/Blobs/blobrect.hpp
+++ b/plugin/src/Caelestia/Blobs/blobrect.hpp
@@ -25,7 +25,7 @@ public:
     explicit BlobRect(QQuickItem* parent = nullptr);
     ~BlobRect() override;
 
-    qreal stiffness() const { return m_stiffness; }
+    [[nodiscard]] qreal stiffness() const { return m_stiffness; }
 
     void setStiffness(qreal s) {
         if (!qFuzzyCompare(m_stiffness, s)) {
@@ -34,7 +34,7 @@ public:
         }
     }
 
-    qreal damping() const { return m_damping; }
+    [[nodiscard]] qreal damping() const { return m_damping; }
 
     void setDamping(qreal d) {
         if (!qFuzzyCompare(m_damping, d)) {
@@ -43,7 +43,7 @@ public:
         }
     }
 
-    qreal deformScale() const { return m_deformScale; }
+    [[nodiscard]] qreal deformScale() const { return m_deformScale; }
 
     void setDeformScale(qreal s) {
         if (!qFuzzyCompare(m_deformScale, s)) {
@@ -59,19 +59,19 @@ public:
     bool isCornerExcluded(const BlobShape* other) const override;
     void cornerRadii(float out[4]) const override;
 
-    qreal topLeftRadius() const { return m_topLeftRadius; }
+    [[nodiscard]] qreal topLeftRadius() const { return m_topLeftRadius; }
 
     void setTopLeftRadius(qreal r);
 
-    qreal topRightRadius() const { return m_topRightRadius; }
+    [[nodiscard]] qreal topRightRadius() const { return m_topRightRadius; }
 
     void setTopRightRadius(qreal r);
 
-    qreal bottomLeftRadius() const { return m_bottomLeftRadius; }
+    [[nodiscard]] qreal bottomLeftRadius() const { return m_bottomLeftRadius; }
 
     void setBottomLeftRadius(qreal r);
 
-    qreal bottomRightRadius() const { return m_bottomRightRadius; }
+    [[nodiscard]] qreal bottomRightRadius() const { return m_bottomRightRadius; }
 
     void setBottomRightRadius(qreal r);
 

--- a/plugin/src/Caelestia/Blobs/blobshape.cpp
+++ b/plugin/src/Caelestia/Blobs/blobshape.cpp
@@ -141,7 +141,7 @@ void BlobShape::updatePolish() {
     m_group->ensurePhysicsUpdated();
 
     const QPointF scenePos = mapToScene(QPointF(0, 0));
-    const float pad = static_cast<float>(m_group->smoothing());
+    const auto pad = static_cast<float>(m_group->smoothing());
 
     if (isInvertedRect()) {
         m_cachedPaddedX = static_cast<float>(scenePos.x());
@@ -267,10 +267,10 @@ void BlobShape::updatePolish() {
     auto* inv = m_group->invertedRect();
     if (inv) {
         const QPointF invScene = inv->mapToScene(QPointF(0, 0));
-        const float outerCX = static_cast<float>(invScene.x() + inv->width() / 2.0);
-        const float outerCY = static_cast<float>(invScene.y() + inv->height() / 2.0);
-        const float outerHW = static_cast<float>(inv->width() / 2.0);
-        const float outerHH = static_cast<float>(inv->height() / 2.0);
+        const auto outerCX = static_cast<float>(invScene.x() + inv->width() / 2.0);
+        const auto outerCY = static_cast<float>(invScene.y() + inv->height() / 2.0);
+        const auto outerHW = static_cast<float>(inv->width() / 2.0);
+        const auto outerHH = static_cast<float>(inv->height() / 2.0);
 
         const float innerCX = outerCX + static_cast<float>((inv->borderLeft() - inv->borderRight()) / 2.0);
         const float innerCY = outerCY + static_cast<float>((inv->borderTop() - inv->borderBottom()) / 2.0);
@@ -396,8 +396,8 @@ QSGNode* BlobShape::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* data)
     auto* geometry = node->geometry();
     auto* v = geometry->vertexDataAsTexturedPoint2D();
 
-    const float x0 = static_cast<float>(m_localPaddedRect.x());
-    const float y0 = static_cast<float>(m_localPaddedRect.y());
+    const auto x0 = static_cast<float>(m_localPaddedRect.x());
+    const auto y0 = static_cast<float>(m_localPaddedRect.y());
     const float x1 = x0 + static_cast<float>(m_localPaddedRect.width());
     const float y1 = y0 + static_cast<float>(m_localPaddedRect.height());
 

--- a/plugin/src/Caelestia/Blobs/blobshape.cpp
+++ b/plugin/src/Caelestia/Blobs/blobshape.cpp
@@ -56,6 +56,10 @@ BlobShape::BlobShape(QQuickItem* parent)
     setFlag(ItemHasContents);
 }
 
+BlobGroup* BlobShape::group() const {
+    return m_group;
+}
+
 void BlobShape::setGroup(BlobGroup* g) {
     if (m_group == g)
         return;
@@ -69,6 +73,10 @@ void BlobShape::setGroup(BlobGroup* g) {
         m_group->markDirty();
 }
 
+qreal BlobShape::radius() const {
+    return m_radius;
+}
+
 void BlobShape::setRadius(qreal r) {
     if (qFuzzyCompare(m_radius, r))
         return;
@@ -76,6 +84,14 @@ void BlobShape::setRadius(qreal r) {
     emit radiusChanged();
     if (m_group)
         m_group->markDirty();
+}
+
+QMatrix4x4 BlobShape::deformMatrix() const {
+    return m_centeredDeformMatrix;
+}
+
+QMatrix4x4 BlobShape::rawDeformMatrix() const {
+    return m_deformMatrix;
 }
 
 void BlobShape::componentComplete() {
@@ -114,6 +130,20 @@ void BlobShape::updateCenteredDeformMatrix() {
     }
 }
 
+bool BlobShape::isInvertedRect() const {
+    return false;
+}
+
+bool BlobShape::isExcluded(const BlobShape* other) const {
+    Q_UNUSED(other);
+    return false;
+}
+
+bool BlobShape::isCornerExcluded(const BlobShape* other) const {
+    Q_UNUSED(other);
+    return false;
+}
+
 void BlobShape::cornerRadii(float out[4]) const {
     const auto maxR = static_cast<float>(std::min(width(), height())) * 0.5f;
     const auto r = std::min(static_cast<float>(m_radius), maxR);
@@ -122,6 +152,8 @@ void BlobShape::cornerRadii(float out[4]) const {
     out[2] = r;
     out[3] = r;
 }
+
+void BlobShape::updatePhysics() {}
 
 void BlobShape::registerWithGroup() {
     if (m_group)

--- a/plugin/src/Caelestia/Blobs/blobshape.cpp
+++ b/plugin/src/Caelestia/Blobs/blobshape.cpp
@@ -354,7 +354,9 @@ void BlobShape::updatePolish() {
     }
 }
 
-QSGNode* BlobShape::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData*) {
+QSGNode* BlobShape::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* data) {
+    Q_UNUSED(data);
+
     if (!m_group) {
         delete oldNode;
         return nullptr;

--- a/plugin/src/Caelestia/Blobs/blobshape.cpp
+++ b/plugin/src/Caelestia/Blobs/blobshape.cpp
@@ -11,8 +11,10 @@
 
 static float deformPadding(const QMatrix4x4& dm, float hw, float hh) {
     // Bounding box of the deformed shape: |M * corners|
-    const float dm00 = dm(0, 0), dm01 = dm(0, 1);
-    const float dm10 = dm(1, 0), dm11 = dm(1, 1);
+    const float dm00 = dm(0, 0);
+    const float dm01 = dm(0, 1);
+    const float dm10 = dm(1, 0);
+    const float dm11 = dm(1, 1);
     const float boundX = std::abs(dm00) * hw + std::abs(dm01) * hh;
     const float boundY = std::abs(dm10) * hw + std::abs(dm11) * hh;
     const float extraX = std::max(boundX - hw, 0.0f) + std::abs(dm(0, 3));
@@ -197,8 +199,10 @@ void BlobShape::updatePolish() {
                 m_cachedMyIndex = static_cast<int>(m_cachedRects.size());
 
             const QMatrix4x4& dm = other->m_deformMatrix;
-            const float a = dm(0, 0), b = dm(1, 0);
-            const float c = dm(0, 1), d = dm(1, 1);
+            const float a = dm(0, 0);
+            const float b = dm(1, 0);
+            const float c = dm(0, 1);
+            const float d = dm(1, 1);
 
             BlobRectData r;
             r.cx = static_cast<float>(otherScene.x() + other->width() / 2.0);
@@ -307,12 +311,19 @@ void BlobShape::updatePolish() {
         auto& ri = m_cachedRects[i];
         const int riExcludeMask = ri.excludeMask;
         BlobShape* const si = rectShapes[i];
-        float fTr = 1.0f, fBr = 1.0f, fBl = 1.0f, fTl = 1.0f;
+        float fTr = 1.0f;
+        float fBr = 1.0f;
+        float fBl = 1.0f;
+        float fTl = 1.0f;
 
-        const float cTrX = ri.cx + ri.hw, cTrY = ri.cy - ri.hh;
-        const float cBrX = ri.cx + ri.hw, cBrY = ri.cy + ri.hh;
-        const float cBlX = ri.cx - ri.hw, cBlY = ri.cy + ri.hh;
-        const float cTlX = ri.cx - ri.hw, cTlY = ri.cy - ri.hh;
+        const float cTrX = ri.cx + ri.hw;
+        const float cTrY = ri.cy - ri.hh;
+        const float cBrX = ri.cx + ri.hw;
+        const float cBrY = ri.cy + ri.hh;
+        const float cBlX = ri.cx - ri.hw;
+        const float cBlY = ri.cy + ri.hh;
+        const float cTlX = ri.cx - ri.hw;
+        const float cTlY = ri.cy - ri.hh;
 
         for (qsizetype j = 0; cornerFill && j < rectCount; ++j) {
             if (j == i)

--- a/plugin/src/Caelestia/Blobs/blobshape.cpp
+++ b/plugin/src/Caelestia/Blobs/blobshape.cpp
@@ -279,11 +279,11 @@ void BlobShape::updatePolish() {
     const auto cachedCount = m_cachedRects.size();
     for (qsizetype i = 0; i < cachedCount; ++i) {
         int mask = 0;
-        BlobShape* si = rectShapes[i];
+        const BlobShape* si = rectShapes[i];
         for (qsizetype j = 0; j < cachedCount; ++j) {
             if (j == i)
                 continue;
-            BlobShape* sj = rectShapes[j];
+            const BlobShape* sj = rectShapes[j];
             if (si->isExcluded(sj) || sj->isExcluded(si))
                 mask |= (1 << j);
         }
@@ -346,7 +346,7 @@ void BlobShape::updatePolish() {
     for (qsizetype i = 0; i < rectCount; ++i) {
         auto& ri = m_cachedRects[i];
         const int riExcludeMask = ri.excludeMask;
-        BlobShape* const si = rectShapes[i];
+        const BlobShape* si = rectShapes[i];
         float fTr = 1.0f;
         float fBr = 1.0f;
         float fBl = 1.0f;
@@ -366,7 +366,7 @@ void BlobShape::updatePolish() {
                 continue;
             if (riExcludeMask & (1 << j))
                 continue;
-            BlobShape* const sj = rectShapes[j];
+            const BlobShape* sj = rectShapes[j];
             if (si->isCornerExcluded(sj) || sj->isCornerExcluded(si))
                 continue;
             const auto& rj = m_cachedRects[j];

--- a/plugin/src/Caelestia/Blobs/blobshape.cpp
+++ b/plugin/src/Caelestia/Blobs/blobshape.cpp
@@ -405,7 +405,7 @@ QSGNode* BlobShape::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData*) {
     memcpy(material->m_invertedOuter, m_cachedInvertedOuter, sizeof(m_cachedInvertedOuter));
     memcpy(material->m_invertedInner, m_cachedInvertedInner, sizeof(m_cachedInvertedInner));
 
-    const int count = static_cast<int>(qMin(m_cachedRects.size(), qsizetype(16)));
+    const int count = static_cast<int>(qMin(m_cachedRects.size(), static_cast<qsizetype>(16)));
     material->m_rectCount = count;
     for (int i = 0; i < count; ++i)
         material->m_rects[i] = m_cachedRects[i];

--- a/plugin/src/Caelestia/Blobs/blobshape.cpp
+++ b/plugin/src/Caelestia/Blobs/blobshape.cpp
@@ -49,6 +49,18 @@ float cornerFillFactor(float sd, float smoothFactor) {
     return std::max(outside, inside);
 }
 
+// Corner order matches BlobRectData::radius: TR, BR, BL, TL
+void rectCorners(const BlobRectData& r, float outX[4], float outY[4]) {
+    outX[0] = r.cx + r.hw;
+    outY[0] = r.cy - r.hh;
+    outX[1] = r.cx + r.hw;
+    outY[1] = r.cy + r.hh;
+    outX[2] = r.cx - r.hw;
+    outY[2] = r.cy + r.hh;
+    outX[3] = r.cx - r.hw;
+    outY[3] = r.cy - r.hh;
+}
+
 } // namespace
 
 BlobShape::BlobShape(QQuickItem* parent)
@@ -172,39 +184,91 @@ void BlobShape::updatePolish() {
     // Ensure all shapes have up-to-date physics (only once per frame)
     m_group->ensurePhysicsUpdated();
 
-    const QPointF scenePos = mapToScene(QPointF(0, 0));
     const auto pad = static_cast<float>(m_group->smoothing());
 
-    if (isInvertedRect()) {
-        m_cachedPaddedX = static_cast<float>(scenePos.x());
-        m_cachedPaddedY = static_cast<float>(scenePos.y());
-        m_cachedPaddedW = static_cast<float>(width());
-        m_cachedPaddedH = static_cast<float>(height());
-        m_localPaddedRect = QRectF(0, 0, width(), height());
-    } else {
-        const float hw = static_cast<float>(width()) * 0.5f;
-        const float hh = static_cast<float>(height()) * 0.5f;
-        const float totalPad = pad + deformPadding(m_deformMatrix, hw, hh);
+    updatePaddedBounds(pad);
 
-        m_cachedPaddedX = static_cast<float>(scenePos.x()) - totalPad;
-        m_cachedPaddedY = static_cast<float>(scenePos.y()) - totalPad;
-        m_cachedPaddedW = static_cast<float>(width()) + 2.0f * totalPad;
-        m_cachedPaddedH = static_cast<float>(height()) + 2.0f * totalPad;
-        m_localPaddedRect = QRectF(static_cast<double>(-totalPad), static_cast<double>(-totalPad),
-            width() + 2.0 * static_cast<double>(totalPad), height() + 2.0 * static_cast<double>(totalPad));
-    }
+    // Tracks shape pointers parallel to m_cachedRects for pairwise exclusion lookups
+    QVector<BlobShape*> rectShapes;
+    collectNearbyRects(pad, rectShapes);
+    computeExcludeMasks(rectShapes);
+    cacheInvertedRect(pad);
+    applyCornerFill(pad, rectShapes);
+}
 
-    // Filter nearby normal rects
+QRectF BlobShape::localPaddedRect(float pad) const {
+    if (isInvertedRect())
+        return { 0, 0, width(), height() };
+
+    const auto hw = static_cast<float>(width()) * 0.5f;
+    const auto hh = static_cast<float>(height()) * 0.5f;
+    const auto totalPad = static_cast<double>(pad + deformPadding(m_deformMatrix, hw, hh));
+
+    return { -totalPad, -totalPad, width() + 2.0 * totalPad, height() + 2.0 * totalPad };
+}
+
+QRectF BlobShape::paddedSceneRect(const QPointF& scenePos, float pad) const {
+    return localPaddedRect(pad).translated(scenePos);
+}
+
+void BlobShape::updatePaddedBounds(float pad) {
+    m_localPaddedRect = localPaddedRect(pad);
+
+    const QRectF padded = m_localPaddedRect.translated(mapToScene(QPointF(0, 0)));
+    m_cachedPaddedX = static_cast<float>(padded.x());
+    m_cachedPaddedY = static_cast<float>(padded.y());
+    m_cachedPaddedW = static_cast<float>(padded.width());
+    m_cachedPaddedH = static_cast<float>(padded.height());
+}
+
+void BlobShape::writeRectData(BlobRectData& r, const QPointF& scenePos) const {
+    const QMatrix4x4& dm = m_deformMatrix;
+    const float a = dm(0, 0);
+    const float b = dm(1, 0);
+    const float c = dm(0, 1);
+    const float d = dm(1, 1);
+
+    r.cx = static_cast<float>(scenePos.x() + width() / 2.0);
+    r.cy = static_cast<float>(scenePos.y() + height() / 2.0);
+    r.hw = static_cast<float>(width() / 2.0);
+    r.hh = static_cast<float>(height() / 2.0);
+    cornerRadii(r.radius);
+    r.offsetX = dm(0, 3);
+    r.offsetY = dm(1, 3);
+
+    // Pre-compute inverse deformation matrix
+    const float det = a * d - c * b;
+    const float invDet = std::abs(det) > 1e-6f ? 1.0f / det : 1.0f;
+    r.invDeform[0] = d * invDet;
+    r.invDeform[1] = -b * invDet;
+    r.invDeform[2] = -c * invDet;
+    r.invDeform[3] = a * invDet;
+
+    // Pre-compute minimum eigenvalue (avoids per-pixel sqrt)
+    const float halfTr = 0.5f * (a + d);
+    const float halfDiff = 0.5f * (a - d);
+    r.minEig = halfTr - std::sqrt(halfDiff * halfDiff + c * c);
+
+    // Pre-compute screen-space AABB half-extents
+    r.screenHalfX = std::abs(a) * r.hw + std::abs(c) * r.hh;
+    r.screenHalfY = std::abs(b) * r.hw + std::abs(d) * r.hh;
+}
+
+void BlobShape::collectNearbyRects(float pad, QVector<BlobShape*>& rectShapes) {
     m_cachedRects.clear();
     m_cachedMyIndex = -2;
+
     const QRectF myPadded(static_cast<double>(m_cachedPaddedX), static_cast<double>(m_cachedPaddedY),
         static_cast<double>(m_cachedPaddedW), static_cast<double>(m_cachedPaddedH));
+    const bool inverted = isInvertedRect();
 
-    // Track shape pointers parallel to m_cachedRects for pairwise exclusion lookups
-    QVector<BlobShape*> rectShapes;
-    rectShapes.reserve(m_group->shapes().size());
+    rectShapes.reserve(k_maxRects);
+    m_cachedRects.reserve(k_maxRects);
 
     for (BlobShape* other : m_group->shapes()) {
+        if (m_cachedRects.size() >= k_maxRects)
+            break;
+
         if (other->isInvertedRect())
             continue;
 
@@ -217,65 +281,26 @@ void BlobShape::updatePolish() {
 
         const QPointF otherScene = other->mapToScene(QPointF(0, 0));
 
-        bool include = false;
-        if (isInvertedRect()) {
-            include = true;
-        } else {
-            const float otherHW = static_cast<float>(other->width()) * 0.5f;
-            const float otherHH = static_cast<float>(other->height()) * 0.5f;
-            const float otherPad = pad + deformPadding(other->m_deformMatrix, otherHW, otherHH);
-            const QRectF otherPadded(otherScene.x() - static_cast<double>(otherPad),
-                otherScene.y() - static_cast<double>(otherPad), other->width() + 2.0 * static_cast<double>(otherPad),
-                other->height() + 2.0 * static_cast<double>(otherPad));
-            include = myPadded.intersects(otherPadded);
-        }
+        // An inverted rect smins against every shape, others only against overlapping ones
+        if (!inverted && !myPadded.intersects(other->paddedSceneRect(otherScene, pad)))
+            continue;
 
-        if (include) {
-            if (other == this)
-                m_cachedMyIndex = static_cast<int>(m_cachedRects.size());
+        if (other == this)
+            m_cachedMyIndex = static_cast<int>(m_cachedRects.size());
 
-            const QMatrix4x4& dm = other->m_deformMatrix;
-            const float a = dm(0, 0);
-            const float b = dm(1, 0);
-            const float c = dm(0, 1);
-            const float d = dm(1, 1);
-
-            BlobRectData r;
-            r.cx = static_cast<float>(otherScene.x() + other->width() / 2.0);
-            r.cy = static_cast<float>(otherScene.y() + other->height() / 2.0);
-            r.hw = static_cast<float>(other->width() / 2.0);
-            r.hh = static_cast<float>(other->height() / 2.0);
-            other->cornerRadii(r.radius);
-            r.offsetX = dm(0, 3);
-            r.offsetY = dm(1, 3);
-
-            // Pre-compute inverse deformation matrix
-            const float det = a * d - c * b;
-            const float invDet = std::abs(det) > 1e-6f ? 1.0f / det : 1.0f;
-            r.invDeform[0] = d * invDet;
-            r.invDeform[1] = -b * invDet;
-            r.invDeform[2] = -c * invDet;
-            r.invDeform[3] = a * invDet;
-
-            // Pre-compute minimum eigenvalue (avoids per-pixel sqrt)
-            const float halfTr = 0.5f * (a + d);
-            const float halfDiff = 0.5f * (a - d);
-            r.minEig = halfTr - std::sqrt(halfDiff * halfDiff + c * c);
-
-            // Pre-compute screen-space AABB half-extents
-            r.screenHalfX = std::abs(a) * r.hw + std::abs(c) * r.hh;
-            r.screenHalfY = std::abs(b) * r.hw + std::abs(d) * r.hh;
-
-            m_cachedRects.append(r);
-            rectShapes.append(other);
-        }
+        BlobRectData r;
+        other->writeRectData(r, otherScene);
+        m_cachedRects.append(r);
+        rectShapes.append(other);
     }
 
-    if (isInvertedRect())
+    if (inverted)
         m_cachedMyIndex = -1;
+}
 
-    // Compute pairwise exclude masks. Bit j in entry i is set iff rect i excludes rect j
-    // or rect j excludes rect i. The shader uses this to avoid smin between excluded pairs.
+void BlobShape::computeExcludeMasks(const QVector<BlobShape*>& rectShapes) {
+    // Bit j in entry i is set iff rect i excludes rect j or rect j excludes rect i.
+    // The shader uses this to avoid smin between excluded pairs.
     const auto cachedCount = m_cachedRects.size();
     for (qsizetype i = 0; i < cachedCount; ++i) {
         int mask = 0;
@@ -289,115 +314,120 @@ void BlobShape::updatePolish() {
         }
         m_cachedRects[i].excludeMask = mask;
     }
+}
 
-    // Cache inverted rect data
+bool BlobShape::isNearInvertedBorder(float cx, float cy, float hw, float hh, float margin) const {
+    const float myCX = m_cachedPaddedX + m_cachedPaddedW * 0.5f;
+    const float myCY = m_cachedPaddedY + m_cachedPaddedH * 0.5f;
+    const float myHW = m_cachedPaddedW * 0.5f;
+    const float myHH = m_cachedPaddedH * 0.5f;
+
+    // Near border if any edge of padded rect is within margin of inner edge
+    return (myCX - myHW < cx - hw + margin) || (myCX + myHW > cx + hw - margin) || (myCY - myHH < cy - hh + margin) ||
+           (myCY + myHH > cy + hh - margin);
+}
+
+void BlobShape::cacheInvertedRect(float pad) {
     m_cachedHasInverted = false;
     m_cachedInvertedRadius = 0;
     memset(m_cachedInvertedOuter, 0, sizeof(m_cachedInvertedOuter));
     memset(m_cachedInvertedInner, 0, sizeof(m_cachedInvertedInner));
 
     auto* inv = m_group->invertedRect();
-    if (inv) {
-        const QPointF invScene = inv->mapToScene(QPointF(0, 0));
-        const auto outerCX = static_cast<float>(invScene.x() + inv->width() / 2.0);
-        const auto outerCY = static_cast<float>(invScene.y() + inv->height() / 2.0);
-        const auto outerHW = static_cast<float>(inv->width() / 2.0);
-        const auto outerHH = static_cast<float>(inv->height() / 2.0);
+    if (!inv)
+        return;
 
-        const float innerCX = outerCX + static_cast<float>((inv->borderLeft() - inv->borderRight()) / 2.0);
-        const float innerCY = outerCY + static_cast<float>((inv->borderTop() - inv->borderBottom()) / 2.0);
-        const float innerHW = outerHW - static_cast<float>((inv->borderLeft() + inv->borderRight()) / 2.0);
-        const float innerHH = outerHH - static_cast<float>((inv->borderTop() + inv->borderBottom()) / 2.0);
+    const QPointF invScene = inv->mapToScene(QPointF(0, 0));
+    const auto outerCX = static_cast<float>(invScene.x() + inv->width() / 2.0);
+    const auto outerCY = static_cast<float>(invScene.y() + inv->height() / 2.0);
+    const auto outerHW = static_cast<float>(inv->width() / 2.0);
+    const auto outerHH = static_cast<float>(inv->height() / 2.0);
 
-        // Check if this rect is near the border (within 2x smoothing of inner edge)
-        bool nearBorder = isInvertedRect();
-        if (!nearBorder) {
-            const float margin = pad * 2.0f;
-            const float myCX = m_cachedPaddedX + m_cachedPaddedW * 0.5f;
-            const float myCY = m_cachedPaddedY + m_cachedPaddedH * 0.5f;
-            const float myHW = m_cachedPaddedW * 0.5f;
-            const float myHH = m_cachedPaddedH * 0.5f;
-            // Near border if any edge of padded rect is within margin of inner edge
-            nearBorder = (myCX - myHW < innerCX - innerHW + margin) || (myCX + myHW > innerCX + innerHW - margin) ||
-                         (myCY - myHH < innerCY - innerHH + margin) || (myCY + myHH > innerCY + innerHH - margin);
-        }
+    const float innerCX = outerCX + static_cast<float>((inv->borderLeft() - inv->borderRight()) / 2.0);
+    const float innerCY = outerCY + static_cast<float>((inv->borderTop() - inv->borderBottom()) / 2.0);
+    const float innerHW = outerHW - static_cast<float>((inv->borderLeft() + inv->borderRight()) / 2.0);
+    const float innerHH = outerHH - static_cast<float>((inv->borderTop() + inv->borderBottom()) / 2.0);
 
-        if (nearBorder) {
-            m_cachedHasInverted = true;
-            m_cachedInvertedRadius = static_cast<float>(inv->radius());
+    // Only rects near the border (within 2x smoothing of the inner edge) need it
+    if (!isInvertedRect() && !isNearInvertedBorder(innerCX, innerCY, innerHW, innerHH, pad * 2.0f))
+        return;
 
-            m_cachedInvertedOuter[0] = outerCX;
-            m_cachedInvertedOuter[1] = outerCY;
-            m_cachedInvertedOuter[2] = outerHW;
-            m_cachedInvertedOuter[3] = outerHH;
+    m_cachedHasInverted = true;
+    m_cachedInvertedRadius = static_cast<float>(inv->radius());
 
-            m_cachedInvertedInner[0] = innerCX;
-            m_cachedInvertedInner[1] = innerCY;
-            m_cachedInvertedInner[2] = innerHW;
-            m_cachedInvertedInner[3] = innerHH;
+    m_cachedInvertedOuter[0] = outerCX;
+    m_cachedInvertedOuter[1] = outerCY;
+    m_cachedInvertedOuter[2] = outerHW;
+    m_cachedInvertedOuter[3] = outerHH;
+
+    m_cachedInvertedInner[0] = innerCX;
+    m_cachedInvertedInner[1] = innerCY;
+    m_cachedInvertedInner[2] = innerHW;
+    m_cachedInvertedInner[3] = innerHH;
+}
+
+void BlobShape::accumulateNeighbourFill(qsizetype index, const QVector<BlobShape*>& rectShapes, const float cornerX[4],
+    const float cornerY[4], float smoothFactor, float factors[4]) const {
+    const auto rectCount = m_cachedRects.size();
+    const int excludeMask = m_cachedRects[index].excludeMask;
+    const BlobShape* si = rectShapes[index];
+
+    for (qsizetype j = 0; j < rectCount; ++j) {
+        if (j == index)
+            continue;
+        if (excludeMask & (1 << j))
+            continue;
+
+        const BlobShape* sj = rectShapes[j];
+        if (si->isCornerExcluded(sj) || sj->isCornerExcluded(si))
+            continue;
+
+        // Square each corner only near rj's edge; keep full radius far outside AND
+        // deep inside rj (buried, so it can't crease the visible junction).
+        const auto& rj = m_cachedRects[j];
+        for (int k = 0; k < 4; ++k) {
+            const float sd = cpuSdBox(cornerX[k], cornerY[k], rj.cx, rj.cy, rj.hw, rj.hh);
+            factors[k] = std::min(factors[k], cornerFillFactor(sd, smoothFactor));
         }
     }
+}
 
-    // Pre-compute effective per-corner radii (moves O(N²) work from GPU to CPU)
-    const float smoothFactor = pad;
+void BlobShape::accumulateInvertedFill(
+    const float cornerX[4], const float cornerY[4], float smoothFactor, float factors[4]) const {
+    const float icx = m_cachedInvertedInner[0];
+    const float icy = m_cachedInvertedInner[1];
+    const float ihw = m_cachedInvertedInner[2];
+    const float ihh = m_cachedInvertedInner[3];
+
+    for (int k = 0; k < 4; ++k) {
+        const float sd = cpuSdBox(cornerX[k], cornerY[k], icx, icy, ihw, ihh);
+        factors[k] = std::min(factors[k], cpuSmoothstep(0.0f, smoothFactor, -sd));
+    }
+}
+
+void BlobShape::applyCornerFill(float smoothFactor, const QVector<BlobShape*>& rectShapes) {
+    // Pre-computes effective per-corner radii (moves O(N^2) work from GPU to CPU)
     constexpr float k_minR = 2.0f;
     const bool cornerFill = m_group->cornerFill();
     const auto rectCount = m_cachedRects.size();
+
     for (qsizetype i = 0; i < rectCount; ++i) {
-        auto& ri = m_cachedRects[i];
-        const int riExcludeMask = ri.excludeMask;
-        const BlobShape* si = rectShapes[i];
-        float fTr = 1.0f;
-        float fBr = 1.0f;
-        float fBl = 1.0f;
-        float fTl = 1.0f;
+        float cornerX[4];
+        float cornerY[4];
+        rectCorners(m_cachedRects[i], cornerX, cornerY);
 
-        const float cTrX = ri.cx + ri.hw;
-        const float cTrY = ri.cy - ri.hh;
-        const float cBrX = ri.cx + ri.hw;
-        const float cBrY = ri.cy + ri.hh;
-        const float cBlX = ri.cx - ri.hw;
-        const float cBlY = ri.cy + ri.hh;
-        const float cTlX = ri.cx - ri.hw;
-        const float cTlY = ri.cy - ri.hh;
-
-        for (qsizetype j = 0; cornerFill && j < rectCount; ++j) {
-            if (j == i)
-                continue;
-            if (riExcludeMask & (1 << j))
-                continue;
-            const BlobShape* sj = rectShapes[j];
-            if (si->isCornerExcluded(sj) || sj->isCornerExcluded(si))
-                continue;
-            const auto& rj = m_cachedRects[j];
-            // Square each corner only near rj's edge; keep full radius far outside AND
-            // deep inside rj (buried, so it can't crease the visible junction).
-            const float sdTr = cpuSdBox(cTrX, cTrY, rj.cx, rj.cy, rj.hw, rj.hh);
-            const float sdBr = cpuSdBox(cBrX, cBrY, rj.cx, rj.cy, rj.hw, rj.hh);
-            const float sdBl = cpuSdBox(cBlX, cBlY, rj.cx, rj.cy, rj.hw, rj.hh);
-            const float sdTl = cpuSdBox(cTlX, cTlY, rj.cx, rj.cy, rj.hw, rj.hh);
-            fTr = std::min(fTr, cornerFillFactor(sdTr, smoothFactor));
-            fBr = std::min(fBr, cornerFillFactor(sdBr, smoothFactor));
-            fBl = std::min(fBl, cornerFillFactor(sdBl, smoothFactor));
-            fTl = std::min(fTl, cornerFillFactor(sdTl, smoothFactor));
-        }
-
-        if (cornerFill && m_cachedHasInverted) {
-            const float icx = m_cachedInvertedInner[0];
-            const float icy = m_cachedInvertedInner[1];
-            const float ihw = m_cachedInvertedInner[2];
-            const float ihh = m_cachedInvertedInner[3];
-            fTr = std::min(fTr, cpuSmoothstep(0.0f, smoothFactor, -cpuSdBox(cTrX, cTrY, icx, icy, ihw, ihh)));
-            fBr = std::min(fBr, cpuSmoothstep(0.0f, smoothFactor, -cpuSdBox(cBrX, cBrY, icx, icy, ihw, ihh)));
-            fBl = std::min(fBl, cpuSmoothstep(0.0f, smoothFactor, -cpuSdBox(cBlX, cBlY, icx, icy, ihw, ihh)));
-            fTl = std::min(fTl, cpuSmoothstep(0.0f, smoothFactor, -cpuSdBox(cTlX, cTlY, icx, icy, ihw, ihh)));
+        float factors[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
+        if (cornerFill) {
+            accumulateNeighbourFill(i, rectShapes, cornerX, cornerY, smoothFactor, factors);
+            if (m_cachedHasInverted)
+                accumulateInvertedFill(cornerX, cornerY, smoothFactor, factors);
         }
 
         // Combine base radii with fill factors into effective per-corner radii
-        ri.radius[0] = std::max(ri.radius[0] * fTr, k_minR);
-        ri.radius[1] = std::max(ri.radius[1] * fBr, k_minR);
-        ri.radius[2] = std::max(ri.radius[2] * fBl, k_minR);
-        ri.radius[3] = std::max(ri.radius[3] * fTl, k_minR);
+        auto& ri = m_cachedRects[i];
+        for (int k = 0; k < 4; ++k) {
+            ri.radius[k] = std::max(ri.radius[k] * factors[k], k_minR);
+        }
     }
 }
 
@@ -454,7 +484,7 @@ QSGNode* BlobShape::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* data)
     memcpy(material->m_invertedOuter, m_cachedInvertedOuter, sizeof(m_cachedInvertedOuter));
     memcpy(material->m_invertedInner, m_cachedInvertedInner, sizeof(m_cachedInvertedInner));
 
-    const int count = static_cast<int>(qMin(m_cachedRects.size(), static_cast<qsizetype>(16)));
+    const int count = static_cast<int>(m_cachedRects.size());
     material->m_rectCount = count;
     for (int i = 0; i < count; ++i)
         material->m_rects[i] = m_cachedRects[i];

--- a/plugin/src/Caelestia/Blobs/blobshape.cpp
+++ b/plugin/src/Caelestia/Blobs/blobshape.cpp
@@ -9,7 +9,9 @@
 #include "blobgroup.hpp"
 #include "blobinvertedrect.hpp"
 
-static float deformPadding(const QMatrix4x4& dm, float hw, float hh) {
+namespace {
+
+float deformPadding(const QMatrix4x4& dm, float hw, float hh) {
     // Bounding box of the deformed shape: |M * corners|
     const float dm00 = dm(0, 0);
     const float dm01 = dm(0, 1);
@@ -22,7 +24,7 @@ static float deformPadding(const QMatrix4x4& dm, float hw, float hh) {
     return std::max(extraX, extraY);
 }
 
-static float cpuSdBox(float px, float py, float cx, float cy, float hw, float hh) {
+float cpuSdBox(float px, float py, float cx, float cy, float hw, float hh) {
     const float dx = std::abs(px - cx) - hw;
     const float dy = std::abs(py - cy) - hh;
     const float mdx = std::max(dx, 0.0f);
@@ -30,12 +32,12 @@ static float cpuSdBox(float px, float py, float cx, float cy, float hw, float hh
     return std::sqrt(mdx * mdx + mdy * mdy) + std::min(std::max(dx, dy), 0.0f);
 }
 
-static float cpuSmoothstep(float edge0, float edge1, float x) {
+float cpuSmoothstep(float edge0, float edge1, float x) {
     const float t = std::clamp((x - edge0) / (edge1 - edge0), 0.0f, 1.0f);
     return t * t * (3.0f - 2.0f * t);
 }
 
-static float cornerFillFactor(float sd, float smoothFactor) {
+float cornerFillFactor(float sd, float smoothFactor) {
     // Continuous two-sided window. The corner is squared (factor -> 0) only within
     // ±smoothFactor of the neighbour's edge (the visible junction); it keeps its full
     // radius both far outside the neighbour and deep inside it (where it is buried and
@@ -46,6 +48,8 @@ static float cornerFillFactor(float sd, float smoothFactor) {
     const float inside = cpuSmoothstep(0.0f, -smoothFactor, sd); // 0 at edge, ->1 deep inside
     return std::max(outside, inside);
 }
+
+} // namespace
 
 BlobShape::BlobShape(QQuickItem* parent)
     : QQuickItem(parent) {

--- a/plugin/src/Caelestia/Blobs/blobshape.cpp
+++ b/plugin/src/Caelestia/Blobs/blobshape.cpp
@@ -340,7 +340,7 @@ void BlobShape::updatePolish() {
 
     // Pre-compute effective per-corner radii (moves O(N²) work from GPU to CPU)
     const float smoothFactor = pad;
-    constexpr float minR = 2.0f;
+    constexpr float k_minR = 2.0f;
     const bool cornerFill = m_group->cornerFill();
     const auto rectCount = m_cachedRects.size();
     for (qsizetype i = 0; i < rectCount; ++i) {
@@ -394,10 +394,10 @@ void BlobShape::updatePolish() {
         }
 
         // Combine base radii with fill factors into effective per-corner radii
-        ri.radius[0] = std::max(ri.radius[0] * fTr, minR);
-        ri.radius[1] = std::max(ri.radius[1] * fBr, minR);
-        ri.radius[2] = std::max(ri.radius[2] * fBl, minR);
-        ri.radius[3] = std::max(ri.radius[3] * fTl, minR);
+        ri.radius[0] = std::max(ri.radius[0] * fTr, k_minR);
+        ri.radius[1] = std::max(ri.radius[1] * fBr, k_minR);
+        ri.radius[2] = std::max(ri.radius[2] * fBl, k_minR);
+        ri.radius[3] = std::max(ri.radius[3] * fTl, k_minR);
     }
 }
 

--- a/plugin/src/Caelestia/Blobs/blobshape.hpp
+++ b/plugin/src/Caelestia/Blobs/blobshape.hpp
@@ -53,6 +53,20 @@ protected:
     virtual void unregisterFromGroup();
     void updateCenteredDeformMatrix();
 
+    [[nodiscard]] QRectF localPaddedRect(float pad) const;
+    [[nodiscard]] QRectF paddedSceneRect(const QPointF& scenePos, float pad) const;
+    void writeRectData(BlobRectData& r, const QPointF& scenePos) const;
+    void updatePaddedBounds(float pad);
+    void collectNearbyRects(float pad, QVector<BlobShape*>& rectShapes);
+    void computeExcludeMasks(const QVector<BlobShape*>& rectShapes);
+    [[nodiscard]] bool isNearInvertedBorder(float cx, float cy, float hw, float hh, float margin) const;
+    void cacheInvertedRect(float pad);
+    void accumulateNeighbourFill(qsizetype index, const QVector<BlobShape*>& rectShapes, const float cornerX[4],
+        const float cornerY[4], float smoothFactor, float factors[4]) const;
+    void accumulateInvertedFill(
+        const float cornerX[4], const float cornerY[4], float smoothFactor, float factors[4]) const;
+    void applyCornerFill(float smoothFactor, const QVector<BlobShape*>& rectShapes);
+
     BlobGroup* m_group = nullptr;
     qreal m_radius = 0;
     QMatrix4x4 m_deformMatrix; // identity by default

--- a/plugin/src/Caelestia/Blobs/blobshape.hpp
+++ b/plugin/src/Caelestia/Blobs/blobshape.hpp
@@ -43,7 +43,7 @@ protected:
     void componentComplete() override;
     void geometryChange(const QRectF& newGeometry, const QRectF& oldGeometry) override;
     void updatePolish() override;
-    QSGNode* updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData*) override;
+    QSGNode* updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* data) override;
 
     virtual bool isInvertedRect() const { return false; }
 

--- a/plugin/src/Caelestia/Blobs/blobshape.hpp
+++ b/plugin/src/Caelestia/Blobs/blobshape.hpp
@@ -21,17 +21,17 @@ public:
     explicit BlobShape(QQuickItem* parent = nullptr);
     ~BlobShape() override = default;
 
-    BlobGroup* group() const { return m_group; }
+    [[nodiscard]] BlobGroup* group() const { return m_group; }
 
     void setGroup(BlobGroup* g);
 
-    qreal radius() const { return m_radius; }
+    [[nodiscard]] qreal radius() const { return m_radius; }
 
     void setRadius(qreal r);
 
-    QMatrix4x4 deformMatrix() const { return m_centeredDeformMatrix; }
+    [[nodiscard]] QMatrix4x4 deformMatrix() const { return m_centeredDeformMatrix; }
 
-    QMatrix4x4 rawDeformMatrix() const { return m_deformMatrix; }
+    [[nodiscard]] QMatrix4x4 rawDeformMatrix() const { return m_deformMatrix; }
 
 signals:
     void groupChanged();
@@ -45,7 +45,7 @@ protected:
     void updatePolish() override;
     QSGNode* updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* data) override;
 
-    virtual bool isInvertedRect() const { return false; }
+    [[nodiscard]] virtual bool isInvertedRect() const { return false; }
 
     virtual bool isExcluded(const BlobShape* /*other*/) const { return false; }
 

--- a/plugin/src/Caelestia/Blobs/blobshape.hpp
+++ b/plugin/src/Caelestia/Blobs/blobshape.hpp
@@ -21,17 +21,14 @@ public:
     explicit BlobShape(QQuickItem* parent = nullptr);
     ~BlobShape() override = default;
 
-    [[nodiscard]] BlobGroup* group() const { return m_group; }
-
+    [[nodiscard]] BlobGroup* group() const;
     void setGroup(BlobGroup* g);
 
-    [[nodiscard]] qreal radius() const { return m_radius; }
-
+    [[nodiscard]] qreal radius() const;
     void setRadius(qreal r);
 
-    [[nodiscard]] QMatrix4x4 deformMatrix() const { return m_centeredDeformMatrix; }
-
-    [[nodiscard]] QMatrix4x4 rawDeformMatrix() const { return m_deformMatrix; }
+    [[nodiscard]] QMatrix4x4 deformMatrix() const;
+    [[nodiscard]] QMatrix4x4 rawDeformMatrix() const;
 
 signals:
     void groupChanged();
@@ -45,15 +42,12 @@ protected:
     void updatePolish() override;
     QSGNode* updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData* data) override;
 
-    [[nodiscard]] virtual bool isInvertedRect() const { return false; }
-
-    virtual bool isExcluded(const BlobShape* /*other*/) const { return false; }
-
-    virtual bool isCornerExcluded(const BlobShape* /*other*/) const { return false; }
+    [[nodiscard]] virtual bool isInvertedRect() const;
+    [[nodiscard]] virtual bool isExcluded(const BlobShape* other) const;
+    [[nodiscard]] virtual bool isCornerExcluded(const BlobShape* other) const;
 
     virtual void cornerRadii(float out[4]) const;
-
-    virtual void updatePhysics() {}
+    virtual void updatePhysics();
 
     virtual void registerWithGroup();
     virtual void unregisterFromGroup();

--- a/plugin/src/Caelestia/Components/buttonrow.hpp
+++ b/plugin/src/Caelestia/Components/buttonrow.hpp
@@ -13,7 +13,7 @@ class ButtonRow : public QQuickItem {
 public:
     explicit ButtonRow(QQuickItem* parent = nullptr);
 
-    qreal spacing() const;
+    [[nodiscard]] qreal spacing() const;
     void setSpacing(qreal spacing);
 
 signals:

--- a/plugin/src/Caelestia/Components/circularindicatormanager.cpp
+++ b/plugin/src/Caelestia/Components/circularindicatormanager.cpp
@@ -7,39 +7,39 @@ namespace {
 
 namespace advance {
 
-constexpr qint32 TOTAL_CYCLES = 4;
-constexpr qint32 TOTAL_DURATION_IN_MS = 5400;
-constexpr qint32 DURATION_TO_EXPAND_IN_MS = 667;
-constexpr qint32 DURATION_TO_COLLAPSE_IN_MS = 667;
-constexpr qint32 DURATION_TO_COMPLETE_END_IN_MS = 333;
-constexpr qint32 TAIL_DEGREES_OFFSET = -20;
-constexpr qint32 EXTRA_DEGREES_PER_CYCLE = 250;
-constexpr qint32 CONSTANT_ROTATION_DEGREES = 1520;
+constexpr qint32 k_totalCycles = 4;
+constexpr qint32 k_totalDurationInMs = 5400;
+constexpr qint32 k_durationToExpandInMs = 667;
+constexpr qint32 k_durationToCollapseInMs = 667;
+constexpr qint32 k_durationToCompleteEndInMs = 333;
+constexpr qint32 k_tailDegreesOffset = -20;
+constexpr qint32 k_extraDegreesPerCycle = 250;
+constexpr qint32 k_constantRotationDegrees = 1520;
 
-constexpr std::array<qint32, TOTAL_CYCLES> DELAY_TO_EXPAND_IN_MS = { 0, 1350, 2700, 4050 };
-constexpr std::array<qint32, TOTAL_CYCLES> DELAY_TO_COLLAPSE_IN_MS = { 667, 2017, 3367, 4717 };
+constexpr std::array<qint32, k_totalCycles> k_delayToExpandInMs = { 0, 1350, 2700, 4050 };
+constexpr std::array<qint32, k_totalCycles> k_delayToCollapseInMs = { 667, 2017, 3367, 4717 };
 
 } // namespace advance
 
 namespace retreat {
 
-constexpr qint32 TOTAL_DURATION_IN_MS = 6000;
-constexpr qint32 DURATION_SPIN_IN_MS = 500;
-constexpr qint32 DURATION_GROW_ACTIVE_IN_MS = 3000;
-constexpr qint32 DURATION_SHRINK_ACTIVE_IN_MS = 3000;
-constexpr std::array DELAY_SPINS_IN_MS = { 0, 1500, 3000, 4500 };
-constexpr qint32 DELAY_GROW_ACTIVE_IN_MS = 0;
-constexpr qint32 DELAY_SHRINK_ACTIVE_IN_MS = 3000;
-constexpr qint32 DURATION_TO_COMPLETE_END_IN_MS = 500;
+constexpr qint32 k_totalDurationInMs = 6000;
+constexpr qint32 k_durationSpinInMs = 500;
+constexpr qint32 k_durationGrowActiveInMs = 3000;
+constexpr qint32 k_durationShrinkActiveInMs = 3000;
+constexpr std::array k_delaySpinsInMs = { 0, 1500, 3000, 4500 };
+constexpr qint32 k_delayGrowActiveInMs = 0;
+constexpr qint32 k_delayShrinkActiveInMs = 3000;
+constexpr qint32 k_durationToCompleteEndInMs = 500;
 
 // Constants for animation values.
 
 // The total degrees that a constant rotation goes by.
-constexpr qint32 CONSTANT_ROTATION_DEGREES = 1080;
+constexpr qint32 k_constantRotationDegrees = 1080;
 // Despite of the constant rotation, there are also 5 extra rotations the entire animation. The
 // total degrees that each extra rotation goes by.
-constexpr qint32 SPIN_ROTATION_DEGREES = 90;
-constexpr std::array<qreal, 2> END_FRACTION_RANGE = { 0.10, 0.87 };
+constexpr qint32 k_spinRotationDegrees = 90;
+constexpr std::array<qreal, 2> k_endFractionRange = { 0.10, 0.87 };
 
 } // namespace retreat
 
@@ -87,16 +87,16 @@ void CircularIndicatorManager::setProgress(qreal progress) {
 
 qreal CircularIndicatorManager::duration() const {
     if (m_type == IndeterminateAnimationType::Advance) {
-        return advance::TOTAL_DURATION_IN_MS;
+        return advance::k_totalDurationInMs;
     }
-    return retreat::TOTAL_DURATION_IN_MS;
+    return retreat::k_totalDurationInMs;
 }
 
 qreal CircularIndicatorManager::completeEndDuration() const {
     if (m_type == IndeterminateAnimationType::Advance) {
-        return advance::DURATION_TO_COMPLETE_END_IN_MS;
+        return advance::k_durationToCompleteEndInMs;
     }
-    return retreat::DURATION_TO_COMPLETE_END_IN_MS;
+    return retreat::k_durationToCompleteEndInMs;
 }
 
 CircularIndicatorManager::IndeterminateAnimationType CircularIndicatorManager::indeterminateAnimationType() const {
@@ -142,15 +142,15 @@ void CircularIndicatorManager::update(qreal progress) {
 
 void CircularIndicatorManager::updateRetreat(qreal progress) {
     using namespace retreat;
-    const auto playtime = progress * TOTAL_DURATION_IN_MS;
+    const auto playtime = progress * k_totalDurationInMs;
 
     // Constant rotation.
-    const qreal constantRotation = CONSTANT_ROTATION_DEGREES * progress;
+    const qreal constantRotation = k_constantRotationDegrees * progress;
     // Extra rotation for the faster spinning.
     qreal spinRotation = 0;
-    for (const int spinDelay : DELAY_SPINS_IN_MS) {
-        spinRotation += m_curve.valueForProgress(getFractionInRange(playtime, spinDelay, DURATION_SPIN_IN_MS)) *
-                        SPIN_ROTATION_DEGREES;
+    for (const int spinDelay : k_delaySpinsInMs) {
+        spinRotation += m_curve.valueForProgress(getFractionInRange(playtime, spinDelay, k_durationSpinInMs)) *
+                        k_spinRotationDegrees;
     }
     const auto oldRotation = m_rotation;
     m_rotation = constantRotation + spinRotation;
@@ -159,16 +159,16 @@ void CircularIndicatorManager::updateRetreat(qreal progress) {
 
     // Grow active indicator.
     qreal fraction =
-        m_curve.valueForProgress(getFractionInRange(playtime, DELAY_GROW_ACTIVE_IN_MS, DURATION_GROW_ACTIVE_IN_MS));
+        m_curve.valueForProgress(getFractionInRange(playtime, k_delayGrowActiveInMs, k_durationGrowActiveInMs));
     fraction -=
-        m_curve.valueForProgress(getFractionInRange(playtime, DELAY_SHRINK_ACTIVE_IN_MS, DURATION_SHRINK_ACTIVE_IN_MS));
+        m_curve.valueForProgress(getFractionInRange(playtime, k_delayShrinkActiveInMs, k_durationShrinkActiveInMs));
 
     if (!qFuzzyIsNull(m_startFraction)) {
         m_startFraction = 0.0;
         emit startFractionChanged();
     }
     const auto oldEndFrac = m_endFraction;
-    m_endFraction = std::lerp(END_FRACTION_RANGE[0], END_FRACTION_RANGE[1], fraction);
+    m_endFraction = std::lerp(k_endFractionRange[0], k_endFractionRange[1], fraction);
 
     // Completing animation.
     if (m_completeEndProgress > 0) {
@@ -182,23 +182,23 @@ void CircularIndicatorManager::updateRetreat(qreal progress) {
 
 void CircularIndicatorManager::updateAdvance(qreal progress) {
     using namespace advance;
-    const auto playtime = progress * TOTAL_DURATION_IN_MS;
+    const auto playtime = progress * k_totalDurationInMs;
     const auto oldStart = m_startFraction;
     const auto oldEnd = m_endFraction;
 
     // Adds constant rotation to segment positions.
-    m_startFraction = CONSTANT_ROTATION_DEGREES * progress + TAIL_DEGREES_OFFSET;
-    m_endFraction = CONSTANT_ROTATION_DEGREES * progress;
+    m_startFraction = k_constantRotationDegrees * progress + k_tailDegreesOffset;
+    m_endFraction = k_constantRotationDegrees * progress;
 
     // Adds cycle specific rotation to segment positions.
-    for (size_t cycleIndex = 0; cycleIndex < TOTAL_CYCLES; ++cycleIndex) {
+    for (size_t cycleIndex = 0; cycleIndex < k_totalCycles; ++cycleIndex) {
         // While expanding.
-        qreal fraction = getFractionInRange(playtime, DELAY_TO_EXPAND_IN_MS[cycleIndex], DURATION_TO_EXPAND_IN_MS);
-        m_endFraction += m_curve.valueForProgress(fraction) * EXTRA_DEGREES_PER_CYCLE;
+        qreal fraction = getFractionInRange(playtime, k_delayToExpandInMs[cycleIndex], k_durationToExpandInMs);
+        m_endFraction += m_curve.valueForProgress(fraction) * k_extraDegreesPerCycle;
 
         // While collapsing.
-        fraction = getFractionInRange(playtime, DELAY_TO_COLLAPSE_IN_MS[cycleIndex], DURATION_TO_COLLAPSE_IN_MS);
-        m_startFraction += m_curve.valueForProgress(fraction) * EXTRA_DEGREES_PER_CYCLE;
+        fraction = getFractionInRange(playtime, k_delayToCollapseInMs[cycleIndex], k_durationToCollapseInMs);
+        m_startFraction += m_curve.valueForProgress(fraction) * k_extraDegreesPerCycle;
     }
 
     // Closes the gap between head and tail for complete end.

--- a/plugin/src/Caelestia/Components/circularindicatormanager.cpp
+++ b/plugin/src/Caelestia/Components/circularindicatormanager.cpp
@@ -88,17 +88,15 @@ void CircularIndicatorManager::setProgress(qreal progress) {
 qreal CircularIndicatorManager::duration() const {
     if (m_type == IndeterminateAnimationType::Advance) {
         return advance::TOTAL_DURATION_IN_MS;
-    } else {
-        return retreat::TOTAL_DURATION_IN_MS;
     }
+    return retreat::TOTAL_DURATION_IN_MS;
 }
 
 qreal CircularIndicatorManager::completeEndDuration() const {
     if (m_type == IndeterminateAnimationType::Advance) {
         return advance::DURATION_TO_COMPLETE_END_IN_MS;
-    } else {
-        return retreat::DURATION_TO_COMPLETE_END_IN_MS;
     }
+    return retreat::DURATION_TO_COMPLETE_END_IN_MS;
 }
 
 CircularIndicatorManager::IndeterminateAnimationType CircularIndicatorManager::indeterminateAnimationType() const {

--- a/plugin/src/Caelestia/Components/circularindicatormanager.hpp
+++ b/plugin/src/Caelestia/Components/circularindicatormanager.hpp
@@ -24,7 +24,7 @@ class CircularIndicatorManager : public QObject {
 public:
     explicit CircularIndicatorManager(QObject* parent = nullptr);
 
-    enum IndeterminateAnimationType {
+    enum IndeterminateAnimationType : quint8 {
         Advance = 0,
         Retreat
     };

--- a/plugin/src/Caelestia/Components/lazylistview.cpp
+++ b/plugin/src/Caelestia/Components/lazylistview.cpp
@@ -7,8 +7,8 @@
 
 namespace {
 
-constexpr int ASYNC_BATCH_CREATE = 2;
-constexpr int ASYNC_BATCH_DESTROY = 4;
+constexpr int k_asyncBatchCreate = 2;
+constexpr int k_asyncBatchDestroy = 4;
 
 } // namespace
 
@@ -612,7 +612,7 @@ void LazyListView::syncDelegates() {
     }
 
     // Batch destroy
-    const int destroyBudget = m_asynchronous ? ASYNC_BATCH_DESTROY : static_cast<int>(toRemove.size());
+    const int destroyBudget = m_asynchronous ? k_asyncBatchDestroy : static_cast<int>(toRemove.size());
     QVector<DelegateEntry> removedEntries;
     removedEntries.reserve(std::min(destroyBudget, static_cast<int>(toRemove.size())));
     int destroyed = 0;
@@ -638,7 +638,7 @@ void LazyListView::syncDelegates() {
     }
 
     // Batch create
-    const int createBudget = m_asynchronous ? ASYNC_BATCH_CREATE : static_cast<int>(toCreate.size());
+    const int createBudget = m_asynchronous ? k_asyncBatchCreate : static_cast<int>(toCreate.size());
     int created = 0;
     for (const int i : toCreate) {
         if (created >= createBudget)

--- a/plugin/src/Caelestia/Components/lazylistview.cpp
+++ b/plugin/src/Caelestia/Components/lazylistview.cpp
@@ -616,7 +616,7 @@ void LazyListView::syncDelegates() {
     QVector<DelegateEntry> removedEntries;
     removedEntries.reserve(std::min(destroyBudget, static_cast<int>(toRemove.size())));
     int destroyed = 0;
-    for (int idx : toRemove) {
+    for (const int idx : toRemove) {
         if (destroyed >= destroyBudget)
             break;
         auto entry = m_delegates.take(idx);
@@ -640,7 +640,7 @@ void LazyListView::syncDelegates() {
     // Batch create
     const int createBudget = m_asynchronous ? ASYNC_BATCH_CREATE : static_cast<int>(toCreate.size());
     int created = 0;
-    for (int i : toCreate) {
+    for (const int i : toCreate) {
         if (created >= createBudget)
             break;
 
@@ -920,7 +920,7 @@ void LazyListView::onRowsInserted(const QModelIndex& parent, int first, int last
     // Shift existing delegate indices
     QHash<int, DelegateEntry> shifted;
     for (auto it = m_delegates.begin(); it != m_delegates.end(); ++it) {
-        int newIdx = it.key() >= first ? it.key() + insertCount : it.key();
+        const int newIdx = it.key() >= first ? it.key() + insertCount : it.key();
         auto entry = std::move(it.value());
         entry.modelIndex = newIdx;
         if (entry.item) {
@@ -996,7 +996,7 @@ void LazyListView::onRowsRemoved(const QModelIndex& parent, int first, int last)
     // Shift remaining delegate indices down
     QHash<int, DelegateEntry> shifted;
     for (auto it = m_delegates.begin(); it != m_delegates.end(); ++it) {
-        int newIdx = it.key() > last ? it.key() - removeCount : it.key();
+        const int newIdx = it.key() > last ? it.key() - removeCount : it.key();
         auto entry = std::move(it.value());
         entry.modelIndex = newIdx;
         if (entry.item) {
@@ -1030,7 +1030,7 @@ void LazyListView::onRowsMoved(const QModelIndex& parent, int start, int end, co
     // Remap delegate indices to match new model order
     QHash<int, DelegateEntry> remapped;
     for (auto it = m_delegates.begin(); it != m_delegates.end(); ++it) {
-        int oldIdx = it.key();
+        const int oldIdx = it.key();
         int newIdx = oldIdx;
 
         if (oldIdx >= start && oldIdx <= end) {

--- a/plugin/src/Caelestia/Components/lazylistview.cpp
+++ b/plugin/src/Caelestia/Components/lazylistview.cpp
@@ -9,6 +9,16 @@ namespace {
 
 constexpr int k_asyncBatchCreate = 2;
 constexpr int k_asyncBatchDestroy = 4;
+constexpr qreal k_fallbackHeight = 40;
+
+// Clip a rect vertically to [top, bottom], empty if there is no overlap
+QRectF clipVertical(const QRectF& rect, qreal top, qreal bottom) {
+    const qreal newTop = std::max(rect.y(), top);
+    const qreal newBottom = std::min(rect.y() + rect.height(), bottom);
+    if (newTop >= newBottom)
+        return {};
+    return { rect.x(), newTop, rect.width(), newBottom - newTop };
+}
 
 } // namespace
 
@@ -236,12 +246,57 @@ void LazyListView::setAsynchronous(bool async) {
     emit asynchronousChanged();
 }
 
+LazyListViewAttached* LazyListView::attachedFor(QQuickItem* item) {
+    return qobject_cast<LazyListViewAttached*>(qmlAttachedPropertiesObject<LazyListView>(item, false));
+}
+
+LazyListViewAttached* LazyListView::attachedForCreate(QQuickItem* item) {
+    return qobject_cast<LazyListViewAttached*>(qmlAttachedPropertiesObject<LazyListView>(item, true));
+}
+
 qreal LazyListView::effectiveEstimatedHeight() const {
     if (m_estimatedHeight >= 0)
         return m_estimatedHeight;
     if (m_knownHeightCount > 0)
         return m_knownHeightSum / m_knownHeightCount;
-    return 40;
+    return k_fallbackHeight;
+}
+
+// Height used for layout positioning, falling back to the estimate while unmeasured
+qreal LazyListView::layoutHeightAt(int index) const {
+    const auto& record = m_layout[index];
+    return record.heightKnown ? record.height : effectiveEstimatedHeight();
+}
+
+// Height as currently rendered, so scrolling follows in-flight animations
+qreal LazyListView::visibleHeightAt(int index) const {
+    const auto it = m_delegates.find(index);
+    if (it != m_delegates.end() && it->item)
+        return delegateVisibleHeight(it->item);
+    return layoutHeightAt(index);
+}
+
+// Position of an item in visible-height space, including the spacing before it.
+// Only non-zero height items participate, so collapsed rows add no spacing.
+qreal LazyListView::visualYAt(int index) const {
+    qreal y = 0;
+    bool hasItem = false;
+    for (int i = 0; i < index; ++i) {
+        const qreal h = visibleHeightAt(i);
+        if (h <= 0)
+            continue;
+        if (hasItem)
+            y += m_spacing;
+        hasItem = true;
+        y += h;
+    }
+    if (hasItem && visibleHeightAt(index) > 0)
+        y += m_spacing;
+    return y;
+}
+
+qreal LazyListView::viewportTop() const {
+    return m_useCustomViewport ? m_viewport.y() : m_contentY;
 }
 
 void LazyListView::trackHeight(qreal height) {
@@ -254,11 +309,33 @@ void LazyListView::untrackHeight(qreal height) {
     --m_knownHeightCount;
 }
 
+// Records a measured height for an item, keeping the running average in sync
+LazyListView::HeightUpdate LazyListView::setKnownHeight(int index, qreal height) {
+    auto& record = m_layout[index];
+    const HeightUpdate previous{ .previousHeight = layoutHeightAt(index), .wasKnown = record.heightKnown };
+
+    if (record.heightKnown)
+        untrackHeight(record.height);
+    record.height = height;
+    record.heightKnown = true;
+    trackHeight(height);
+
+    return previous;
+}
+
+// A resize above the viewport shifts everything below it, so opted-in delegates
+// report the delta and let the consumer compensate its scroll position.
+void LazyListView::adjustViewportIfAbove(int index, QQuickItem* item, qreal delta) {
+    auto* attached = attachedFor(item);
+    if (attached && attached->trackViewport() && m_layout[index].targetY < viewportTop())
+        emit viewportAdjustNeeded(delta);
+}
+
 qreal LazyListView::delegateHeight(QQuickItem* item) {
     if (!item)
         return 0;
 
-    auto* attached = qobject_cast<LazyListViewAttached*>(qmlAttachedPropertiesObject<LazyListView>(item, false));
+    auto* attached = attachedFor(item);
     if (attached && attached->preferredHeight() >= 0)
         return attached->preferredHeight();
 
@@ -269,22 +346,18 @@ qreal LazyListView::delegateVisibleHeight(QQuickItem* item) {
     if (!item)
         return 0;
 
-    auto* attached = qobject_cast<LazyListViewAttached*>(qmlAttachedPropertiesObject<LazyListView>(item, false));
-    if (attached) {
-        if (attached->visibleHeight() >= 0)
-            return attached->visibleHeight();
-        if (attached->preferredHeight() >= 0)
-            return attached->preferredHeight();
-    }
+    auto* attached = attachedFor(item);
+    if (attached && attached->visibleHeight() >= 0)
+        return attached->visibleHeight();
 
-    return item->implicitHeight();
+    return delegateHeight(item);
 }
 
 bool LazyListView::isDelegateReady(QQuickItem* item) {
     if (!item)
         return false;
-    auto* att = qobject_cast<LazyListViewAttached*>(qmlAttachedPropertiesObject<LazyListView>(item, false));
-    return !att || att->ready();
+    auto* attached = attachedFor(item);
+    return !attached || attached->ready();
 }
 
 // --- Animation Durations ---
@@ -345,90 +418,80 @@ void LazyListView::updatePolish() {
     if (!m_componentComplete || !m_model || !m_delegate)
         return;
 
-    // Flush pending inserts — make items visible and clear the adding flag
-    // so enter animations begin. When readyDelay > 0 the entire insert is
-    // deferred so delegates have time to lay out before appearing.
-    for (auto& entry : m_delegates) {
-        if (!entry.pendingInsert || !entry.item)
-            continue;
-
-        if (m_readyDelay > 0) {
-            if (!entry.readyDelayStarted) {
-                entry.readyDelayStarted = true;
-                auto* item = entry.item;
-                QTimer::singleShot(m_readyDelay, this, [this, item] {
-                    auto indexIt = m_itemToIndex.find(item);
-                    if (indexIt == m_itemToIndex.end())
-                        return;
-                    const int idx = indexIt.value();
-                    auto it = m_delegates.find(idx);
-                    if (it == m_delegates.end() || it->item != item || !it->pendingInsert)
-                        return;
-
-                    it->pendingInsert = false;
-                    it->readyDelayStarted = false;
-
-                    // Set initial y to visual position (based on current visible heights)
-                    if (idx >= 0 && idx < static_cast<int>(m_layout.size())) {
-                        qreal visualY = 0;
-                        bool hasVisItem = false;
-                        for (int i = 0; i < static_cast<int>(m_layout.size()); ++i) {
-                            qreal h;
-                            auto dit = m_delegates.find(i);
-                            if (dit != m_delegates.end() && dit->item)
-                                h = delegateVisibleHeight(dit->item);
-                            else
-                                h = m_layout[i].heightKnown ? m_layout[i].height : effectiveEstimatedHeight();
-                            if (h > 0) {
-                                if (hasVisItem)
-                                    visualY += m_spacing;
-                                hasVisItem = true;
-                            }
-                            if (i == idx)
-                                break;
-                            if (h > 0)
-                                visualY += h;
-                        }
-                        item->setY(visualY - m_contentY);
-                    }
-
-                    item->setVisible(true);
-                    auto* att =
-                        qobject_cast<LazyListViewAttached*>(qmlAttachedPropertiesObject<LazyListView>(item, false));
-                    if (att) {
-                        att->setAdding(false);
-                        att->setReady(true);
-                    }
-
-                    // Animate from visual position to layout position
-                    if (idx >= 0 && idx < static_cast<int>(m_layout.size()))
-                        item->setProperty("y", m_layout[idx].targetY - m_contentY);
-
-                    polish();
-                });
-            }
-            continue;
-        }
-
-        entry.pendingInsert = false;
-        entry.item->setVisible(true);
-        auto* att = qobject_cast<LazyListViewAttached*>(qmlAttachedPropertiesObject<LazyListView>(entry.item, false));
-        if (att) {
-            att->setAdding(false);
-            att->setReady(true);
-        }
-    }
-
+    flushPendingInserts();
     relayout();
     syncDelegates();
 
-    // Clear isNew flags — the add animation only plays for items created
+    // Clear isNew flags - the add animation only plays for items created
     // during the same polish cycle as their model insertion, not for
     // delegates created later when scrolling items into the viewport.
     for (auto& record : m_layout)
         record.isNew = false;
 
-    // Position delegates — QML Behavior on y handles the animation
+    positionDelegates();
+}
+
+// Makes newly created delegates visible and clears the adding flag so enter
+// animations begin. When readyDelay > 0 the reveal is deferred so delegates
+// have time to lay out before appearing.
+void LazyListView::flushPendingInserts() {
+    for (auto& entry : m_delegates) {
+        if (!entry.pendingInsert || !entry.item)
+            continue;
+
+        if (m_readyDelay <= 0) {
+            entry.pendingInsert = false;
+            revealDelegate(entry.item);
+            continue;
+        }
+
+        if (!entry.readyDelayStarted) {
+            entry.readyDelayStarted = true;
+            QTimer::singleShot(m_readyDelay, this, [this, item = entry.item] {
+                finishDelayedInsert(item);
+            });
+        }
+    }
+}
+
+void LazyListView::revealDelegate(QQuickItem* item) {
+    item->setVisible(true);
+
+    auto* attached = attachedFor(item);
+    if (attached) {
+        attached->setAdding(false);
+        attached->setReady(true);
+    }
+}
+
+// Reveals a delegate whose readyDelay has elapsed, seeding its y from the
+// current visual position so the move to the layout position animates.
+void LazyListView::finishDelayedInsert(QQuickItem* item) {
+    const int idx = indexOfDelegate(item);
+    if (idx < 0)
+        return;
+
+    auto& entry = m_delegates[idx];
+    if (!entry.pendingInsert)
+        return;
+
+    entry.pendingInsert = false;
+    entry.readyDelayStarted = false;
+
+    if (idx < static_cast<int>(m_layout.size()))
+        item->setY(visualYAt(idx) - m_contentY);
+
+    revealDelegate(item);
+
+    // Re-check the bounds: revealing runs QML bindings and onReady handlers,
+    // which may have mutated the model out from under us.
+    if (idx < static_cast<int>(m_layout.size()))
+        item->setProperty("y", m_layout[idx].targetY - m_contentY); // animate to layout position
+
+    polish();
+}
+
+void LazyListView::positionDelegates() {
     for (auto& entry : m_delegates) {
         if (!entry.item || entry.pendingRemoval || entry.pendingInsert)
             continue;
@@ -449,46 +512,41 @@ void LazyListView::updatePolish() {
 // --- Layout Engine ---
 
 void LazyListView::relayout() {
-    // Layout positioning uses preferredHeight (final/non-animated).
-    // Only add spacing between items with non-zero height.
+    updateLayoutPositions();
+    updateContentHeight();
+}
+
+// Layout positioning uses preferredHeight (final/non-animated).
+// Only adds spacing between items with non-zero height.
+void LazyListView::updateLayoutPositions() {
     qreal y = 0;
-    bool hasLayoutItem = false;
-    for (auto& record : m_layout) {
-        const qreal layoutH = record.heightKnown ? record.height : effectiveEstimatedHeight();
-        if (layoutH > 0) {
-            if (hasLayoutItem)
-                y += m_spacing;
-            hasLayoutItem = true;
-            record.targetY = y;
-            y += layoutH;
-        } else {
+    bool hasItem = false;
+    for (int i = 0; i < static_cast<int>(m_layout.size()); ++i) {
+        auto& record = m_layout[i];
+        record.targetY = y;
+
+        const qreal h = layoutHeightAt(i);
+        if (h <= 0)
+            continue;
+
+        if (hasItem) {
+            y += m_spacing;
             record.targetY = y;
         }
+        hasItem = true;
+        y += h;
     }
 
     if (!qFuzzyCompare(m_layoutHeight + 1.0, y + 1.0)) {
         m_layoutHeight = y;
         emit layoutHeightChanged();
     }
+}
 
-    // Content height tracks actual visible heights so scrolling follows animations.
-    // Only add spacing between items with non-zero visible height.
-    qreal visY = 0;
-    bool hasVisItem = false;
-    for (int i = 0; i < static_cast<int>(m_layout.size()); ++i) {
-        qreal h;
-        auto dit = m_delegates.find(i);
-        if (dit != m_delegates.end() && dit->item)
-            h = delegateVisibleHeight(dit->item);
-        else
-            h = m_layout[i].heightKnown ? m_layout[i].height : effectiveEstimatedHeight();
-        if (h > 0) {
-            if (hasVisItem)
-                visY += m_spacing;
-            hasVisItem = true;
-            visY += h;
-        }
-    }
+// Content height tracks actual visible heights so scrolling follows animations
+void LazyListView::updateContentHeight() {
+    const int last = static_cast<int>(m_layout.size()) - 1;
+    qreal visY = last < 0 ? 0 : visualYAt(last) + visibleHeightAt(last);
 
     // Account for dying delegates still visually present
     for (const auto& dying : std::as_const(m_dyingDelegates)) {
@@ -503,6 +561,19 @@ void LazyListView::relayout() {
         m_contentHeight = visY;
         emit contentHeightChanged();
     }
+}
+
+// Coalesces height-driven relayouts into a single deferred pass
+void LazyListView::scheduleRelayout() {
+    if (m_relayoutPending)
+        return;
+
+    m_relayoutPending = true;
+    QTimer::singleShot(0, this, [this] {
+        m_relayoutPending = false;
+        relayout();
+        polish();
+    });
 }
 
 QRectF LazyListView::effectiveViewport() const {
@@ -528,14 +599,8 @@ QRectF LazyListView::effectiveViewport() const {
     // Trim the cache-buffered viewport to [0, layoutHeight]. No items exist outside
     // those bounds, so extending past them wastes budget and can cause edge thrashing
     // when a large cache buffer reaches the opposite end of the content.
-    if (m_layoutHeight > 0) {
-        const qreal top = std::max(vp.y(), 0.0);
-        const qreal bottom = std::min(vp.y() + vp.height(), m_layoutHeight);
-        if (top < bottom)
-            vp = QRectF(vp.x(), top, vp.width(), bottom - top);
-        else
-            return {};
-    }
+    if (m_layoutHeight > 0)
+        return clipVertical(vp, 0, m_layoutHeight);
 
     return vp;
 }
@@ -595,72 +660,101 @@ void LazyListView::syncDelegates() {
             visibleIndices.insert(i);
     }
 
-    // Collect delegates to destroy — only if visually outside the viewport
-    const auto vp = effectiveViewport();
-    QList<int> toRemove;
-    for (auto it = m_delegates.begin(); it != m_delegates.end(); ++it) {
-        if (visibleIndices.contains(it.key()))
-            continue;
-        if (!it->item || vp.isEmpty()) {
-            toRemove.append(it.key());
-            continue;
-        }
-        const qreal itemTop = it->item->y();
-        const qreal itemBottom = itemTop + delegateVisibleHeight(it->item);
-        if (itemBottom < vp.top() || itemTop > vp.bottom())
-            toRemove.append(it.key());
-    }
+    const auto toRemove = delegatesOutsideViewport(visibleIndices, effectiveViewport());
+    const int destroyed =
+        destroyDelegates(toRemove, m_asynchronous ? k_asyncBatchDestroy : static_cast<int>(toRemove.size()));
 
-    // Batch destroy
-    const int destroyBudget = m_asynchronous ? k_asyncBatchDestroy : static_cast<int>(toRemove.size());
-    QVector<DelegateEntry> removedEntries;
-    removedEntries.reserve(std::min(destroyBudget, static_cast<int>(toRemove.size())));
-    int destroyed = 0;
-    for (const int idx : toRemove) {
-        if (destroyed >= destroyBudget)
-            break;
-        auto entry = m_delegates.take(idx);
-        if (entry.item)
-            m_itemToIndex.remove(entry.item);
-        removedEntries.append(std::move(entry));
-        ++destroyed;
-    }
-    for (auto& entry : removedEntries)
-        destroyDelegate(entry);
-
-    // Collect indices to create
-    QList<int> toCreate;
-    if (first >= 0) {
-        for (int i = first; i <= last; ++i) {
-            if (!m_delegates.contains(i))
-                toCreate.append(i);
-        }
-    }
-
-    // Batch create
-    const int createBudget = m_asynchronous ? k_asyncBatchCreate : static_cast<int>(toCreate.size());
-    int created = 0;
-    for (const int i : toCreate) {
-        if (created >= createBudget)
-            break;
-
-        auto entry = createDelegate(i);
-        if (entry.item) {
-            // Height tracking and viewport compensation are deferred
-            // until the delegate signals ready via readyChanged.
-            entry.pendingInsert = true;
-            entry.item->setY(m_layout[i].targetY - m_contentY);
-            m_itemToIndex.insert(entry.item, i);
-            m_delegates.insert(i, entry);
-            ++created;
-        }
-    }
+    const auto toCreate = missingDelegates(first, last);
+    const int created =
+        createDelegates(toCreate, m_asynchronous ? k_asyncBatchCreate : static_cast<int>(toCreate.size()));
 
     // Pending inserts need to become visible on the next frame, and
     // async mode may have remaining create/destroy work.
-    if (created > 0 || (m_asynchronous && (destroyed < static_cast<int>(toRemove.size()) ||
-                                              created < static_cast<int>(toCreate.size()))))
+    const bool workRemains = m_asynchronous && (destroyed < static_cast<int>(toRemove.size()) ||
+                                                   created < static_cast<int>(toCreate.size()));
+    if (created > 0 || workRemains)
         polish();
+}
+
+// Delegates safe to destroy - outside the range to keep and no longer visually
+// overlapping the viewport, so nothing mid-animation disappears.
+QList<int> LazyListView::delegatesOutsideViewport(const QSet<int>& keep, const QRectF& viewport) const {
+    QList<int> outside;
+
+    for (auto it = m_delegates.constBegin(); it != m_delegates.constEnd(); ++it) {
+        if (keep.contains(it.key()))
+            continue;
+
+        if (!it->item || viewport.isEmpty()) {
+            outside.append(it.key());
+            continue;
+        }
+
+        const qreal itemTop = it->item->y();
+        const qreal itemBottom = itemTop + delegateVisibleHeight(it->item);
+        if (itemBottom < viewport.top() || itemTop > viewport.bottom())
+            outside.append(it.key());
+    }
+
+    return outside;
+}
+
+QList<int> LazyListView::missingDelegates(int first, int last) const {
+    if (first < 0)
+        return {};
+
+    QList<int> missing;
+    for (int i = first; i <= last; ++i) {
+        if (!m_delegates.contains(i))
+            missing.append(i);
+    }
+
+    return missing;
+}
+
+int LazyListView::destroyDelegates(const QList<int>& indices, int budget) {
+    // Take entries out of the maps first so destruction cannot observe
+    // a delegate that is already unreachable from the view.
+    QVector<DelegateEntry> removed;
+    removed.reserve(std::min(budget, static_cast<int>(indices.size())));
+
+    for (const int idx : indices) {
+        if (static_cast<int>(removed.size()) >= budget)
+            break;
+
+        auto entry = m_delegates.take(idx);
+        if (entry.item)
+            m_itemToIndex.remove(entry.item);
+        removed.append(std::move(entry));
+    }
+
+    for (auto& entry : removed)
+        destroyDelegate(entry);
+
+    return static_cast<int>(removed.size());
+}
+
+int LazyListView::createDelegates(const QList<int>& indices, int budget) {
+    int created = 0;
+
+    for (const int idx : indices) {
+        if (created >= budget)
+            break;
+
+        auto entry = createDelegate(idx);
+        if (!entry.item)
+            continue;
+
+        // Height tracking and viewport compensation are deferred
+        // until the delegate signals ready via readyChanged.
+        entry.pendingInsert = true;
+        entry.item->setY(m_layout[idx].targetY - m_contentY);
+        m_itemToIndex.insert(entry.item, idx);
+        m_delegates.insert(idx, entry);
+        ++created;
+    }
+
+    return created;
 }
 
 LazyListView::DelegateEntry LazyListView::createDelegate(int modelIndex) {
@@ -669,8 +763,6 @@ LazyListView::DelegateEntry LazyListView::createDelegate(int modelIndex) {
 
     if (!m_delegate || !m_model)
         return entry;
-
-    const auto roleNames = m_model->roleNames();
 
     // Use the delegate component's creation context for beginCreate
     // so bound components (pragma ComponentBehavior: Bound) are accepted.
@@ -690,24 +782,10 @@ LazyListView::DelegateEntry LazyListView::createDelegate(int modelIndex) {
         return entry;
     }
 
-    // Build initial properties from model data
-    const auto index = m_model->index(modelIndex, 0);
+    const auto props = delegateProperties(modelIndex);
     QVariantMap initialProps;
-    bool hasModelData = false;
-
-    for (auto it = roleNames.constBegin(); it != roleNames.constEnd(); ++it) {
-        const auto name = QString::fromUtf8(it.value());
-        initialProps.insert(name, m_model->data(index, it.key()));
-        if (name == QStringLiteral("modelData"))
-            hasModelData = true;
-    }
-    initialProps.insert(QStringLiteral("index"), modelIndex);
-
-    if (!hasModelData) {
-        const auto role = roleNames.isEmpty() ? Qt::DisplayRole : roleNames.constBegin().key();
-        initialProps.insert(QStringLiteral("modelData"), m_model->data(index, role));
-    }
-
+    for (const auto& [name, value] : props)
+        initialProps.insert(name, value);
     m_delegate->setInitialProperties(entry.item, initialProps);
 
     entry.item->setParentItem(this);
@@ -716,101 +794,95 @@ LazyListView::DelegateEntry LazyListView::createDelegate(int modelIndex) {
     // Only set adding = true for genuinely new model items (not viewport entries).
     // Cleared on the next frame in updatePolish when the item becomes visible.
     if (modelIndex < static_cast<int>(m_layout.size()) && m_layout[modelIndex].isNew) {
-        auto* addingAttached =
-            qobject_cast<LazyListViewAttached*>(qmlAttachedPropertiesObject<LazyListView>(entry.item, true));
-        if (addingAttached)
-            addingAttached->setAdding(true);
+        auto* attached = attachedForCreate(entry.item);
+        if (attached)
+            attached->setAdding(true);
     }
 
     m_delegate->completeCreate();
 
-    // Keep adding=true and hide — flushed on the next frame in updatePolish
+    // Keep adding=true and hide - flushed on the next frame in updatePolish
     entry.item->setVisible(false);
 
-    // Height-change handler — uses m_itemToIndex for O(1) lookup.
-    // Ignored while the delegate is not yet ready.
-    auto onHeightChanged = [this, item = entry.item] {
-        if (!isDelegateReady(item))
-            return;
-        auto indexIt = m_itemToIndex.find(item);
-        if (indexIt == m_itemToIndex.end())
-            return;
-        const int idx = indexIt.value();
-        auto delegateIt = m_delegates.find(idx);
-        if (delegateIt == m_delegates.end() || delegateIt->item != item)
-            return;
-        const qreal h = delegateHeight(item);
-        if (idx < static_cast<int>(m_layout.size()) && !qFuzzyCompare(m_layout[idx].height + 1.0, h + 1.0)) {
-            const qreal oldH = m_layout[idx].height;
-            const bool wasKnown = m_layout[idx].heightKnown;
-            m_layout[idx].height = h;
-            m_layout[idx].heightKnown = true;
-            if (wasKnown)
-                untrackHeight(oldH);
-            trackHeight(h);
-
-            // If this tracked item is above the viewport, emit a
-            // compensation delta so the consumer can adjust scroll.
-            if (wasKnown) {
-                auto* att = qobject_cast<LazyListViewAttached*>(qmlAttachedPropertiesObject<LazyListView>(item, false));
-                if (att && att->trackViewport()) {
-                    const qreal vpTop = m_useCustomViewport ? m_viewport.y() : m_contentY;
-                    if (m_layout[idx].targetY < vpTop)
-                        emit viewportAdjustNeeded(h - oldH);
-                }
-            }
-
-            if (!m_relayoutPending) {
-                m_relayoutPending = true;
-                QTimer::singleShot(0, this, [this] {
-                    m_relayoutPending = false;
-                    relayout();
-                    polish();
-                });
-            }
-        }
-    };
-
-    // Watch implicitHeight as fallback
-    connect(entry.item, &QQuickItem::implicitHeightChanged, this, onHeightChanged);
-
-    // Watch attached properties if the delegate uses them
-    auto* attached = qobject_cast<LazyListViewAttached*>(qmlAttachedPropertiesObject<LazyListView>(entry.item, false));
-    if (attached) {
-        connect(attached, &LazyListViewAttached::preferredHeightChanged, this, onHeightChanged);
-        connect(attached, &LazyListViewAttached::visibleHeightChanged, this, [this] {
-            polish();
-        });
-        connect(attached, &LazyListViewAttached::readyChanged, this, [this, item = entry.item] {
-            auto indexIt = m_itemToIndex.find(item);
-            if (indexIt == m_itemToIndex.end())
-                return;
-            const int idx = indexIt.value();
-            if (idx >= static_cast<int>(m_layout.size()))
-                return;
-            auto* att = qobject_cast<LazyListViewAttached*>(qmlAttachedPropertiesObject<LazyListView>(item, false));
-            if (!att || !att->ready())
-                return;
-
-            const qreal h = delegateHeight(item);
-            const qreal oldLayoutH = m_layout[idx].heightKnown ? m_layout[idx].height : effectiveEstimatedHeight();
-            if (m_layout[idx].heightKnown)
-                untrackHeight(m_layout[idx].height);
-            m_layout[idx].height = h;
-            m_layout[idx].heightKnown = true;
-            trackHeight(h);
-
-            if (att->trackViewport() && !qFuzzyCompare(h + 1.0, oldLayoutH + 1.0)) {
-                const qreal vpTop = m_useCustomViewport ? m_viewport.y() : m_contentY;
-                if (m_layout[idx].targetY < vpTop)
-                    emit viewportAdjustNeeded(h - oldLayoutH);
-            }
-
-            polish();
-        });
-    }
+    connectDelegate(entry);
 
     return entry;
+}
+
+void LazyListView::connectDelegate(const DelegateEntry& entry) {
+    auto* item = entry.item;
+
+    // Watch implicitHeight as fallback
+    connect(item, &QQuickItem::implicitHeightChanged, this, [this, item] {
+        onDelegateHeightChanged(item);
+    });
+
+    // Watch attached properties if the delegate uses them
+    auto* attached = attachedFor(item);
+    if (!attached)
+        return;
+
+    connect(attached, &LazyListViewAttached::preferredHeightChanged, this, [this, item] {
+        onDelegateHeightChanged(item);
+    });
+    connect(attached, &LazyListViewAttached::visibleHeightChanged, this, [this] {
+        polish();
+    });
+    connect(attached, &LazyListViewAttached::readyChanged, this, [this, item] {
+        onDelegateReady(item);
+    });
+}
+
+// Resolves a delegate item to its model index, or -1 if it is no longer the
+// live delegate for that index (stale signal from a destroyed or replaced item).
+int LazyListView::indexOfDelegate(QQuickItem* item) const {
+    const auto indexIt = m_itemToIndex.constFind(item);
+    if (indexIt == m_itemToIndex.constEnd())
+        return -1;
+
+    const int idx = indexIt.value();
+    const auto delegateIt = m_delegates.constFind(idx);
+    if (delegateIt == m_delegates.constEnd() || delegateIt->item != item)
+        return -1;
+
+    return idx;
+}
+
+// Re-measures a delegate whose height changed after it became ready
+void LazyListView::onDelegateHeightChanged(QQuickItem* item) {
+    if (!isDelegateReady(item))
+        return;
+
+    const int idx = indexOfDelegate(item);
+    if (idx < 0 || idx >= static_cast<int>(m_layout.size()))
+        return;
+
+    const qreal h = delegateHeight(item);
+    if (qFuzzyCompare(m_layout[idx].height + 1.0, h + 1.0))
+        return;
+
+    const auto previous = setKnownHeight(idx, h);
+    if (previous.wasKnown)
+        adjustViewportIfAbove(idx, item, h - previous.previousHeight);
+
+    scheduleRelayout();
+}
+
+// Takes the first real measurement once a delegate reports itself ready
+void LazyListView::onDelegateReady(QQuickItem* item) {
+    if (!isDelegateReady(item))
+        return;
+
+    const int idx = indexOfDelegate(item);
+    if (idx < 0 || idx >= static_cast<int>(m_layout.size()))
+        return;
+
+    const qreal h = delegateHeight(item);
+    const auto previous = setKnownHeight(idx, h);
+    if (!qFuzzyCompare(h + 1.0, previous.previousHeight + 1.0))
+        adjustViewportIfAbove(idx, item, h - previous.previousHeight);
+
+    polish();
 }
 
 void LazyListView::destroyDelegate(DelegateEntry& entry) {
@@ -822,27 +894,64 @@ void LazyListView::destroyDelegate(DelegateEntry& entry) {
     }
 }
 
-void LazyListView::updateDelegateData(DelegateEntry& entry) {
-    if (!m_model || !entry.item)
-        return;
+// Delegate properties for a row, in the order they must be applied: every model
+// role, then index, then a modelData fallback for models with no such role.
+// The order is observable - an onIndexChanged handler may read modelData.
+LazyListView::PropertyList LazyListView::delegateProperties(int modelIndex) const {
+    PropertyList props;
+    if (!m_model)
+        return props;
 
     const auto roleNames = m_model->roleNames();
-    const auto index = m_model->index(entry.modelIndex, 0);
+    const auto index = m_model->index(modelIndex, 0);
     bool hasModelData = false;
+
+    props.reserve(roleNames.size() + 2);
 
     for (auto it = roleNames.constBegin(); it != roleNames.constEnd(); ++it) {
         const auto name = QString::fromUtf8(it.value());
-        entry.item->setProperty(name.toUtf8().constData(), m_model->data(index, it.key()));
+        props.emplaceBack(name, m_model->data(index, it.key()));
         if (name == QStringLiteral("modelData"))
             hasModelData = true;
     }
 
-    entry.item->setProperty("index", entry.modelIndex);
+    props.emplaceBack(QStringLiteral("index"), modelIndex);
 
     if (!hasModelData) {
         const auto role = roleNames.isEmpty() ? Qt::DisplayRole : roleNames.constBegin().key();
-        entry.item->setProperty("modelData", m_model->data(index, role));
+        props.emplaceBack(QStringLiteral("modelData"), m_model->data(index, role));
     }
+
+    return props;
+}
+
+void LazyListView::updateDelegateData(DelegateEntry& entry) {
+    if (!m_model || !entry.item)
+        return;
+
+    const auto props = delegateProperties(entry.modelIndex);
+    for (const auto& [name, value] : props)
+        entry.item->setProperty(name.toUtf8().constData(), value);
+}
+
+// Re-keys every delegate through mapIndex, keeping modelIndex, the reverse
+// lookup and the delegate's own index property in sync.
+void LazyListView::remapDelegates(const std::function<int(int)>& mapIndex) {
+    QHash<int, DelegateEntry> remapped;
+    remapped.reserve(m_delegates.size());
+
+    for (auto it = m_delegates.begin(); it != m_delegates.end(); ++it) {
+        const int newIdx = mapIndex(it.key());
+        auto entry = it.value();
+        entry.modelIndex = newIdx;
+        if (entry.item) {
+            entry.item->setProperty("index", newIdx);
+            m_itemToIndex[entry.item] = newIdx;
+        }
+        remapped.insert(newIdx, entry);
+    }
+
+    m_delegates = std::move(remapped);
 }
 
 // --- Model Connection ---
@@ -897,12 +1006,7 @@ void LazyListView::resetContent() {
     // Rebuild layout from model
     m_layout.clear();
     if (m_model && m_componentComplete) {
-        const int rows = m_model->rowCount();
-        m_layout.resize(rows);
-        for (int i = 0; i < rows; ++i) {
-            m_layout[i].height = 0;
-            m_layout[i].heightKnown = false;
-        }
+        m_layout.resize(m_model->rowCount());
         emit countChanged();
     }
 
@@ -918,18 +1022,9 @@ void LazyListView::onRowsInserted(const QModelIndex& parent, int first, int last
     m_layout.insert(first, insertCount, ItemRecord{ .targetY = 0, .height = 0, .heightKnown = false, .isNew = true });
 
     // Shift existing delegate indices
-    QHash<int, DelegateEntry> shifted;
-    for (auto it = m_delegates.begin(); it != m_delegates.end(); ++it) {
-        const int newIdx = it.key() >= first ? it.key() + insertCount : it.key();
-        auto entry = it.value();
-        entry.modelIndex = newIdx;
-        if (entry.item) {
-            entry.item->setProperty("index", newIdx);
-            m_itemToIndex[entry.item] = newIdx;
-        }
-        shifted.insert(newIdx, entry);
-    }
-    m_delegates = std::move(shifted);
+    remapDelegates([first, insertCount](int idx) {
+        return idx >= first ? idx + insertCount : idx;
+    });
 
     emit countChanged();
     polish();
@@ -955,8 +1050,7 @@ void LazyListView::onRowsAboutToBeRemoved(const QModelIndex& parent, int first, 
         }
 
         if (m_removeDuration > 0 && entry.item) {
-            auto* attached =
-                qobject_cast<LazyListViewAttached*>(qmlAttachedPropertiesObject<LazyListView>(entry.item, false));
+            auto* attached = attachedFor(entry.item);
             if (attached)
                 attached->setRemoving(true);
 
@@ -994,18 +1088,9 @@ void LazyListView::onRowsRemoved(const QModelIndex& parent, int first, int last)
     m_layout.remove(first, removeCount);
 
     // Shift remaining delegate indices down
-    QHash<int, DelegateEntry> shifted;
-    for (auto it = m_delegates.begin(); it != m_delegates.end(); ++it) {
-        const int newIdx = it.key() > last ? it.key() - removeCount : it.key();
-        auto entry = it.value();
-        entry.modelIndex = newIdx;
-        if (entry.item) {
-            entry.item->setProperty("index", newIdx);
-            m_itemToIndex[entry.item] = newIdx;
-        }
-        shifted.insert(newIdx, entry);
-    }
-    m_delegates = std::move(shifted);
+    remapDelegates([last, removeCount](int idx) {
+        return idx > last ? idx - removeCount : idx;
+    });
 
     emit countChanged();
     polish();
@@ -1028,29 +1113,15 @@ void LazyListView::onRowsMoved(const QModelIndex& parent, int start, int end, co
         m_layout.insert(dest + i, moved[i]);
 
     // Remap delegate indices to match new model order
-    QHash<int, DelegateEntry> remapped;
-    for (auto it = m_delegates.begin(); it != m_delegates.end(); ++it) {
-        const int oldIdx = it.key();
-        int newIdx = oldIdx;
+    remapDelegates([start, end, dest, count](int idx) {
+        if (idx >= start && idx <= end)
+            return dest + (idx - start);
 
-        if (oldIdx >= start && oldIdx <= end) {
-            newIdx = dest + (oldIdx - start);
-        } else {
-            if (oldIdx > end)
-                newIdx -= count;
-            if (newIdx >= dest)
-                newIdx += count;
-        }
-
-        auto entry = it.value();
-        entry.modelIndex = newIdx;
-        if (entry.item) {
-            entry.item->setProperty("index", newIdx);
-            m_itemToIndex[entry.item] = newIdx;
-        }
-        remapped.insert(newIdx, entry);
-    }
-    m_delegates = std::move(remapped);
+        int newIdx = idx > end ? idx - count : idx;
+        if (newIdx >= dest)
+            newIdx += count;
+        return newIdx;
+    });
 
     polish();
 }

--- a/plugin/src/Caelestia/Components/lazylistview.cpp
+++ b/plugin/src/Caelestia/Components/lazylistview.cpp
@@ -651,7 +651,7 @@ void LazyListView::syncDelegates() {
             entry.pendingInsert = true;
             entry.item->setY(m_layout[i].targetY - m_contentY);
             m_itemToIndex.insert(entry.item, i);
-            m_delegates.insert(i, std::move(entry));
+            m_delegates.insert(i, entry);
             ++created;
         }
     }
@@ -921,13 +921,13 @@ void LazyListView::onRowsInserted(const QModelIndex& parent, int first, int last
     QHash<int, DelegateEntry> shifted;
     for (auto it = m_delegates.begin(); it != m_delegates.end(); ++it) {
         const int newIdx = it.key() >= first ? it.key() + insertCount : it.key();
-        auto entry = std::move(it.value());
+        auto entry = it.value();
         entry.modelIndex = newIdx;
         if (entry.item) {
             entry.item->setProperty("index", newIdx);
             m_itemToIndex[entry.item] = newIdx;
         }
-        shifted.insert(newIdx, std::move(entry));
+        shifted.insert(newIdx, entry);
     }
     m_delegates = std::move(shifted);
 
@@ -997,13 +997,13 @@ void LazyListView::onRowsRemoved(const QModelIndex& parent, int first, int last)
     QHash<int, DelegateEntry> shifted;
     for (auto it = m_delegates.begin(); it != m_delegates.end(); ++it) {
         const int newIdx = it.key() > last ? it.key() - removeCount : it.key();
-        auto entry = std::move(it.value());
+        auto entry = it.value();
         entry.modelIndex = newIdx;
         if (entry.item) {
             entry.item->setProperty("index", newIdx);
             m_itemToIndex[entry.item] = newIdx;
         }
-        shifted.insert(newIdx, std::move(entry));
+        shifted.insert(newIdx, entry);
     }
     m_delegates = std::move(shifted);
 
@@ -1042,13 +1042,13 @@ void LazyListView::onRowsMoved(const QModelIndex& parent, int start, int end, co
                 newIdx += count;
         }
 
-        auto entry = std::move(it.value());
+        auto entry = it.value();
         entry.modelIndex = newIdx;
         if (entry.item) {
             entry.item->setProperty("index", newIdx);
             m_itemToIndex[entry.item] = newIdx;
         }
-        remapped.insert(newIdx, std::move(entry));
+        remapped.insert(newIdx, entry);
     }
     m_delegates = std::move(remapped);
 

--- a/plugin/src/Caelestia/Components/lazylistview.cpp
+++ b/plugin/src/Caelestia/Components/lazylistview.cpp
@@ -915,7 +915,7 @@ void LazyListView::onRowsInserted(const QModelIndex& parent, int first, int last
 
     const int insertCount = last - first + 1;
     // Insert new layout records
-    m_layout.insert(first, insertCount, ItemRecord{ 0, 0, false, true });
+    m_layout.insert(first, insertCount, ItemRecord{ .targetY = 0, .height = 0, .heightKnown = false, .isNew = true });
 
     // Shift existing delegate indices
     QHash<int, DelegateEntry> shifted;

--- a/plugin/src/Caelestia/Components/lazylistview.hpp
+++ b/plugin/src/Caelestia/Components/lazylistview.hpp
@@ -7,7 +7,12 @@
 #include <qqmlintegration.h>
 #include <qquickitem.h>
 #include <qrect.h>
+#include <qset.h>
+#include <qvariant.h>
 #include <qvector.h>
+
+#include <functional>
+#include <utility>
 
 namespace caelestia::components {
 
@@ -180,22 +185,58 @@ private:
         bool readyDelayStarted = false;
     };
 
+    // Delegate properties in the order they must be applied
+    using PropertyList = QList<std::pair<QString, QVariant>>;
+
+    // Result of recording a measured delegate height
+    struct HeightUpdate {
+        qreal previousHeight = 0;
+        bool wasKnown = false;
+    };
+
+    // Attached properties
+    [[nodiscard]] static LazyListViewAttached* attachedFor(QQuickItem* item);
+    [[nodiscard]] static LazyListViewAttached* attachedForCreate(QQuickItem* item);
+
     // Layout
     void relayout();
+    void updateLayoutPositions();
+    void updateContentHeight();
+    void scheduleRelayout();
     [[nodiscard]] std::pair<int, int> computeVisibleRange() const;
     [[nodiscard]] QRectF effectiveViewport() const;
+    [[nodiscard]] qreal viewportTop() const;
     [[nodiscard]] qreal effectiveEstimatedHeight() const;
+    [[nodiscard]] qreal layoutHeightAt(int index) const;
+    [[nodiscard]] qreal visibleHeightAt(int index) const;
+    [[nodiscard]] qreal visualYAt(int index) const;
     [[nodiscard]] static qreal delegateHeight(QQuickItem* item);
     [[nodiscard]] static qreal delegateVisibleHeight(QQuickItem* item);
     [[nodiscard]] static bool isDelegateReady(QQuickItem* item);
     void trackHeight(qreal height);
     void untrackHeight(qreal height);
+    HeightUpdate setKnownHeight(int index, qreal height);
+    void adjustViewportIfAbove(int index, QQuickItem* item, qreal delta);
 
     // Delegate lifecycle
     void syncDelegates();
+    [[nodiscard]] QList<int> delegatesOutsideViewport(const QSet<int>& keep, const QRectF& viewport) const;
+    [[nodiscard]] QList<int> missingDelegates(int first, int last) const;
+    int destroyDelegates(const QList<int>& indices, int budget);
+    int createDelegates(const QList<int>& indices, int budget);
     DelegateEntry createDelegate(int modelIndex);
+    void connectDelegate(const DelegateEntry& entry);
+    [[nodiscard]] int indexOfDelegate(QQuickItem* item) const;
+    void onDelegateHeightChanged(QQuickItem* item);
+    void onDelegateReady(QQuickItem* item);
     static void destroyDelegate(DelegateEntry& entry);
+    static void revealDelegate(QQuickItem* item);
+    void flushPendingInserts();
+    void finishDelayedInsert(QQuickItem* item);
+    void positionDelegates();
+    [[nodiscard]] PropertyList delegateProperties(int modelIndex) const;
     void updateDelegateData(DelegateEntry& entry);
+    void remapDelegates(const std::function<int(int)>& mapIndex);
 
     // Model connection
     void connectModel();

--- a/plugin/src/Caelestia/Components/lazylistview.hpp
+++ b/plugin/src/Caelestia/Components/lazylistview.hpp
@@ -194,7 +194,7 @@ private:
     // Delegate lifecycle
     void syncDelegates();
     DelegateEntry createDelegate(int modelIndex);
-    void destroyDelegate(DelegateEntry& entry);
+    static void destroyDelegate(DelegateEntry& entry);
     void updateDelegateData(DelegateEntry& entry);
 
     // Model connection

--- a/plugin/src/Caelestia/Components/linearindicatormanager.cpp
+++ b/plugin/src/Caelestia/Components/linearindicatormanager.cpp
@@ -85,11 +85,11 @@ void LinearIndicatorManager::setGap(int gap) {
     update(m_progress);
 }
 
-int LinearIndicatorManager::duration() const {
+int LinearIndicatorManager::duration() {
     return TOTAL_DURATION_IN_MS;
 }
 
-int LinearIndicatorManager::completeEndDuration() const {
+int LinearIndicatorManager::completeEndDuration() {
     return TOTAL_DURATION_IN_MS;
 }
 

--- a/plugin/src/Caelestia/Components/linearindicatormanager.cpp
+++ b/plugin/src/Caelestia/Components/linearindicatormanager.cpp
@@ -58,7 +58,7 @@ LinearIndicatorManager::LinearIndicatorManager(QObject* parent)
           new LinearIndicatorSegment(m_gap, this),
           new LinearIndicatorSegment(m_gap, this),
       }) {
-    for (auto el : m_activeIndicators)
+    for (auto* el : m_activeIndicators)
         QObject::connect(this, &LinearIndicatorManager::updated, el, &LinearIndicatorSegment::updated);
 }
 
@@ -80,7 +80,7 @@ int LinearIndicatorManager::gap() const {
 
 void LinearIndicatorManager::setGap(int gap) {
     m_gap = gap;
-    for (auto el : m_activeIndicators)
+    for (auto* el : m_activeIndicators)
         el->m_gapSize = m_gap;
     update(m_progress);
 }

--- a/plugin/src/Caelestia/Components/linearindicatormanager.cpp
+++ b/plugin/src/Caelestia/Components/linearindicatormanager.cpp
@@ -6,9 +6,9 @@ namespace {
 
 // See
 // https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/progressindicator/LinearIndeterminateDisjointAnimatorDelegate.java#L44-L46
-constexpr int TOTAL_DURATION_IN_MS = 1800;
-constexpr std::array DURATION_TO_MOVE_SEGMENT_ENDS = { 533, 567, 850, 750 };
-constexpr std::array DELAY_TO_MOVE_SEGMENT_ENDS = { 1267, 1000, 333, 0 };
+constexpr int k_totalDurationInMs = 1800;
+constexpr std::array k_durationToMoveSegmentEnds = { 533, 567, 850, 750 };
+constexpr std::array k_delayToMoveSegmentEnds = { 1267, 1000, 333, 0 };
 
 QEasingCurve curve(const QPointF& c1, const QPointF& c2) {
     QEasingCurve curve(QEasingCurve::BezierSpline);
@@ -86,24 +86,23 @@ void LinearIndicatorManager::setGap(int gap) {
 }
 
 int LinearIndicatorManager::duration() {
-    return TOTAL_DURATION_IN_MS;
+    return k_totalDurationInMs;
 }
 
 int LinearIndicatorManager::completeEndDuration() {
-    return TOTAL_DURATION_IN_MS;
+    return k_totalDurationInMs;
 }
 
 void LinearIndicatorManager::update(qreal progress) {
-    const auto playtime = progress * TOTAL_DURATION_IN_MS;
-    for (size_t i = 0; i < SEGMENTS; i++) {
+    const auto playtime = progress * k_totalDurationInMs;
+    for (size_t i = 0; i < k_segments; i++) {
         const auto di = i * 2;
         auto* const indicator = m_activeIndicators[i];
 
-        auto fraction = getFractionInRange(playtime, DELAY_TO_MOVE_SEGMENT_ENDS[di], DURATION_TO_MOVE_SEGMENT_ENDS[di]);
+        auto fraction = getFractionInRange(playtime, k_delayToMoveSegmentEnds[di], k_durationToMoveSegmentEnds[di]);
         indicator->m_startFraction = std::clamp(m_interpolators[di].valueForProgress(fraction), 0.0, 1.0);
 
-        fraction =
-            getFractionInRange(playtime, DELAY_TO_MOVE_SEGMENT_ENDS[di + 1], DURATION_TO_MOVE_SEGMENT_ENDS[di + 1]);
+        fraction = getFractionInRange(playtime, k_delayToMoveSegmentEnds[di + 1], k_durationToMoveSegmentEnds[di + 1]);
         indicator->m_endFraction = std::clamp(m_interpolators[di + 1].valueForProgress(fraction), 0.0, 1.0);
     }
 

--- a/plugin/src/Caelestia/Components/linearindicatormanager.hpp
+++ b/plugin/src/Caelestia/Components/linearindicatormanager.hpp
@@ -23,9 +23,9 @@ class LinearIndicatorSegment : public QObject {
 public:
     explicit LinearIndicatorSegment(int gap, QObject* parent = nullptr);
 
-    qreal startFraction() const;
-    qreal endFraction() const;
-    int gapSize() const;
+    [[nodiscard]] qreal startFraction() const;
+    [[nodiscard]] qreal endFraction() const;
+    [[nodiscard]] int gapSize() const;
 
 signals:
     void updated();
@@ -55,16 +55,16 @@ class LinearIndicatorManager : public QObject {
 public:
     explicit LinearIndicatorManager(QObject* parent = nullptr);
 
-    QList<LinearIndicatorSegment*> activeIndicators() const;
+    [[nodiscard]] QList<LinearIndicatorSegment*> activeIndicators() const;
 
-    qreal progress() const;
-    qreal completeEndProgress() const;
+    [[nodiscard]] qreal progress() const;
+    [[nodiscard]] qreal completeEndProgress() const;
 
-    int gap() const;
+    [[nodiscard]] int gap() const;
     void setGap(int gap);
 
-    int duration() const;
-    int completeEndDuration() const;
+    [[nodiscard]] int duration() const;
+    [[nodiscard]] int completeEndDuration() const;
 
     void update(qreal progress);
     void updateCompleteEndProgress(qreal progress);

--- a/plugin/src/Caelestia/Components/linearindicatormanager.hpp
+++ b/plugin/src/Caelestia/Components/linearindicatormanager.hpp
@@ -73,14 +73,14 @@ signals:
     void updated();
 
 private:
-    static constexpr int SEGMENTS = 2;
+    static constexpr int k_segments = 2;
 
     std::array<QEasingCurve, 4> m_interpolators;
     qreal m_progress;
     qreal m_completeEndProgress;
     int m_gap;
 
-    std::array<LinearIndicatorSegment*, SEGMENTS> m_activeIndicators;
+    std::array<LinearIndicatorSegment*, k_segments> m_activeIndicators;
 };
 
 } // namespace caelestia::components

--- a/plugin/src/Caelestia/Components/linearindicatormanager.hpp
+++ b/plugin/src/Caelestia/Components/linearindicatormanager.hpp
@@ -63,8 +63,8 @@ public:
     [[nodiscard]] int gap() const;
     void setGap(int gap);
 
-    [[nodiscard]] int duration() const;
-    [[nodiscard]] int completeEndDuration() const;
+    [[nodiscard]] static int duration();
+    [[nodiscard]] static int completeEndDuration();
 
     void update(qreal progress);
     void updateCompleteEndProgress(qreal progress);

--- a/plugin/src/Caelestia/Components/wavyline.cpp
+++ b/plugin/src/Caelestia/Components/wavyline.cpp
@@ -230,12 +230,12 @@ void WavyLine::paintArc(QPainter* painter) {
         return;
     }
 
-    const auto N = qMax(64, qCeil(radius * drawAngleRad));
-    const auto dTheta = drawAngleRad / N;
+    const auto segments = qMax(64, qCeil(radius * drawAngleRad));
+    const auto dTheta = drawAngleRad / segments;
 
     QPainterPath path;
 
-    for (int i = 0; i <= N; ++i) {
+    for (int i = 0; i <= segments; ++i) {
         const auto theta = m_startAngleRad + i * dTheta;
         const auto s = i * dTheta * radius;
         const auto phi = m_frequency * 2 * M_PI * (s + m_startX) / len + phase;

--- a/plugin/src/Caelestia/Components/wavyline.hpp
+++ b/plugin/src/Caelestia/Components/wavyline.hpp
@@ -24,7 +24,7 @@ class WavyLine : public QQuickPaintedItem {
     Q_PROPERTY(qreal value READ value WRITE setValue NOTIFY valueChanged FINAL)
 
 public:
-    enum PathType {
+    enum PathType : quint8 {
         Linear,
         Arc
     };

--- a/plugin/src/Caelestia/Config/CMakeLists.txt
+++ b/plugin/src/Caelestia/Config/CMakeLists.txt
@@ -6,6 +6,7 @@ qml_module(caelestia-config
         rootnodes.cpp
         configattached.cpp
         appearanceconfig.cpp
+        borderconfig.cpp
         font.cpp
         fontbuilder.cpp
         tokensattached.cpp
@@ -13,7 +14,6 @@ qml_module(caelestia-config
         enums.hpp
         backgroundconfig.hpp
         barconfig.hpp
-        borderconfig.hpp
         dashboardconfig.hpp
         generalconfig.hpp
         launcherconfig.hpp

--- a/plugin/src/Caelestia/Config/anim.cpp
+++ b/plugin/src/Caelestia/Config/anim.cpp
@@ -69,9 +69,9 @@ QEasingCurve AnimTokens::buildCurve(const QList<qreal>& points) {
     // Each segment needs 3 control points: c1, c2, endPoint.
     // So 6 values per segment: c1x, c1y, c2x, c2y, endX, endY.
     for (int i = 0; i + 5 < points.size(); i += 6) {
-        QPointF c1(points[i], points[i + 1]);
-        QPointF c2(points[i + 2], points[i + 3]);
-        QPointF end(points[i + 4], points[i + 5]);
+        const QPointF c1(points[i], points[i + 1]);
+        const QPointF c2(points[i + 2], points[i + 3]);
+        const QPointF end(points[i + 4], points[i + 5]);
         curve.addCubicBezierSegment(c1, c2, end);
     }
 

--- a/plugin/src/Caelestia/Config/appearanceconfig.cpp
+++ b/plugin/src/Caelestia/Config/appearanceconfig.cpp
@@ -62,7 +62,7 @@ int AppearanceRounding::extraExtraLarge() const {
 }
 
 int AppearanceRounding::full() const {
-    return m_tokens ? static_cast<int>(m_tokens->full()) : 0;
+    return m_tokens ? m_tokens->full() : 0;
 }
 
 // AppearanceSpacing

--- a/plugin/src/Caelestia/Config/appearanceconfig.cpp
+++ b/plugin/src/Caelestia/Config/appearanceconfig.cpp
@@ -1,7 +1,5 @@
 #include "appearanceconfig.hpp"
 
-#include <qmetaobject.h>
-
 #include "tokens.hpp"
 
 namespace caelestia::config {

--- a/plugin/src/Caelestia/Config/appearanceconfig.cpp
+++ b/plugin/src/Caelestia/Config/appearanceconfig.cpp
@@ -6,9 +6,11 @@
 
 namespace caelestia::config {
 
+namespace {
+
 // Helper: connect all changed signals from a token object to a single valuesChanged signal,
 // plus connect the local scaleChanged signal.
-template <typename Source, typename Target> static void connectTokenSignals(Source* source, Target* target) {
+template <typename Source, typename Target> void connectTokenSignals(Source* source, Target* target) {
     const auto* meta = source->metaObject();
 
     for (int i = meta->propertyOffset(); i < meta->propertyCount(); ++i) {
@@ -21,6 +23,8 @@ template <typename Source, typename Target> static void connectTokenSignals(Sour
 
     QObject::connect(target, &Target::scaleChanged, target, &Target::valuesChanged);
 }
+
+} // namespace
 
 // AppearanceRounding
 

--- a/plugin/src/Caelestia/Config/borderconfig.cpp
+++ b/plugin/src/Caelestia/Config/borderconfig.cpp
@@ -1,0 +1,15 @@
+#include "borderconfig.hpp"
+
+#include <algorithm>
+
+namespace caelestia::config {
+
+int BorderConfig::minThickness() {
+    return 2;
+}
+
+int BorderConfig::clampedThickness() const {
+    return std::max(minThickness(), m_thickness);
+}
+
+} // namespace caelestia::config

--- a/plugin/src/Caelestia/Config/borderconfig.hpp
+++ b/plugin/src/Caelestia/Config/borderconfig.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <algorithm>
-
 #include "settings/objectnode.hpp"
 #include "common.hpp"
 
@@ -18,9 +16,8 @@ class BorderConfig : public settings::ObjectNode {
     Q_PROPERTY(int clampedThickness READ clampedThickness NOTIFY thicknessChanged)
 
 public:
-    [[nodiscard]] static int minThickness() { return 2; }
-
-    [[nodiscard]] int clampedThickness() const { return std::max(minThickness(), m_thickness); }
+    [[nodiscard]] static int minThickness();
+    [[nodiscard]] int clampedThickness() const;
 };
 
 } // namespace caelestia::config

--- a/plugin/src/Caelestia/Config/configattached.hpp
+++ b/plugin/src/Caelestia/Config/configattached.hpp
@@ -58,6 +58,9 @@ public:
 
     static Config* qmlAttachedProperties(QObject* object);
 
+    void classBegin() override;
+    void componentComplete() override;
+
 signals:
     void sourceChanged();
 
@@ -66,9 +69,6 @@ protected:
         QQuickAttachedPropertyPropagator* newParent, QQuickAttachedPropertyPropagator* oldParent) override;
 
 private:
-    void classBegin() override;
-    void componentComplete() override;
-
     void propagateScreen();
 
     bool m_complete = false;

--- a/plugin/src/Caelestia/Config/configattached.hpp
+++ b/plugin/src/Caelestia/Config/configattached.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "rootnodes.hpp"
-
 #include <qquickattachedpropertypropagator.h>
+
+#include "rootnodes.hpp"
 
 namespace caelestia::config {
 

--- a/plugin/src/Caelestia/Config/enums.hpp
+++ b/plugin/src/Caelestia/Config/enums.hpp
@@ -11,7 +11,7 @@ namespace caelestia::config {
     Q_NAMESPACE                                                                                                        \
     QML_ELEMENT                                                                                                        \
                                                                                                                        \
-    enum Enum {                                                                                                        \
+    enum Enum : quint8 {                                                                                               \
         __VA_ARGS__                                                                                                    \
     };                                                                                                                 \
     Q_ENUM_NS(Enum)                                                                                                    \

--- a/plugin/src/Caelestia/Config/font.cpp
+++ b/plugin/src/Caelestia/Config/font.cpp
@@ -14,6 +14,9 @@ settings::ObjectNode* style(settings::ObjectNode* cfg, const QString& key) {
 
 // FontStyleBase
 
+FontStyleBase::FontStyleBase(QObject* parent)
+    : QObject(parent) {}
+
 QFont FontStyleBase::large() const {
     return m_large;
 }

--- a/plugin/src/Caelestia/Config/font.hpp
+++ b/plugin/src/Caelestia/Config/font.hpp
@@ -57,7 +57,7 @@ class FontStyleBase : public QObject {
 public:
     explicit FontStyleBase(QObject* parent = nullptr);
 
-    void bind(settings::ObjectNode* cfg);
+    virtual void bind(settings::ObjectNode* cfg);
     void setScale(qreal scale);
 
     [[nodiscard]] QFont large() const;
@@ -106,7 +106,7 @@ public:
 
     Q_INVOKABLE FontBuilder size(int pointSize);
 
-    void bind(settings::ObjectNode* cfg);
+    void bind(settings::ObjectNode* cfg) override;
 
     [[nodiscard]] QFont extraLarge() const;
     [[nodiscard]] IconFontBuilders* builders() const;

--- a/plugin/src/Caelestia/Config/font.hpp
+++ b/plugin/src/Caelestia/Config/font.hpp
@@ -55,8 +55,7 @@ class FontStyleBase : public QObject {
     Q_PROPERTY(QFont small READ small NOTIFY fontsChanged FINAL)
 
 public:
-    explicit FontStyleBase(QObject* parent = nullptr)
-        : QObject(parent) {}
+    explicit FontStyleBase(QObject* parent = nullptr);
 
     void bind(settings::ObjectNode* cfg);
     void setScale(qreal scale);

--- a/plugin/src/Caelestia/Config/fontbuilder.cpp
+++ b/plugin/src/Caelestia/Config/fontbuilder.cpp
@@ -10,8 +10,8 @@ Q_LOGGING_CATEGORY(lcFontBuilder, "caelestia.fontbuilder", QtInfoMsg)
 
 namespace caelestia::config {
 
-FontBuilder::FontBuilder(QFont font)
-    : m_font(std::move(font)) {}
+FontBuilder::FontBuilder(const QFont& font)
+    : m_font(font) {}
 
 FontBuilder FontBuilder::family(const QString& family) {
     m_font.setFamily(family);

--- a/plugin/src/Caelestia/Config/fontbuilder.cpp
+++ b/plugin/src/Caelestia/Config/fontbuilder.cpp
@@ -60,7 +60,7 @@ FontBuilder FontBuilder::vaxis(const QString& tag, float value) {
     return *this;
 }
 
-FontBuilder FontBuilder::vaxes(QVariantMap axes) {
+FontBuilder FontBuilder::vaxes(const QVariantMap& axes) {
     for (auto it = axes.constBegin(); it != axes.constEnd(); ++it) {
         if (it.value().canConvert<float>()) {
             if (auto tag = QFont::Tag::fromString(it.key()))

--- a/plugin/src/Caelestia/Config/fontbuilder.cpp
+++ b/plugin/src/Caelestia/Config/fontbuilder.cpp
@@ -2,9 +2,13 @@
 
 #include <qloggingcategory.h>
 
-namespace caelestia::config {
+namespace {
 
 Q_LOGGING_CATEGORY(lcFontBuilder, "caelestia.fontbuilder", QtInfoMsg)
+
+} // namespace
+
+namespace caelestia::config {
 
 FontBuilder::FontBuilder(QFont font)
     : m_font(std::move(font)) {}

--- a/plugin/src/Caelestia/Config/fontbuilder.hpp
+++ b/plugin/src/Caelestia/Config/fontbuilder.hpp
@@ -22,7 +22,7 @@ public:
     [[nodiscard]] Q_INVOKABLE FontBuilder letterSpacing(qreal spacing, bool absolute = true);
     [[nodiscard]] Q_INVOKABLE FontBuilder capitalisation(QFont::Capitalization cap);
     [[nodiscard]] Q_INVOKABLE FontBuilder vaxis(const QString& tag, float value);
-    [[nodiscard]] Q_INVOKABLE FontBuilder vaxes(QVariantMap axes);
+    [[nodiscard]] Q_INVOKABLE FontBuilder vaxes(const QVariantMap& axes);
     [[nodiscard]] Q_INVOKABLE QFont build() const;
 
     // Common vaxes

--- a/plugin/src/Caelestia/Config/fontbuilder.hpp
+++ b/plugin/src/Caelestia/Config/fontbuilder.hpp
@@ -12,7 +12,7 @@ class FontBuilder {
 
 public:
     FontBuilder() = default;
-    explicit FontBuilder(QFont font);
+    explicit FontBuilder(const QFont& font);
 
     [[nodiscard]] Q_INVOKABLE FontBuilder family(const QString& family);
     [[nodiscard]] Q_INVOKABLE FontBuilder size(int pointSize);

--- a/plugin/src/Caelestia/Config/rootnodes.hpp
+++ b/plugin/src/Caelestia/Config/rootnodes.hpp
@@ -69,7 +69,7 @@ public:
 
 namespace detail {
 
-enum class ConfigKind {
+enum class ConfigKind : quint8 {
     Shell,
     Tokens
 };

--- a/plugin/src/Caelestia/Config/rootnodes.hpp
+++ b/plugin/src/Caelestia/Config/rootnodes.hpp
@@ -5,12 +5,11 @@
 
 #include "settings/layerregistry.hpp"
 #include "settings/rootnode.hpp"
-#include "common.hpp"
-
 #include "appearanceconfig.hpp"
 #include "backgroundconfig.hpp"
 #include "barconfig.hpp"
 #include "borderconfig.hpp"
+#include "common.hpp"
 #include "dashboardconfig.hpp"
 #include "generalconfig.hpp"
 #include "launcherconfig.hpp"

--- a/plugin/src/Caelestia/Config/tokensattached.cpp
+++ b/plugin/src/Caelestia/Config/tokensattached.cpp
@@ -95,7 +95,7 @@ TOKENS_ATTACHED_GETTER(AppearancePadding, padding)
 
 #undef TOKENS_ATTACHED_GETTER
 
-const AppearanceTransparency* Tokens::transparency() const {
+const AppearanceTransparency* Tokens::transparency() {
     return ConfigSingleton::instance()->appearance()->transparency(); // Transparency is always global
 }
 

--- a/plugin/src/Caelestia/Config/tokensattached.hpp
+++ b/plugin/src/Caelestia/Config/tokensattached.hpp
@@ -45,6 +45,9 @@ public:
 
     static Tokens* qmlAttachedProperties(QObject* object);
 
+    void classBegin() override;
+    void componentComplete() override;
+
 signals:
     void sourceChanged();
 
@@ -53,9 +56,6 @@ protected:
         QQuickAttachedPropertyPropagator* newParent, QQuickAttachedPropertyPropagator* oldParent) override;
 
 private:
-    void classBegin() override;
-    void componentComplete() override;
-
     void propagateScreen();
     void bindAnim();
     void bindFont();

--- a/plugin/src/Caelestia/Config/tokensattached.hpp
+++ b/plugin/src/Caelestia/Config/tokensattached.hpp
@@ -35,7 +35,7 @@ public:
     [[nodiscard]] const AppearanceRounding* rounding() const;
     [[nodiscard]] const AppearanceSpacing* spacing() const;
     [[nodiscard]] const AppearancePadding* padding() const;
-    [[nodiscard]] const AppearanceTransparency* transparency() const;
+    [[nodiscard]] static const AppearanceTransparency* transparency();
 
     [[nodiscard]] const SizeTokens* sizes() const;
     [[nodiscard]] const FontTokens* font() const;

--- a/plugin/src/Caelestia/Images/cachingimageprovider.cpp
+++ b/plugin/src/Caelestia/Images/cachingimageprovider.cpp
@@ -9,7 +9,11 @@
 
 #include "imagecacher.hpp"
 
+namespace {
+
 Q_LOGGING_CATEGORY(lcCProv, "caelestia.images.cacheprovider", QtInfoMsg)
+
+} // namespace
 
 namespace caelestia::images {
 

--- a/plugin/src/Caelestia/Images/cachingimageprovider.cpp
+++ b/plugin/src/Caelestia/Images/cachingimageprovider.cpp
@@ -7,6 +7,8 @@
 #include <qrunnable.h>
 #include <qthreadpool.h>
 
+#include <utility>
+
 #include "imagecacher.hpp"
 
 namespace {
@@ -21,7 +23,7 @@ namespace {
 
 class CachingImageResponse final : public QQuickImageResponse, public QRunnable {
 public:
-    CachingImageResponse(const QString& id, const QSize& requestedSize, ImageCacher::FillMode fillMode);
+    CachingImageResponse(QString id, const QSize& requestedSize, ImageCacher::FillMode fillMode);
 
     [[nodiscard]] QQuickTextureFactory* textureFactory() const override;
 
@@ -39,9 +41,8 @@ private:
     QString m_error;
 };
 
-CachingImageResponse::CachingImageResponse(
-    const QString& id, const QSize& requestedSize, ImageCacher::FillMode fillMode)
-    : m_id(id)
+CachingImageResponse::CachingImageResponse(QString id, const QSize& requestedSize, ImageCacher::FillMode fillMode)
+    : m_id(std::move(id))
     , m_requestedSize(requestedSize)
     , m_fillMode(fillMode) {
     setAutoDelete(false);

--- a/plugin/src/Caelestia/Images/cachingimageprovider.cpp
+++ b/plugin/src/Caelestia/Images/cachingimageprovider.cpp
@@ -21,87 +21,16 @@ namespace {
 
 class CachingImageResponse final : public QQuickImageResponse, public QRunnable {
 public:
-    CachingImageResponse(const QString& id, const QSize& requestedSize, ImageCacher::FillMode fillMode)
-        : m_id(id)
-        , m_requestedSize(requestedSize)
-        , m_fillMode(fillMode) {
-        setAutoDelete(false);
-    }
+    CachingImageResponse(const QString& id, const QSize& requestedSize, ImageCacher::FillMode fillMode);
 
-    [[nodiscard]] QQuickTextureFactory* textureFactory() const override {
-        return QQuickTextureFactory::textureFactoryForImage(m_image);
-    }
+    [[nodiscard]] QQuickTextureFactory* textureFactory() const override;
 
-    [[nodiscard]] QString errorString() const override { return m_error; }
+    [[nodiscard]] QString errorString() const override;
 
-    void run() override {
-        process();
-        emit finished();
-    }
+    void run() override;
 
 private:
-    void process() {
-        QString path = QString::fromUtf8(m_id.toUtf8().percentDecoded());
-        if (!path.startsWith(QLatin1Char('/')))
-            path.prepend(QLatin1Char('/'));
-
-        if (!QFileInfo::exists(path)) {
-            m_error = QStringLiteral("Source file does not exist: ") + path;
-            qCWarning(lcCProv).noquote() << m_error;
-            return;
-        }
-
-        QSize size = m_requestedSize;
-        const bool needsW = size.width() <= 0;
-        const bool needsH = size.height() <= 0;
-
-        // If both dimensions are missing, return the original directly
-        if (needsW && needsH) {
-            qCDebug(lcCProv).noquote() << "Given source size is invalid, returning original:" << path;
-            m_image = QImage(path);
-            if (m_image.isNull()) {
-                m_error = QStringLiteral("Failed to decode source: ") + path;
-                qCWarning(lcCProv).noquote() << m_error;
-            }
-            return;
-        }
-
-        // If one dimension is missing, derive it from the source aspect ratio
-        if (needsW || needsH) {
-            const QImageReader sourceReader(path);
-            const QSize sourceSize = sourceReader.size();
-            if (!sourceSize.isValid() || sourceSize.isEmpty()) {
-                m_error = QStringLiteral("Could not determine source size for: ") + path;
-                qCWarning(lcCProv).noquote() << m_error;
-                return;
-            }
-
-            if (needsW)
-                size.setWidth(qRound(size.height() * sourceSize.width() / static_cast<qreal>(sourceSize.height())));
-            else
-                size.setHeight(qRound(size.width() * sourceSize.height() / static_cast<qreal>(sourceSize.width())));
-        }
-
-        // Try to use cached image
-        const auto cachePath = ImageCacher::cachePathFor(path, size, m_fillMode);
-        if (!cachePath.isEmpty()) {
-            QImageReader cacheReader(cachePath);
-            if (cacheReader.canRead()) {
-                m_image = cacheReader.read();
-                if (!m_image.isNull())
-                    return;
-            }
-        }
-
-        // Schedule cache job (this call will return the original image, but later ones will use cache)
-        ImageCacher::instance()->schedule(path, cachePath, size, m_fillMode);
-
-        m_image = QImage(path);
-        if (m_image.isNull()) {
-            m_error = QStringLiteral("Failed to decode source: ") + path;
-            qCWarning(lcCProv).noquote() << m_error;
-        }
-    }
+    void process();
 
     QString m_id;
     QSize m_requestedSize;
@@ -109,6 +38,90 @@ private:
     QImage m_image;
     QString m_error;
 };
+
+CachingImageResponse::CachingImageResponse(
+    const QString& id, const QSize& requestedSize, ImageCacher::FillMode fillMode)
+    : m_id(id)
+    , m_requestedSize(requestedSize)
+    , m_fillMode(fillMode) {
+    setAutoDelete(false);
+}
+
+QQuickTextureFactory* CachingImageResponse::textureFactory() const {
+    return QQuickTextureFactory::textureFactoryForImage(m_image);
+}
+
+QString CachingImageResponse::errorString() const {
+    return m_error;
+}
+
+void CachingImageResponse::run() {
+    process();
+    emit finished();
+}
+
+void CachingImageResponse::process() {
+    QString path = QString::fromUtf8(m_id.toUtf8().percentDecoded());
+    if (!path.startsWith(QLatin1Char('/')))
+        path.prepend(QLatin1Char('/'));
+
+    if (!QFileInfo::exists(path)) {
+        m_error = QStringLiteral("Source file does not exist: ") + path;
+        qCWarning(lcCProv).noquote() << m_error;
+        return;
+    }
+
+    QSize size = m_requestedSize;
+    const bool needsW = size.width() <= 0;
+    const bool needsH = size.height() <= 0;
+
+    // If both dimensions are missing, return the original directly
+    if (needsW && needsH) {
+        qCDebug(lcCProv).noquote() << "Given source size is invalid, returning original:" << path;
+        m_image = QImage(path);
+        if (m_image.isNull()) {
+            m_error = QStringLiteral("Failed to decode source: ") + path;
+            qCWarning(lcCProv).noquote() << m_error;
+        }
+        return;
+    }
+
+    // If one dimension is missing, derive it from the source aspect ratio
+    if (needsW || needsH) {
+        const QImageReader sourceReader(path);
+        const QSize sourceSize = sourceReader.size();
+        if (!sourceSize.isValid() || sourceSize.isEmpty()) {
+            m_error = QStringLiteral("Could not determine source size for: ") + path;
+            qCWarning(lcCProv).noquote() << m_error;
+            return;
+        }
+
+        if (needsW)
+            size.setWidth(qRound(size.height() * sourceSize.width() / static_cast<qreal>(sourceSize.height())));
+        else
+            size.setHeight(qRound(size.width() * sourceSize.height() / static_cast<qreal>(sourceSize.width())));
+    }
+
+    // Try to use cached image
+    const auto cachePath = ImageCacher::cachePathFor(path, size, m_fillMode);
+    if (!cachePath.isEmpty()) {
+        QImageReader cacheReader(cachePath);
+        if (cacheReader.canRead()) {
+            m_image = cacheReader.read();
+            if (!m_image.isNull())
+                return;
+        }
+    }
+
+    // Schedule cache job (this call will return the original image, but later ones will use cache)
+    ImageCacher::instance()->schedule(path, cachePath, size, m_fillMode);
+
+    m_image = QImage(path);
+    if (m_image.isNull()) {
+        m_error = QStringLiteral("Failed to decode source: ") + path;
+        qCWarning(lcCProv).noquote() << m_error;
+    }
+}
 
 } // namespace
 

--- a/plugin/src/Caelestia/Images/imageanalyser.cpp
+++ b/plugin/src/Caelestia/Images/imageanalyser.cpp
@@ -7,7 +7,11 @@
 #include <qquickwindow.h>
 #include <qtconcurrentrun.h>
 
+namespace {
+
 Q_LOGGING_CATEGORY(lcImageAnalyser, "caelestia.imageanalyser", QtInfoMsg)
+
+} // namespace
 
 namespace caelestia::images {
 

--- a/plugin/src/Caelestia/Images/imageanalyser.cpp
+++ b/plugin/src/Caelestia/Images/imageanalyser.cpp
@@ -197,7 +197,7 @@ void ImageAnalyser::analyse(QPromise<AnalyseResult>& promise, const QImage& imag
                 return;
             }
 
-            const uchar* pixel = line + x * 4;
+            const uchar* pixel = line + (static_cast<qsizetype>(x) * 4);
 
             if (pixel[3] == 0) {
                 continue;

--- a/plugin/src/Caelestia/Images/imageanalyser.cpp
+++ b/plugin/src/Caelestia/Images/imageanalyser.cpp
@@ -1,11 +1,11 @@
 #include "imageanalyser.hpp"
 
-#include <QtConcurrent/qtconcurrentrun.h>
-#include <QtQuick/qquickitemgrabresult.h>
 #include <qfuturewatcher.h>
 #include <qimage.h>
 #include <qloggingcategory.h>
+#include <qquickitemgrabresult.h>
 #include <qquickwindow.h>
+#include <qtconcurrentrun.h>
 
 Q_LOGGING_CATEGORY(lcImageAnalyser, "caelestia.imageanalyser", QtInfoMsg)
 

--- a/plugin/src/Caelestia/Images/imageanalyser.cpp
+++ b/plugin/src/Caelestia/Images/imageanalyser.cpp
@@ -203,9 +203,9 @@ void ImageAnalyser::analyse(QPromise<AnalyseResult>& promise, const QImage& imag
                 continue;
             }
 
-            const quint32 mr = static_cast<quint32>(pixel[2] & 0xF8);
-            const quint32 mg = static_cast<quint32>(pixel[1] & 0xF8);
-            const quint32 mb = static_cast<quint32>(pixel[0] & 0xF8);
+            const auto mr = static_cast<quint32>(pixel[2] & 0xF8);
+            const auto mg = static_cast<quint32>(pixel[1] & 0xF8);
+            const auto mb = static_cast<quint32>(pixel[0] & 0xF8);
             ++colours[(mr << 16) | (mg << 8) | mb];
 
             const qreal r = pixel[2] / 255.0;

--- a/plugin/src/Caelestia/Images/imageanalyser.hpp
+++ b/plugin/src/Caelestia/Images/imageanalyser.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <QtQuick/qquickitem.h>
 #include <qfuture.h>
 #include <qfuturewatcher.h>
 #include <qobject.h>
 #include <qpointer.h>
 #include <qqmlintegration.h>
+#include <qquickitem.h>
 
 namespace caelestia::images {
 

--- a/plugin/src/Caelestia/Images/imagecacher.cpp
+++ b/plugin/src/Caelestia/Images/imagecacher.cpp
@@ -87,7 +87,7 @@ void ImageCacher::schedule(const QString& sourcePath, const QString& cachePath, 
         return;
 
     {
-        QMutexLocker locker(&m_mutex);
+        const QMutexLocker locker(&m_mutex);
         if (m_inflight.contains(cachePath))
             return;
         m_inflight.insert(cachePath);
@@ -95,7 +95,7 @@ void ImageCacher::schedule(const QString& sourcePath, const QString& cachePath, 
 
     QThreadPool::globalInstance()->start([this, sourcePath, cachePath, size, fillMode]() {
         runJob(sourcePath, cachePath, size, fillMode);
-        QMutexLocker locker(&m_mutex);
+        const QMutexLocker locker(&m_mutex);
         m_inflight.remove(cachePath);
     });
 }

--- a/plugin/src/Caelestia/Images/imagecacher.cpp
+++ b/plugin/src/Caelestia/Images/imagecacher.cpp
@@ -49,13 +49,13 @@ QString fillSuffix(ImageCacher::FillMode fillMode) {
 } // namespace
 
 const QString& ImageCacher::cacheDir() {
-    static const QString s_dir = [] {
+    static const QString k_dir = [] {
         QString cache = qEnvironmentVariable("XDG_CACHE_HOME");
         if (cache.isEmpty())
             cache = QDir::homePath() + QStringLiteral("/.cache");
         return cache + QStringLiteral("/caelestia/imagecache");
     }();
-    return s_dir;
+    return k_dir;
 }
 
 QString ImageCacher::cachePathFor(const QString& sourcePath, const QSize& size, FillMode fillMode) {

--- a/plugin/src/Caelestia/Images/imagecacher.cpp
+++ b/plugin/src/Caelestia/Images/imagecacher.cpp
@@ -96,6 +96,7 @@ void ImageCacher::schedule(const QString& sourcePath, const QString& cachePath, 
     QThreadPool::globalInstance()->start([this, sourcePath, cachePath, size, fillMode]() {
         runJob(sourcePath, cachePath, size, fillMode);
         const QMutexLocker locker(&m_mutex);
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage) m_inflight is a value member, not a pointer
         m_inflight.remove(cachePath);
     });
 }

--- a/plugin/src/Caelestia/Images/imagecacher.cpp
+++ b/plugin/src/Caelestia/Images/imagecacher.cpp
@@ -11,7 +11,11 @@
 #include <qsavefile.h>
 #include <qthreadpool.h>
 
+namespace {
+
 Q_LOGGING_CATEGORY(lcCacher, "caelestia.images.cacher", QtInfoMsg)
+
+} // namespace
 
 namespace caelestia::images {
 

--- a/plugin/src/Caelestia/Images/imagecacher.hpp
+++ b/plugin/src/Caelestia/Images/imagecacher.hpp
@@ -12,7 +12,7 @@ class ImageCacher : public QObject {
     Q_OBJECT
 
 public:
-    enum class FillMode {
+    enum class FillMode : quint8 {
         Crop,
         Fit,
         Stretch,

--- a/plugin/src/Caelestia/Images/iutils.cpp
+++ b/plugin/src/Caelestia/Images/iutils.cpp
@@ -17,7 +17,7 @@ IUtils* IUtils::create(QQmlEngine* engine, QJSEngine* jsEngine) {
 
 QUrl IUtils::urlForPath(const QString& path, int fillMode) {
     if (path.isEmpty())
-        return QUrl();
+        return {};
 
     QString prefix;
     switch (fillMode) {

--- a/plugin/src/Caelestia/Images/iutils.cpp
+++ b/plugin/src/Caelestia/Images/iutils.cpp
@@ -4,6 +4,9 @@
 
 namespace caelestia::images {
 
+IUtils::IUtils(QObject* parent)
+    : QObject(parent) {}
+
 IUtils* IUtils::create(QQmlEngine* engine, QJSEngine* jsEngine) {
     Q_UNUSED(jsEngine);
 

--- a/plugin/src/Caelestia/Images/iutils.hpp
+++ b/plugin/src/Caelestia/Images/iutils.hpp
@@ -19,8 +19,7 @@ public:
     Q_INVOKABLE static QUrl urlForPath(const QString& path, int fillMode);
 
 private:
-    explicit IUtils(QObject* parent = nullptr)
-        : QObject(parent) {};
+    explicit IUtils(QObject* parent = nullptr);
 };
 
 } // namespace caelestia::images

--- a/plugin/src/Caelestia/Models/appdb.cpp
+++ b/plugin/src/Caelestia/Models/appdb.cpp
@@ -17,8 +17,8 @@ AppEntry::AppEntry(QObject* entry, unsigned int frequency, QObject* parent)
     : QObject(parent)
     , m_entry(entry)
     , m_frequency(frequency) {
-    const auto* const mo = m_entry->metaObject();
-    const auto* const tmo = &AppEntry::staticMetaObject;
+    const auto* mo = m_entry->metaObject();
+    const auto* tmo = &AppEntry::staticMetaObject;
 
     for (const auto& prop :
         { "name", "comment", "execString", "startupClass", "genericName", "categories", "keywords" }) {

--- a/plugin/src/Caelestia/Models/appdb.cpp
+++ b/plugin/src/Caelestia/Models/appdb.cpp
@@ -5,6 +5,8 @@
 #include <qsqlquery.h>
 #include <quuid.h>
 
+#include <algorithm>
+
 namespace {
 
 Q_LOGGING_CATEGORY(lcAppDb, "caelestia.appdb", QtInfoMsg)
@@ -253,12 +255,10 @@ QList<AppEntry*>& AppDb::getSortedApps() const {
 }
 
 bool AppDb::isFavourite(const AppEntry* app) const {
-    for (const QRegularExpression& re : m_favouriteAppsRegex) {
-        if (re.match(app->id()).hasMatch()) {
-            return true;
-        }
-    }
-    return false;
+    const QString id = app->id();
+    return std::ranges::any_of(m_favouriteAppsRegex, [&id](const QRegularExpression& re) {
+        return re.match(id).hasMatch();
+    });
 }
 
 quint32 AppDb::getFrequency(const QString& id) const {

--- a/plugin/src/Caelestia/Models/appdb.cpp
+++ b/plugin/src/Caelestia/Models/appdb.cpp
@@ -196,7 +196,7 @@ void AppDb::setFavouriteApps(const QStringList& favApps) {
     emit appsChanged();
 }
 
-QString AppDb::regexifyString(const QString& original) const {
+QString AppDb::regexifyString(const QString& original) {
     if (original.startsWith('^') && original.endsWith('$'))
         return original;
 

--- a/plugin/src/Caelestia/Models/appdb.cpp
+++ b/plugin/src/Caelestia/Models/appdb.cpp
@@ -5,7 +5,11 @@
 #include <qsqlquery.h>
 #include <quuid.h>
 
+namespace {
+
 Q_LOGGING_CATEGORY(lcAppDb, "caelestia.appdb", QtInfoMsg)
+
+} // namespace
 
 namespace caelestia::models {
 

--- a/plugin/src/Caelestia/Models/appdb.cpp
+++ b/plugin/src/Caelestia/Models/appdb.cpp
@@ -203,7 +203,7 @@ QString AppDb::regexifyString(const QString& original) const {
 }
 
 QQmlListProperty<AppEntry> AppDb::apps() {
-    return QQmlListProperty<AppEntry>(this, &getSortedApps());
+    return { this, &getSortedApps() };
 }
 
 void AppDb::incrementFrequency(const QString& id) {

--- a/plugin/src/Caelestia/Models/appdb.cpp
+++ b/plugin/src/Caelestia/Models/appdb.cpp
@@ -13,8 +13,8 @@ AppEntry::AppEntry(QObject* entry, unsigned int frequency, QObject* parent)
     : QObject(parent)
     , m_entry(entry)
     , m_frequency(frequency) {
-    const auto mo = m_entry->metaObject();
-    const auto tmo = &AppEntry::staticMetaObject;
+    const auto* const mo = m_entry->metaObject();
+    const auto* const tmo = &AppEntry::staticMetaObject;
 
     for (const auto& prop :
         { "name", "comment", "execString", "startupClass", "genericName", "categories", "keywords" }) {

--- a/plugin/src/Caelestia/Models/appdb.cpp
+++ b/plugin/src/Caelestia/Models/appdb.cpp
@@ -242,7 +242,7 @@ QList<AppEntry*>& AppDb::getSortedApps() const {
             favSet.insert(app->id());
     }
 
-    std::sort(m_sortedApps.begin(), m_sortedApps.end(), [&favSet](AppEntry* a, AppEntry* b) {
+    std::ranges::sort(m_sortedApps, [&favSet](AppEntry* a, AppEntry* b) {
         const bool aIsFav = favSet.contains(a->id());
         const bool bIsFav = favSet.contains(b->id());
         if (aIsFav != bIsFav)

--- a/plugin/src/Caelestia/Models/appdb.hpp
+++ b/plugin/src/Caelestia/Models/appdb.hpp
@@ -105,7 +105,7 @@ private:
     QHash<QString, AppEntry*> m_apps;
     mutable QList<AppEntry*> m_sortedApps;
 
-    QString regexifyString(const QString& original) const;
+    static QString regexifyString(const QString& original);
     QList<AppEntry*>& getSortedApps() const;
     bool isFavourite(const AppEntry* app) const;
     quint32 getFrequency(const QString& id) const;

--- a/plugin/src/Caelestia/Models/filesystemmodel.cpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.cpp
@@ -1,7 +1,6 @@
 #include "filesystemmodel.hpp"
 
 #include <qdiriterator.h>
-#include <qfuturewatcher.h>
 #include <qtconcurrentrun.h>
 
 #include <algorithm>

--- a/plugin/src/Caelestia/Models/filesystemmodel.cpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.cpp
@@ -4,6 +4,7 @@
 #include <qtconcurrentrun.h>
 
 #include <algorithm>
+#include <optional>
 #include <utility>
 
 namespace caelestia::models {
@@ -289,91 +290,86 @@ void FileSystemModel::updateEntriesForDir(const QString& dir) {
     const auto nameFilters = m_nameFilters;
 
     QSet<QString> oldPaths;
-    for (const auto& entry : std::as_const(m_entries)) {
+    for (const auto& entry : std::as_const(m_entries))
         oldPaths << entry->path();
-    }
 
-    auto future = QtConcurrent::run([=](QPromise<QPair<QSet<QString>, QSet<QString>>>& promise) {
+    auto future = QtConcurrent::run([=](QPromise<PathDiff>& promise) {
         const auto flags = recursive ? QDirIterator::Subdirectories : QDirIterator::NoIteratorFlags;
-
-        std::optional<QDirIterator> iter;
-
-        if (filter == Images) {
-            QStringList extraNameFilters = nameFilters;
-            const auto formats = QImageReader::supportedImageFormats();
-            for (const auto& format : formats) {
-                extraNameFilters << "*." + format;
-            }
-
-            QDir::Filters filters = QDir::Files;
-            if (showHidden) {
-                filters |= QDir::Hidden;
-            }
-
-            iter.emplace(dir, extraNameFilters, filters, flags);
-        } else {
-            QDir::Filters filters;
-
-            if (filter == Files) {
-                filters = QDir::Files;
-            } else if (filter == Dirs) {
-                filters = QDir::Dirs | QDir::NoDotAndDotDot;
-            } else {
-                filters = QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot;
-            }
-
-            if (showHidden) {
-                filters |= QDir::Hidden;
-            }
-
-            if (nameFilters.isEmpty()) {
-                iter.emplace(dir, filters, flags);
-            } else {
-                iter.emplace(dir, nameFilters, filters, flags);
-            }
-        }
-
-        QSet<QString> newPaths;
-        while (iter->hasNext()) {
-            if (promise.isCanceled()) {
-                return;
-            }
-
-            const QString path = iter->next();
-
-            if (filter == Images) {
-                const QImageReader reader(path);
-                if (!reader.canRead()) {
-                    continue;
-                }
-            }
-
-            newPaths.insert(path);
-        }
-
-        if (promise.isCanceled()) {
+        const auto newPaths = scanDir(dir, filtersFor(filter, nameFilters, showHidden), flags, promise);
+        if (!newPaths)
             return;
-        }
 
-        promise.addResult(qMakePair(oldPaths - newPaths, newPaths - oldPaths));
+        promise.addResult({ .removed = oldPaths - *newPaths, .added = *newPaths - oldPaths });
     });
 
-    if (m_futures.contains(dir)) {
+    if (m_futures.contains(dir))
         m_futures[dir].cancel();
-    }
     m_futures.insert(dir, future);
 
     future
         .then(this,
-            [dir, this](const QPair<QSet<QString>, QSet<QString>>& result) {
+            [dir, this](const PathDiff& result) {
                 m_futures.remove(dir);
-                if (!result.first.isEmpty() || !result.second.isEmpty()) {
-                    applyChanges(result.first, result.second);
-                }
+                if (!result.removed.isEmpty() || !result.added.isEmpty())
+                    applyChanges(result.removed, result.added);
             })
         .onCanceled(this, [dir, this]() {
             m_futures.remove(dir);
         });
+}
+
+FileSystemModel::ScanFilters FileSystemModel::filtersFor(
+    Filter filter, const QStringList& nameFilters, bool showHidden) {
+    ScanFilters filters;
+    filters.nameFilters = nameFilters;
+
+    if (filter == Filter::Images) {
+        const auto formats = QImageReader::supportedImageFormats();
+        for (const auto& format : formats)
+            filters.nameFilters << "*." + format;
+
+        filters.filterFn = [](const QString& path) {
+            return QImageReader(path).canRead();
+        };
+    }
+
+    if (filter == Filter::Files || filter == Filter::Images)
+        filters.filters = QDir::Files;
+    else if (filter == Filter::Dirs)
+        filters.filters = QDir::Dirs | QDir::NoDotAndDotDot;
+    else
+        filters.filters = QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot;
+
+    if (showHidden)
+        filters.filters |= QDir::Hidden;
+
+    return filters;
+}
+
+std::optional<QSet<QString>> FileSystemModel::scanDir(const QString& dir, const ScanFilters& filters,
+    QDirIterator::IteratorFlags flags, const QPromise<PathDiff>& promise) {
+    std::optional<QDirIterator> iter;
+    if (filters.nameFilters.isEmpty())
+        iter.emplace(dir, filters.filters, flags);
+    else
+        iter.emplace(dir, filters.nameFilters, filters.filters, flags);
+
+    QSet<QString> paths;
+    while (iter->hasNext()) {
+        if (promise.isCanceled())
+            return std::nullopt;
+
+        const QString path = iter->next();
+        if (filters.filterFn && !filters.filterFn(path))
+            continue;
+
+        paths.insert(path);
+    }
+
+    if (promise.isCanceled())
+        return std::nullopt;
+
+    return paths;
 }
 
 void FileSystemModel::applyChanges(const QSet<QString>& removedPaths, const QSet<QString>& addedPaths) {

--- a/plugin/src/Caelestia/Models/filesystemmodel.cpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.cpp
@@ -381,7 +381,7 @@ void FileSystemModel::applyChanges(const QSet<QString>& removedPaths, const QSet
             removedIndices << i;
         }
     }
-    std::sort(removedIndices.begin(), removedIndices.end(), std::greater<int>());
+    std::sort(removedIndices.begin(), removedIndices.end(), std::greater<>());
 
     // Batch remove old entries
     int start = -1;

--- a/plugin/src/Caelestia/Models/filesystemmodel.cpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.cpp
@@ -59,8 +59,8 @@ bool FileSystemEntry::isImage() const {
 
 QString FileSystemEntry::mimeType() const {
     if (!m_mimeTypeInitialised) {
-        static const QMimeDatabase s_db;
-        m_mimeType = s_db.mimeTypeForFile(m_path).name();
+        static const QMimeDatabase k_db;
+        m_mimeType = k_db.mimeTypeForFile(m_path).name();
         m_mimeTypeInitialised = true;
     }
     return m_mimeType;

--- a/plugin/src/Caelestia/Models/filesystemmodel.cpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.cpp
@@ -366,7 +366,7 @@ void FileSystemModel::updateEntriesForDir(const QString& dir) {
 
     future
         .then(this,
-            [dir, this](QPair<QSet<QString>, QSet<QString>> result) {
+            [dir, this](const QPair<QSet<QString>, QSet<QString>>& result) {
                 m_futures.remove(dir);
                 if (!result.first.isEmpty() || !result.second.isEmpty()) {
                     applyChanges(result.first, result.second);

--- a/plugin/src/Caelestia/Models/filesystemmodel.cpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.cpp
@@ -5,14 +5,15 @@
 #include <qtconcurrentrun.h>
 
 #include <algorithm>
+#include <utility>
 
 namespace caelestia::models {
 
-FileSystemEntry::FileSystemEntry(const QString& path, const QString& relativePath, QObject* parent)
+FileSystemEntry::FileSystemEntry(const QString& path, QString relativePath, QObject* parent)
     : QObject(parent)
     , m_fileInfo(path)
     , m_path(path)
-    , m_relativePath(relativePath)
+    , m_relativePath(std::move(relativePath))
     , m_isImageInitialised(false)
     , m_mimeTypeInitialised(false) {}
 

--- a/plugin/src/Caelestia/Models/filesystemmodel.cpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.cpp
@@ -48,7 +48,7 @@ bool FileSystemEntry::isDir() const {
 
 bool FileSystemEntry::isImage() const {
     if (!m_isImageInitialised) {
-        QImageReader reader(m_path);
+        const QImageReader reader(m_path);
         m_isImage = reader.canRead();
         m_isImageInitialised = true;
     }
@@ -337,10 +337,10 @@ void FileSystemModel::updateEntriesForDir(const QString& dir) {
                 return;
             }
 
-            QString path = iter->next();
+            const QString path = iter->next();
 
             if (filter == Images) {
-                QImageReader reader(path);
+                const QImageReader reader(path);
                 if (!reader.canRead()) {
                     continue;
                 }
@@ -386,7 +386,7 @@ void FileSystemModel::applyChanges(const QSet<QString>& removedPaths, const QSet
     // Batch remove old entries
     int start = -1;
     int end = -1;
-    for (int idx : std::as_const(removedIndices)) {
+    for (const int idx : std::as_const(removedIndices)) {
         if (start == -1) {
             start = idx;
             end = idx;

--- a/plugin/src/Caelestia/Models/filesystemmodel.cpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.cpp
@@ -4,6 +4,8 @@
 #include <qfuturewatcher.h>
 #include <qtconcurrentrun.h>
 
+#include <algorithm>
+
 namespace caelestia::models {
 
 FileSystemEntry::FileSystemEntry(const QString& path, const QString& relativePath, QObject* parent)
@@ -381,7 +383,7 @@ void FileSystemModel::applyChanges(const QSet<QString>& removedPaths, const QSet
             removedIndices << i;
         }
     }
-    std::sort(removedIndices.begin(), removedIndices.end(), std::greater<>());
+    std::ranges::sort(removedIndices, std::greater<>());
 
     // Batch remove old entries
     int start = -1;
@@ -416,15 +418,15 @@ void FileSystemModel::applyChanges(const QSet<QString>& removedPaths, const QSet
     for (const auto& path : addedPaths) {
         newEntries << new FileSystemEntry(path, m_dir.relativeFilePath(path), this);
     }
-    std::sort(newEntries.begin(), newEntries.end(), [this](const FileSystemEntry* a, const FileSystemEntry* b) {
+    std::ranges::sort(newEntries, [this](const FileSystemEntry* a, const FileSystemEntry* b) {
         return compareEntries(a, b);
     });
 
     // Batch insert new entries (each run lands contiguously before m_entries[row])
     int i = 0;
     while (i < newEntries.size()) {
-        const auto it = std::lower_bound(m_entries.begin(), m_entries.end(), newEntries[i],
-            [this](const FileSystemEntry* a, const FileSystemEntry* b) {
+        const auto it = std::ranges::lower_bound(
+            m_entries, newEntries[i], [this](const FileSystemEntry* a, const FileSystemEntry* b) {
                 return compareEntries(a, b);
             });
         const auto row = static_cast<int>(it - m_entries.begin());

--- a/plugin/src/Caelestia/Models/filesystemmodel.cpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.cpp
@@ -91,7 +91,7 @@ int FileSystemModel::rowCount(const QModelIndex& parent) const {
 
 QVariant FileSystemModel::data(const QModelIndex& index, int role) const {
     if (role != Qt::UserRole || !index.isValid() || index.row() >= m_entries.size()) {
-        return QVariant();
+        return {};
     }
     return QVariant::fromValue(m_entries.at(index.row()));
 }
@@ -212,7 +212,7 @@ void FileSystemModel::setNameFilters(const QStringList& nameFilters) {
 }
 
 QQmlListProperty<FileSystemEntry> FileSystemModel::entries() {
-    return QQmlListProperty<FileSystemEntry>(this, &m_entries);
+    return { this, &m_entries };
 }
 
 void FileSystemModel::watchDirIfRecursive(const QString& path) {

--- a/plugin/src/Caelestia/Models/filesystemmodel.hpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.hpp
@@ -29,7 +29,7 @@ class FileSystemEntry : public QObject {
     Q_PROPERTY(QString mimeType READ mimeType CONSTANT)
 
 public:
-    explicit FileSystemEntry(const QString& path, const QString& relativePath, QObject* parent = nullptr);
+    explicit FileSystemEntry(const QString& path, QString relativePath, QObject* parent = nullptr);
 
     [[nodiscard]] QString path() const;
     [[nodiscard]] QString relativePath() const;

--- a/plugin/src/Caelestia/Models/filesystemmodel.hpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.hpp
@@ -2,6 +2,7 @@
 
 #include <qabstractitemmodel.h>
 #include <qdir.h>
+#include <qdiriterator.h>
 #include <qfilesystemwatcher.h>
 #include <qfuture.h>
 #include <qimagereader.h>
@@ -123,10 +124,21 @@ signals:
     void entriesChanged();
 
 private:
+    struct PathDiff {
+        QSet<QString> removed;
+        QSet<QString> added;
+    };
+
+    struct ScanFilters {
+        QStringList nameFilters;
+        QDir::Filters filters;
+        std::function<bool(const QString&)> filterFn = nullptr;
+    };
+
     QDir m_dir;
     QFileSystemWatcher m_watcher;
     QList<FileSystemEntry*> m_entries;
-    QHash<QString, QFuture<QPair<QSet<QString>, QSet<QString>>>> m_futures;
+    QHash<QString, QFuture<PathDiff>> m_futures;
 
     QString m_path;
     bool m_recursive;
@@ -141,6 +153,9 @@ private:
     void updateWatcher();
     void updateEntries();
     void updateEntriesForDir(const QString& dir);
+    [[nodiscard]] static ScanFilters filtersFor(Filter filter, const QStringList& nameFilters, bool showHidden);
+    [[nodiscard]] static std::optional<QSet<QString>> scanDir(const QString& dir, const ScanFilters& filters,
+        QDirIterator::IteratorFlags flags, const QPromise<PathDiff>& promise);
     void applyChanges(const QSet<QString>& removedPaths, const QSet<QString>& addedPaths);
     [[nodiscard]] bool compareEntries(const FileSystemEntry* a, const FileSystemEntry* b) const;
 };

--- a/plugin/src/Caelestia/Models/filesystemmodel.hpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.hpp
@@ -85,9 +85,9 @@ public:
 
     explicit FileSystemModel(QObject* parent = nullptr);
 
-    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
-    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
-    QHash<int, QByteArray> roleNames() const override;
+    [[nodiscard]] int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    [[nodiscard]] QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
 
     [[nodiscard]] QString path() const;
     void setPath(const QString& path);

--- a/plugin/src/Caelestia/Models/filesystemmodel.hpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.hpp
@@ -75,7 +75,7 @@ class FileSystemModel : public QAbstractListModel {
     Q_PROPERTY(QQmlListProperty<caelestia::models::FileSystemEntry> entries READ entries NOTIFY entriesChanged)
 
 public:
-    enum Filter {
+    enum Filter : quint8 {
         NoFilter,
         Images,
         Files,

--- a/plugin/src/Caelestia/Services/audiocollector.cpp
+++ b/plugin/src/Caelestia/Services/audiocollector.cpp
@@ -13,8 +13,11 @@
 
 #include "service.hpp"
 
-Q_LOGGING_CATEGORY(lcAc, "caelestia.services.ac", QtInfoMsg)
+namespace {
+
 Q_LOGGING_CATEGORY(lcAcWorker, "caelestia.services.ac.worker", QtInfoMsg)
+
+} // namespace
 
 namespace caelestia::services {
 

--- a/plugin/src/Caelestia/Services/audiocollector.cpp
+++ b/plugin/src/Caelestia/Services/audiocollector.cpp
@@ -252,7 +252,7 @@ void AudioCollector::start() {
     clearBuffer();
 
     m_thread = std::jthread([this](std::stop_token token) {
-        PipeWireWorker worker(token, this);
+        const PipeWireWorker worker(token, this);
     });
 }
 

--- a/plugin/src/Caelestia/Services/audiocollector.cpp
+++ b/plugin/src/Caelestia/Services/audiocollector.cpp
@@ -157,7 +157,7 @@ void PipeWireWorker::processStream() {
     }
 
     const spa_buffer* buf = buffer->buffer;
-    const qint16* samples = reinterpret_cast<const qint16*>(buf->datas[0].data);
+    const auto* samples = reinterpret_cast<const qint16*>(buf->datas[0].data);
     if (samples == nullptr) {
         return;
     }

--- a/plugin/src/Caelestia/Services/audiocollector.cpp
+++ b/plugin/src/Caelestia/Services/audiocollector.cpp
@@ -195,9 +195,7 @@ void AudioCollector::clearBuffer() {
 }
 
 void AudioCollector::loadChunk(const qint16* samples, quint32 count) {
-    if (count > ac::CHUNK_SIZE) {
-        count = ac::CHUNK_SIZE;
-    }
+    count = std::min(count, ac::CHUNK_SIZE);
 
     auto* writeBuffer = m_writeBuffer.load(std::memory_order_relaxed);
     std::transform(samples, samples + count, writeBuffer->begin(), [](qint16 sample) {

--- a/plugin/src/Caelestia/Services/audiocollector.cpp
+++ b/plugin/src/Caelestia/Services/audiocollector.cpp
@@ -186,8 +186,8 @@ unsigned int PipeWireWorker::nextPowerOf2(unsigned int n) {
 }
 
 AudioCollector& AudioCollector::instance() {
-    static AudioCollector instance;
-    return instance;
+    static AudioCollector s_instance;
+    return s_instance;
 }
 
 void AudioCollector::clearBuffer() {

--- a/plugin/src/Caelestia/Services/audiocollector.cpp
+++ b/plugin/src/Caelestia/Services/audiocollector.cpp
@@ -44,7 +44,7 @@ PipeWireWorker::PipeWireWorker(std::stop_token token, AudioCollector* collector)
     }
     pw_loop_update_timer(pw_main_loop_get_loop(m_loop), m_timer, &timeout, &timeout, false);
 
-    auto props = pw_properties_new(
+    auto* props = pw_properties_new(
         PW_KEY_MEDIA_TYPE, "Audio", PW_KEY_MEDIA_CATEGORY, "Capture", PW_KEY_MEDIA_ROLE, "Music", nullptr);
     pw_properties_set(props, PW_KEY_STREAM_CAPTURE_SINK, "true");
     pw_properties_setf(

--- a/plugin/src/Caelestia/Services/audiocollector.cpp
+++ b/plugin/src/Caelestia/Services/audiocollector.cpp
@@ -191,7 +191,7 @@ AudioCollector& AudioCollector::instance() {
 
 void AudioCollector::clearBuffer() {
     auto* writeBuffer = m_writeBuffer.load(std::memory_order_relaxed);
-    std::fill(writeBuffer->begin(), writeBuffer->end(), 0.0f);
+    std::ranges::fill(*writeBuffer, 0.0f);
 
     auto* oldRead = m_readBuffer.exchange(writeBuffer, std::memory_order_acq_rel);
     m_writeBuffer.store(oldRead, std::memory_order_release);

--- a/plugin/src/Caelestia/Services/audiocollector.cpp
+++ b/plugin/src/Caelestia/Services/audiocollector.cpp
@@ -38,7 +38,7 @@ PipeWireWorker::PipeWireWorker(std::stop_token token, AudioCollector* collector)
         return;
     }
 
-    timespec timeout = { 0, 10 * SPA_NSEC_PER_MSEC };
+    timespec timeout = { .tv_sec = 0, .tv_nsec = 10 * SPA_NSEC_PER_MSEC };
     m_timer = pw_loop_add_timer(pw_main_loop_get_loop(m_loop), handleTimeout, this);
     if (!m_timer) {
         qCWarning(lcAcWorker) << "init: failed to create timer";
@@ -121,7 +121,7 @@ void PipeWireWorker::handleTimeout(void* data, uint64_t expirations) {
             self->m_collector->clearBuffer();
         } else {
             self->m_idle = true;
-            timespec timeout = { 0, 500 * SPA_NSEC_PER_MSEC };
+            timespec timeout = { .tv_sec = 0, .tv_nsec = 500 * SPA_NSEC_PER_MSEC };
             pw_loop_update_timer(pw_main_loop_get_loop(self->m_loop), self->m_timer, &timeout, &timeout, false);
         }
     }
@@ -131,7 +131,7 @@ void PipeWireWorker::streamStateChanged(pw_stream_state state) {
     m_idle = false;
     switch (state) {
     case PW_STREAM_STATE_PAUSED: {
-        timespec timeout = { 0, 10 * SPA_NSEC_PER_MSEC };
+        timespec timeout = { .tv_sec = 0, .tv_nsec = 10 * SPA_NSEC_PER_MSEC };
         pw_loop_update_timer(pw_main_loop_get_loop(m_loop), m_timer, &timeout, &timeout, false);
         break;
     }

--- a/plugin/src/Caelestia/Services/audiocollector.cpp
+++ b/plugin/src/Caelestia/Services/audiocollector.cpp
@@ -202,7 +202,7 @@ void AudioCollector::loadChunk(const qint16* samples, quint32 count) {
 
     auto* writeBuffer = m_writeBuffer.load(std::memory_order_relaxed);
     std::transform(samples, samples + count, writeBuffer->begin(), [](qint16 sample) {
-        return sample / 32768.0f;
+        return static_cast<float>(sample) / 32768.0f;
     });
 
     auto* oldRead = m_readBuffer.exchange(writeBuffer, std::memory_order_acq_rel);

--- a/plugin/src/Caelestia/Services/audiocollector.cpp
+++ b/plugin/src/Caelestia/Services/audiocollector.cpp
@@ -49,19 +49,19 @@ PipeWireWorker::PipeWireWorker(std::stop_token token, AudioCollector* collector)
         PW_KEY_MEDIA_TYPE, "Audio", PW_KEY_MEDIA_CATEGORY, "Capture", PW_KEY_MEDIA_ROLE, "Music", nullptr);
     pw_properties_set(props, PW_KEY_STREAM_CAPTURE_SINK, "true");
     pw_properties_setf(
-        props, PW_KEY_NODE_LATENCY, "%u/%u", nextPowerOf2(512 * ac::SAMPLE_RATE / 48000), ac::SAMPLE_RATE);
+        props, PW_KEY_NODE_LATENCY, "%u/%u", nextPowerOf2(512 * ac::k_sampleRate / 48000), ac::k_sampleRate);
     pw_properties_set(props, PW_KEY_NODE_PASSIVE, "true");
     pw_properties_set(props, PW_KEY_NODE_VIRTUAL, "true");
     pw_properties_set(props, PW_KEY_STREAM_DONT_REMIX, "false");
     pw_properties_set(props, "channelmix.upmix", "true");
 
-    std::vector<uint8_t> buffer(ac::CHUNK_SIZE);
+    std::vector<uint8_t> buffer(ac::k_chunkSize);
     spa_pod_builder b;
     spa_pod_builder_init(&b, buffer.data(), static_cast<quint32>(buffer.size()));
 
     spa_audio_info_raw info{};
     info.format = SPA_AUDIO_FORMAT_S16;
-    info.rate = ac::SAMPLE_RATE;
+    info.rate = ac::k_sampleRate;
     info.channels = 1;
 
     const spa_pod* params[1];
@@ -196,7 +196,7 @@ void AudioCollector::clearBuffer() {
 }
 
 void AudioCollector::loadChunk(const qint16* samples, quint32 count) {
-    count = std::min(count, ac::CHUNK_SIZE);
+    count = std::min(count, ac::k_chunkSize);
 
     auto* writeBuffer = m_writeBuffer.load(std::memory_order_relaxed);
     std::transform(samples, samples + count, writeBuffer->begin(), [](qint16 sample) {
@@ -208,8 +208,8 @@ void AudioCollector::loadChunk(const qint16* samples, quint32 count) {
 }
 
 quint32 AudioCollector::readChunk(float* out, quint32 count) {
-    if (count == 0 || count > ac::CHUNK_SIZE) {
-        count = ac::CHUNK_SIZE;
+    if (count == 0 || count > ac::k_chunkSize) {
+        count = ac::k_chunkSize;
     }
 
     auto* readBuffer = m_readBuffer.load(std::memory_order_acquire);
@@ -219,8 +219,8 @@ quint32 AudioCollector::readChunk(float* out, quint32 count) {
 }
 
 quint32 AudioCollector::readChunk(double* out, quint32 count) {
-    if (count == 0 || count > ac::CHUNK_SIZE) {
-        count = ac::CHUNK_SIZE;
+    if (count == 0 || count > ac::k_chunkSize) {
+        count = ac::k_chunkSize;
     }
 
     auto* readBuffer = m_readBuffer.load(std::memory_order_acquire);
@@ -233,8 +233,8 @@ quint32 AudioCollector::readChunk(double* out, quint32 count) {
 
 AudioCollector::AudioCollector(QObject* parent)
     : Service(parent)
-    , m_buffer1(ac::CHUNK_SIZE)
-    , m_buffer2(ac::CHUNK_SIZE)
+    , m_buffer1(ac::k_chunkSize)
+    , m_buffer2(ac::k_chunkSize)
     , m_readBuffer(&m_buffer1)
     , m_writeBuffer(&m_buffer2) {}
 

--- a/plugin/src/Caelestia/Services/audiocollector.cpp
+++ b/plugin/src/Caelestia/Services/audiocollector.cpp
@@ -1,11 +1,8 @@
 #include "audiocollector.hpp"
 
 #include <qloggingcategory.h>
-#include <qmutex.h>
 
 #include <pipewire/pipewire.h>
-#include <spa/param/audio/format-utils.h>
-#include <spa/param/latency-utils.h>
 
 #include <algorithm>
 #include <stop_token>

--- a/plugin/src/Caelestia/Services/audiocollector.cpp
+++ b/plugin/src/Caelestia/Services/audiocollector.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <stop_token>
+#include <utility>
 #include <vector>
 
 #include "service.hpp"
@@ -26,7 +27,7 @@ PipeWireWorker::PipeWireWorker(std::stop_token token, AudioCollector* collector)
     , m_stream(nullptr)
     , m_timer(nullptr)
     , m_idle(true)
-    , m_token(token)
+    , m_token(std::move(token))
     , m_collector(collector) {
     pw_init(nullptr, nullptr);
 

--- a/plugin/src/Caelestia/Services/audiocollector.cpp
+++ b/plugin/src/Caelestia/Services/audiocollector.cpp
@@ -253,7 +253,7 @@ void AudioCollector::start() {
     clearBuffer();
 
     m_thread = std::jthread([this](std::stop_token token) {
-        const PipeWireWorker worker(token, this);
+        const PipeWireWorker worker(std::move(token), this);
     });
 }
 

--- a/plugin/src/Caelestia/Services/audiocollector.hpp
+++ b/plugin/src/Caelestia/Services/audiocollector.hpp
@@ -17,8 +17,8 @@ namespace caelestia::services {
 
 namespace ac {
 
-constexpr quint32 SAMPLE_RATE = 44100;
-constexpr quint32 CHUNK_SIZE = 512;
+constexpr quint32 k_sampleRate = 44100;
+constexpr quint32 k_chunkSize = 512;
 
 } // namespace ac
 

--- a/plugin/src/Caelestia/Services/audiocollector.hpp
+++ b/plugin/src/Caelestia/Services/audiocollector.hpp
@@ -43,7 +43,7 @@ private:
     void streamStateChanged(pw_stream_state state);
     void processStream();
 
-    [[nodiscard]] unsigned int nextPowerOf2(unsigned int n);
+    [[nodiscard]] static unsigned int nextPowerOf2(unsigned int n);
 };
 
 class AudioCollector : public Service {

--- a/plugin/src/Caelestia/Services/audiocollector.hpp
+++ b/plugin/src/Caelestia/Services/audiocollector.hpp
@@ -62,7 +62,7 @@ public:
 
 private:
     explicit AudioCollector(QObject* parent = nullptr);
-    ~AudioCollector();
+    ~AudioCollector() override;
 
     std::jthread m_thread;
     std::vector<float> m_buffer1;

--- a/plugin/src/Caelestia/Services/audioprovider.cpp
+++ b/plugin/src/Caelestia/Services/audioprovider.cpp
@@ -23,7 +23,7 @@ AudioProcessor::~AudioProcessor() {
 
 void AudioProcessor::init() {
     m_timer = new QTimer(this);
-    m_timer->setInterval(static_cast<int>(ac::CHUNK_SIZE * 1000.0 / ac::SAMPLE_RATE));
+    m_timer->setInterval(static_cast<int>(ac::k_chunkSize * 1000.0 / ac::k_sampleRate));
     connect(m_timer, &QTimer::timeout, this, &AudioProcessor::process);
 }
 

--- a/plugin/src/Caelestia/Services/audioprovider.cpp
+++ b/plugin/src/Caelestia/Services/audioprovider.cpp
@@ -6,8 +6,11 @@
 #include "audiocollector.hpp"
 #include "service.hpp"
 
+namespace {
+
 Q_LOGGING_CATEGORY(lcAp, "caelestia.services.ap", QtInfoMsg)
-Q_LOGGING_CATEGORY(lcApProcessor, "caelestia.services.ap.processor", QtInfoMsg)
+
+} // namespace
 
 namespace caelestia::services {
 

--- a/plugin/src/Caelestia/Services/audioprovider.hpp
+++ b/plugin/src/Caelestia/Services/audioprovider.hpp
@@ -12,7 +12,7 @@ class AudioProcessor : public QObject {
 
 public:
     explicit AudioProcessor(QObject* parent = nullptr);
-    ~AudioProcessor();
+    ~AudioProcessor() override;
 
     void init();
 
@@ -32,7 +32,7 @@ class AudioProvider : public Service {
 
 public:
     explicit AudioProvider(QObject* parent = nullptr);
-    ~AudioProvider();
+    ~AudioProvider() override;
 
 protected:
     AudioProcessor* m_processor;

--- a/plugin/src/Caelestia/Services/beattracker.cpp
+++ b/plugin/src/Caelestia/Services/beattracker.cpp
@@ -7,8 +7,8 @@ namespace caelestia::services {
 
 BeatProcessor::BeatProcessor(QObject* parent)
     : AudioProcessor(parent)
-    , m_tempo(new_aubio_tempo("default", 1024, ac::CHUNK_SIZE, ac::SAMPLE_RATE))
-    , m_in(new_fvec(ac::CHUNK_SIZE))
+    , m_tempo(new_aubio_tempo("default", 1024, ac::k_chunkSize, ac::k_sampleRate))
+    , m_in(new_fvec(ac::k_chunkSize))
     , m_out(new_fvec(2)) {};
 
 BeatProcessor::~BeatProcessor() {

--- a/plugin/src/Caelestia/Services/beattracker.cpp
+++ b/plugin/src/Caelestia/Services/beattracker.cpp
@@ -1,7 +1,5 @@
 #include "beattracker.hpp"
 
-#include <aubio/aubio.h>
-
 #include "audiocollector.hpp"
 #include "audioprovider.hpp"
 

--- a/plugin/src/Caelestia/Services/beattracker.hpp
+++ b/plugin/src/Caelestia/Services/beattracker.hpp
@@ -13,7 +13,7 @@ class BeatProcessor : public AudioProcessor {
 
 public:
     explicit BeatProcessor(QObject* parent = nullptr);
-    ~BeatProcessor();
+    ~BeatProcessor() override;
 
 signals:
     void beat(smpl_t bpm);

--- a/plugin/src/Caelestia/Services/cavaprovider.cpp
+++ b/plugin/src/Caelestia/Services/cavaprovider.cpp
@@ -140,7 +140,7 @@ QVector<double> CavaProvider::values() const {
     return m_values;
 }
 
-void CavaProvider::updateValues(QVector<double> values) {
+void CavaProvider::updateValues(const QVector<double>& values) {
     if (values != m_values) {
         m_values = values;
         emit valuesChanged();

--- a/plugin/src/Caelestia/Services/cavaprovider.cpp
+++ b/plugin/src/Caelestia/Services/cavaprovider.cpp
@@ -21,7 +21,7 @@ namespace caelestia::services {
 CavaProcessor::CavaProcessor(QObject* parent)
     : AudioProcessor(parent)
     , m_plan(nullptr)
-    , m_in(new double[ac::CHUNK_SIZE])
+    , m_in(new double[ac::k_chunkSize])
     , m_out(nullptr)
     , m_bars(0) {};
 
@@ -99,7 +99,7 @@ void CavaProcessor::initCava() {
         return;
     }
 
-    m_plan = cava_init(m_bars, ac::SAMPLE_RATE, 1, 1, 0.85, 50, 10000);
+    m_plan = cava_init(m_bars, ac::k_sampleRate, 1, 1, 0.85, 50, 10000);
     m_out = new double[static_cast<size_t>(m_bars)];
 }
 

--- a/plugin/src/Caelestia/Services/cavaprovider.cpp
+++ b/plugin/src/Caelestia/Services/cavaprovider.cpp
@@ -9,8 +9,12 @@
 #include "audiocollector.hpp"
 #include "audioprovider.hpp"
 
+namespace {
+
 Q_LOGGING_CATEGORY(lcCava, "caelestia.services.cava", QtInfoMsg)
 Q_LOGGING_CATEGORY(lcCavaProcessor, "caelestia.services.cava.processor", QtInfoMsg)
+
+} // namespace
 
 namespace caelestia::services {
 

--- a/plugin/src/Caelestia/Services/cavaprovider.hpp
+++ b/plugin/src/Caelestia/Services/cavaprovider.hpp
@@ -13,7 +13,7 @@ class CavaProcessor : public AudioProcessor {
 
 public:
     explicit CavaProcessor(QObject* parent = nullptr);
-    ~CavaProcessor();
+    ~CavaProcessor() override;
 
     void setBars(int bars);
 

--- a/plugin/src/Caelestia/Services/cavaprovider.hpp
+++ b/plugin/src/Caelestia/Services/cavaprovider.hpp
@@ -60,7 +60,7 @@ private:
     int m_bars;
     QVector<double> m_values;
 
-    void updateValues(QVector<double> values);
+    void updateValues(const QVector<double>& values);
 };
 
 } // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/cpu.cpp
+++ b/plugin/src/Caelestia/Services/cpu.cpp
@@ -42,8 +42,8 @@ void Cpu::readNameOnce() {
     const QByteArray data = f.readAll();
     f.close();
 
-    static const QRegularExpression re(QStringLiteral("model name\\s*:\\s*(.+)"));
-    const auto match = re.match(QString::fromLatin1(data));
+    static const QRegularExpression k_re(QStringLiteral("model name\\s*:\\s*(.+)"));
+    const auto match = k_re.match(QString::fromLatin1(data));
     if (!match.hasMatch()) {
         return;
     }
@@ -65,9 +65,9 @@ void Cpu::refreshPercentage() {
     const QByteArray data = f.readAll();
     f.close();
 
-    static const QRegularExpression re(
+    static const QRegularExpression k_re(
         QStringLiteral("^cpu\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)"));
-    const auto match = re.match(QString::fromLatin1(data));
+    const auto match = k_re.match(QString::fromLatin1(data));
     if (!match.hasMatch()) {
         return;
     }
@@ -105,13 +105,13 @@ void Cpu::refreshTemperature() {
 }
 
 QString Cpu::cleanName(QString s) {
-    static const QRegularExpression noise(
+    static const QRegularExpression k_noise(
         QStringLiteral("\\(R\\)|\\(TM\\)|CPU|\\d+(?:th|nd|rd|st) Gen |Core |Processor"),
         QRegularExpression::CaseInsensitiveOption);
-    static const QRegularExpression spaces(QStringLiteral("\\s+"));
+    static const QRegularExpression k_spaces(QStringLiteral("\\s+"));
 
-    s.replace(noise, QString());
-    s.replace(spaces, QStringLiteral(" "));
+    s.replace(k_noise, QString());
+    s.replace(k_spaces, QStringLiteral(" "));
     return s.trimmed();
 }
 

--- a/plugin/src/Caelestia/Services/diskinfo.cpp
+++ b/plugin/src/Caelestia/Services/diskinfo.cpp
@@ -4,7 +4,7 @@ namespace caelestia::services {
 
 namespace {
 
-constexpr qreal kKib = 1024.0;
+constexpr qreal k_kib = 1024.0;
 
 } // namespace
 
@@ -20,16 +20,16 @@ QString DiskInfo::mount() const {
 }
 
 qreal DiskInfo::used() const {
-    return static_cast<qreal>(m_usedBytes) / kKib;
+    return static_cast<qreal>(m_usedBytes) / k_kib;
 }
 
 qreal DiskInfo::total() const {
-    return static_cast<qreal>(m_totalBytes) / kKib;
+    return static_cast<qreal>(m_totalBytes) / k_kib;
 }
 
 qreal DiskInfo::free() const {
     const quint64 freeBytes = m_totalBytes > m_usedBytes ? m_totalBytes - m_usedBytes : 0;
-    return static_cast<qreal>(freeBytes) / kKib;
+    return static_cast<qreal>(freeBytes) / k_kib;
 }
 
 qreal DiskInfo::perc() const {

--- a/plugin/src/Caelestia/Services/gpu.cpp
+++ b/plugin/src/Caelestia/Services/gpu.cpp
@@ -226,7 +226,11 @@ void Gpu::finishNameSource(int index, int generation, QString name) {
     // Under Auto the NVIDIA name probe doubles as the type probe: a non-empty result
     // means an NVIDIA GPU is present and queryable.
     if (m_userType == GpuType::Auto && index == kNvidiaSource) {
-        setType(!name.isEmpty() ? GpuType::Nvidia : (m_busyFiles.isEmpty() ? GpuType::None : GpuType::Generic));
+        if (!name.isEmpty())
+            setType(GpuType::Nvidia);
+        else
+            setType(m_busyFiles.isEmpty() ? GpuType::None : GpuType::Generic);
+
         if (m_type == GpuType::None) {
             setName(tr("None"));
             return;

--- a/plugin/src/Caelestia/Services/gpu.cpp
+++ b/plugin/src/Caelestia/Services/gpu.cpp
@@ -14,13 +14,13 @@ namespace caelestia::services {
 namespace {
 
 QStringList gpuBusyFiles() {
-    static const QRegularExpression cardRe(QStringLiteral("^card\\d+$"));
+    static const QRegularExpression k_cardRe(QStringLiteral("^card\\d+$"));
 
     QStringList files;
     QDirIterator it(QStringLiteral("/sys/class/drm"), QDir::Dirs | QDir::NoDotAndDotDot);
     while (it.hasNext()) {
         const QString path = it.next();
-        if (!cardRe.match(it.fileName()).hasMatch()) {
+        if (!k_cardRe.match(it.fileName()).hasMatch()) {
             continue;
         }
         const QString busy = path + QStringLiteral("/device/gpu_busy_percent");
@@ -32,11 +32,11 @@ QStringList gpuBusyFiles() {
 }
 
 QString cleanName(QString s) {
-    static const QRegularExpression noise(
+    static const QRegularExpression k_noise(
         QStringLiteral("\\(R\\)|\\(TM\\)|Graphics"), QRegularExpression::CaseInsensitiveOption);
-    static const QRegularExpression spaces(QStringLiteral("\\s+"));
-    s.replace(noise, QString());
-    s.replace(spaces, QStringLiteral(" "));
+    static const QRegularExpression k_spaces(QStringLiteral("\\s+"));
+    s.replace(k_noise, QString());
+    s.replace(k_spaces, QStringLiteral(" "));
     return s.trimmed();
 }
 
@@ -69,13 +69,13 @@ QString parseGlxinfoName(const QByteArray& out) {
 }
 
 QString parseLspciName(const QByteArray& out) {
-    static const QRegularExpression lineRe(
+    static const QRegularExpression k_lineRe(
         QStringLiteral("vga|3d controller|display"), QRegularExpression::CaseInsensitiveOption);
 
     const QStringList lines = QString::fromUtf8(out).split('\n');
     QString match;
     for (const QString& line : lines) {
-        if (lineRe.match(line).hasMatch()) {
+        if (k_lineRe.match(line).hasMatch()) {
             match = line;
             break;
         }
@@ -85,16 +85,16 @@ QString parseLspciName(const QByteArray& out) {
         return {};
     }
 
-    static const QRegularExpression bracketRe(QStringLiteral("\\[([^\\]]+)\\][^\\[]*$"));
-    const auto bracket = bracketRe.match(match);
+    static const QRegularExpression k_bracketRe(QStringLiteral("\\[([^\\]]+)\\][^\\[]*$"));
+    const auto bracket = k_bracketRe.match(match);
     if (bracket.hasMatch()) {
         return cleanName(bracket.captured(1));
     }
 
     // Split on a colon followed by whitespace so the PCI slot ("00:02.0") is not
     // mistaken for the class/name separator ("controller: Device").
-    static const QRegularExpression colonRe(QStringLiteral(":\\s+(.+)"));
-    const auto colon = colonRe.match(match);
+    static const QRegularExpression k_colonRe(QStringLiteral(":\\s+(.+)"));
+    const auto colon = k_colonRe.match(match);
     if (colon.hasMatch()) {
         return cleanName(colon.captured(1));
     }
@@ -111,7 +111,7 @@ struct NameSource {
 // Name probes in priority order; the first non-empty result wins. Which of them run
 // depends on the resolved type.
 const std::array<NameSource, 3>& nameSources() {
-    static const std::array<NameSource, 3> sources = { {
+    static const std::array<NameSource, 3> k_sources = { {
         {
             .program = QStringLiteral("nvidia-smi"),
             .args = { QStringLiteral("--query-gpu=name"), QStringLiteral("--format=csv,noheader") },
@@ -128,12 +128,12 @@ const std::array<NameSource, 3>& nameSources() {
             .parse = &parseLspciName,
         },
     } };
-    return sources;
+    return k_sources;
 }
 
 // Indices within nameSources(): nvidia-smi, then the driver-agnostic probes.
-constexpr int kNvidiaSource = 0;
-constexpr int kFirstGenericSource = 1;
+constexpr int k_nvidiaSource = 0;
+constexpr int k_firstGenericSource = 1;
 
 } // namespace
 
@@ -215,11 +215,11 @@ void Gpu::resolveGpu() {
     }
 
     setName(tr("Detecting GPU..."));
-    tryNameSource(m_userType == GpuType::Generic ? kFirstGenericSource : kNvidiaSource, generation);
+    tryNameSource(m_userType == GpuType::Generic ? k_firstGenericSource : k_nvidiaSource, generation);
 }
 
 int Gpu::probeEnd() const {
-    return m_userType == GpuType::Nvidia ? kFirstGenericSource : static_cast<int>(nameSources().size());
+    return m_userType == GpuType::Nvidia ? k_firstGenericSource : static_cast<int>(nameSources().size());
 }
 
 void Gpu::tryNameSource(int index, int generation) {
@@ -236,7 +236,7 @@ void Gpu::finishNameSource(int index, int generation, QString name) {
 
     // Under Auto the NVIDIA name probe doubles as the type probe: a non-empty result
     // means an NVIDIA GPU is present and queryable.
-    if (m_userType == GpuType::Auto && index == kNvidiaSource) {
+    if (m_userType == GpuType::Auto && index == k_nvidiaSource) {
         if (!name.isEmpty())
             setType(GpuType::Nvidia);
         else

--- a/plugin/src/Caelestia/Services/gpu.cpp
+++ b/plugin/src/Caelestia/Services/gpu.cpp
@@ -112,10 +112,21 @@ struct NameSource {
 // depends on the resolved type.
 const std::array<NameSource, 3>& nameSources() {
     static const std::array<NameSource, 3> sources = { {
-        { QStringLiteral("nvidia-smi"), { QStringLiteral("--query-gpu=name"), QStringLiteral("--format=csv,noheader") },
-            &parseNvidiaName },
-        { QStringLiteral("glxinfo"), { QStringLiteral("-B") }, &parseGlxinfoName },
-        { QStringLiteral("lspci"), {}, &parseLspciName },
+        {
+            .program = QStringLiteral("nvidia-smi"),
+            .args = { QStringLiteral("--query-gpu=name"), QStringLiteral("--format=csv,noheader") },
+            .parse = &parseNvidiaName,
+        },
+        {
+            .program = QStringLiteral("glxinfo"),
+            .args = { QStringLiteral("-B") },
+            .parse = &parseGlxinfoName,
+        },
+        {
+            .program = QStringLiteral("lspci"),
+            .args = {},
+            .parse = &parseLspciName,
+        },
     } };
     return sources;
 }

--- a/plugin/src/Caelestia/Services/gpu.cpp
+++ b/plugin/src/Caelestia/Services/gpu.cpp
@@ -65,7 +65,7 @@ QString parseGlxinfoName(const QByteArray& out) {
         }
     }
 
-    return QString();
+    return {};
 }
 
 QString parseLspciName(const QByteArray& out) {
@@ -82,7 +82,7 @@ QString parseLspciName(const QByteArray& out) {
     }
 
     if (match.isEmpty()) {
-        return QString();
+        return {};
     }
 
     static const QRegularExpression bracketRe(QStringLiteral("\\[([^\\]]+)\\][^\\[]*$"));
@@ -99,7 +99,7 @@ QString parseLspciName(const QByteArray& out) {
         return cleanName(colon.captured(1));
     }
 
-    return QString();
+    return {};
 }
 
 struct NameSource {

--- a/plugin/src/Caelestia/Services/hyprdevices.cpp
+++ b/plugin/src/Caelestia/Services/hyprdevices.cpp
@@ -3,6 +3,7 @@
 #include <qjsonarray.h>
 
 #include <algorithm>
+#include <utility>
 
 #include "config/rootnodes.hpp"
 #include "core/toaster.hpp"
@@ -49,7 +50,7 @@ void toastKbLayout(const QString& layout) {
 
 HyprKeyboard::HyprKeyboard(QJsonObject ipcObject, QObject* parent)
     : QObject(parent)
-    , m_lastIpcObject(ipcObject) {}
+    , m_lastIpcObject(std::move(ipcObject)) {}
 
 QVariantHash HyprKeyboard::lastIpcObject() const {
     return m_lastIpcObject.toVariantHash();

--- a/plugin/src/Caelestia/Services/hyprdevices.cpp
+++ b/plugin/src/Caelestia/Services/hyprdevices.cpp
@@ -84,7 +84,7 @@ bool HyprKeyboard::main() const {
     return m_lastIpcObject.value(u"main"_s).toBool();
 }
 
-bool HyprKeyboard::updateLastIpcObject(QJsonObject object) {
+bool HyprKeyboard::updateLastIpcObject(const QJsonObject& object) {
     if (m_lastIpcObject == object) {
         return false;
     }
@@ -140,7 +140,7 @@ QQmlListProperty<HyprKeyboard> HyprDevices::keyboards() {
     return { this, &m_keyboards };
 }
 
-bool HyprDevices::updateLastIpcObject(QJsonObject object) {
+bool HyprDevices::updateLastIpcObject(const QJsonObject& object) {
     const auto val = object.value(u"keyboards"_s).toArray();
     bool dirty = false;
 

--- a/plugin/src/Caelestia/Services/hyprdevices.cpp
+++ b/plugin/src/Caelestia/Services/hyprdevices.cpp
@@ -2,6 +2,8 @@
 
 #include <qjsonarray.h>
 
+#include <algorithm>
+
 #include "config/rootnodes.hpp"
 #include "core/toaster.hpp"
 
@@ -143,7 +145,7 @@ bool HyprDevices::updateLastIpcObject(QJsonObject object) {
 
     for (auto it = m_keyboards.begin(); it != m_keyboards.end();) {
         auto* const keyboard = *it;
-        const auto inNewValues = std::any_of(val.begin(), val.end(), [keyboard](const QJsonValue& o) {
+        const auto inNewValues = std::ranges::any_of(val, [keyboard](const QJsonValue& o) {
             return o.toObject().value(u"address"_s).toString() == keyboard->address();
         });
 
@@ -160,7 +162,7 @@ bool HyprDevices::updateLastIpcObject(QJsonObject object) {
         const auto obj = o.toObject();
         const auto addr = obj.value(u"address"_s).toString();
 
-        auto it = std::find_if(m_keyboards.begin(), m_keyboards.end(), [addr](const HyprKeyboard* kb) {
+        auto it = std::ranges::find_if(m_keyboards, [addr](const HyprKeyboard* kb) {
             return kb->address() == addr;
         });
 

--- a/plugin/src/Caelestia/Services/hyprdevices.cpp
+++ b/plugin/src/Caelestia/Services/hyprdevices.cpp
@@ -134,7 +134,7 @@ HyprDevices::HyprDevices(QObject* parent)
     : QObject(parent) {}
 
 QQmlListProperty<HyprKeyboard> HyprDevices::keyboards() {
-    return QQmlListProperty<HyprKeyboard>(this, &m_keyboards);
+    return { this, &m_keyboards };
 }
 
 bool HyprDevices::updateLastIpcObject(QJsonObject object) {

--- a/plugin/src/Caelestia/Services/hyprdevices.hpp
+++ b/plugin/src/Caelestia/Services/hyprdevices.hpp
@@ -33,7 +33,7 @@ public:
     [[nodiscard]] bool numLock() const;
     [[nodiscard]] bool main() const;
 
-    bool updateLastIpcObject(QJsonObject object);
+    bool updateLastIpcObject(const QJsonObject& object);
 
 signals:
     void lastIpcObjectChanged();
@@ -62,7 +62,7 @@ public:
 
     [[nodiscard]] QQmlListProperty<HyprKeyboard> keyboards();
 
-    bool updateLastIpcObject(QJsonObject object);
+    bool updateLastIpcObject(const QJsonObject& object);
 
 signals:
     void keyboardsChanged();

--- a/plugin/src/Caelestia/Services/hyprextras.cpp
+++ b/plugin/src/Caelestia/Services/hyprextras.cpp
@@ -8,7 +8,11 @@
 
 #include "hyprdevices.hpp"
 
+namespace {
+
 Q_LOGGING_CATEGORY(lcHypr, "caelestia.services.hypr", QtInfoMsg)
+
+} // namespace
 
 namespace caelestia::services::hypr {
 

--- a/plugin/src/Caelestia/Services/hyprextras.cpp
+++ b/plugin/src/Caelestia/Services/hyprextras.cpp
@@ -210,7 +210,7 @@ HyprExtras::SocketPtr HyprExtras::makeRequest(
 
     QObject::connect(socket.data(), &QLocalSocket::connected, this, [=, this]() {
         QObject::connect(socket.data(), &QLocalSocket::readyRead, this, [socket, callback]() {
-            const auto response = socket->readAll();
+            auto response = socket->readAll();
             callback(true, std::move(response));
             socket->close();
         });

--- a/plugin/src/Caelestia/Services/hyprextras.cpp
+++ b/plugin/src/Caelestia/Services/hyprextras.cpp
@@ -203,7 +203,7 @@ HyprExtras::SocketPtr HyprExtras::makeRequestJson(
 HyprExtras::SocketPtr HyprExtras::makeRequest(
     const QString& request, const std::function<void(bool, QByteArray)>& callback) {
     if (m_requestSocket.isEmpty()) {
-        return SocketPtr();
+        return {};
     }
 
     auto socket = SocketPtr::create(this);

--- a/plugin/src/Caelestia/Services/lyrics.cpp
+++ b/plugin/src/Caelestia/Services/lyrics.cpp
@@ -7,6 +7,8 @@
 #include <qsavefile.h>
 #include <qurlquery.h>
 
+#include <algorithm>
+
 #include "config/rootnodes.hpp"
 #include "config/serviceconfig.hpp"
 #include "config/userpaths.hpp"
@@ -281,7 +283,7 @@ void Lyrics::setLoading(bool value) {
 }
 
 void Lyrics::setLines(QVector<LyricLine> lines, LyricsBackend source) {
-    std::sort(lines.begin(), lines.end(), [](const LyricLine& a, const LyricLine& b) {
+    std::ranges::sort(lines, [](const LyricLine& a, const LyricLine& b) {
         return a.time < b.time;
     });
 
@@ -1056,7 +1058,7 @@ QVector<LyricLine> Lyrics::parseLrc(const QString& text) {
         }
     }
 
-    std::sort(result.begin(), result.end(), [](const LyricLine& a, const LyricLine& b) {
+    std::ranges::sort(result, [](const LyricLine& a, const LyricLine& b) {
         return a.time < b.time;
     });
 

--- a/plugin/src/Caelestia/Services/lyrics.cpp
+++ b/plugin/src/Caelestia/Services/lyrics.cpp
@@ -846,7 +846,7 @@ void Lyrics::persistTrackPrefs() {
     }
 }
 
-QString Lyrics::lyricsDir() const {
+QString Lyrics::lyricsDir() {
     QString dir = config::ConfigSingleton::instance()->paths()->lyricsDir();
     if (dir.isEmpty()) {
         return {};
@@ -862,7 +862,7 @@ QString Lyrics::lyricsDir() const {
     return dir;
 }
 
-QString Lyrics::lyricsMapPath() const {
+QString Lyrics::lyricsMapPath() {
     return stateDir() + u"/lyrics_map.json"_s;
 }
 

--- a/plugin/src/Caelestia/Services/lyrics.cpp
+++ b/plugin/src/Caelestia/Services/lyrics.cpp
@@ -26,22 +26,22 @@ using Qt::StringLiterals::operator""_ba;
 
 namespace {
 
-constexpr int kLoadDebounceMs = 50;
-constexpr qreal kIndexFudge = 0.1;
+constexpr int k_loadDebounceMs = 50;
+constexpr qreal k_indexFudge = 0.1;
 
 [[nodiscard]] const QHash<QByteArray, QByteArray>& netEaseHeaders() {
-    static const QHash<QByteArray, QByteArray> h = {
+    static const QHash<QByteArray, QByteArray> k_h = {
         { "User-Agent"_ba, "Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0"_ba },
         { "Referer"_ba, "https://music.163.com/"_ba },
     };
-    return h;
+    return k_h;
 }
 
 [[nodiscard]] const QHash<QByteArray, QByteArray>& lrclibHeaders() {
-    static const QHash<QByteArray, QByteArray> h = {
+    static const QHash<QByteArray, QByteArray> k_h = {
         { "User-Agent"_ba, "caelestia-shell (https://github.com/caelestia-dots/shell)"_ba },
     };
-    return h;
+    return k_h;
 }
 
 [[nodiscard]] QString joinArtists(const QString& s) {
@@ -72,7 +72,7 @@ Lyrics::Lyrics(QObject* parent)
     , m_nam(new QNetworkAccessManager(this))
     , m_loadDebounce(new QTimer(this)) {
     m_loadDebounce->setSingleShot(true);
-    m_loadDebounce->setInterval(kLoadDebounceMs);
+    m_loadDebounce->setInterval(k_loadDebounceMs);
     QObject::connect(m_loadDebounce, &QTimer::timeout, this, &Lyrics::doLoad);
 
     const auto* cfg = config::ConfigSingleton::instance();
@@ -211,7 +211,7 @@ int Lyrics::indexForTime(qreal time) const {
     if (m_lines.isEmpty()) {
         return -1;
     }
-    const qreal target = time - m_offset + kIndexFudge;
+    const qreal target = time - m_offset + k_indexFudge;
     qsizetype lo = 0;
     qsizetype hi = m_lines.size();
     while (lo < hi) {
@@ -513,8 +513,8 @@ void Lyrics::tryLrclib(int reqId) {
         q.addQueryItem(u"album_name"_s, m_album);
     }
 
-    constexpr qreal kMaxDurationSecs = std::numeric_limits<int>::max();
-    if (m_duration > 0 && qIsFinite(m_duration) && m_duration < kMaxDurationSecs) {
+    constexpr qreal k_maxDurationSecs = std::numeric_limits<int>::max();
+    if (m_duration > 0 && qIsFinite(m_duration) && m_duration < k_maxDurationSecs) {
         q.addQueryItem(u"duration"_s, QString::number(qRound(m_duration)));
     }
     url.setQuery(q);
@@ -903,25 +903,25 @@ LyricsBackend Lyrics::backendFromKey(const QString& key) {
 }
 
 const QString& Lyrics::stateDir() {
-    static const QString s_dir = [] {
+    static const QString k_dir = [] {
         QString state = qEnvironmentVariable("XDG_STATE_HOME");
         if (state.isEmpty()) {
             state = QDir::homePath() + u"/.local/state"_s;
         }
         return state + u"/caelestia/lyrics"_s;
     }();
-    return s_dir;
+    return k_dir;
 }
 
 const QString& Lyrics::cacheDir() {
-    static const QString s_dir = [] {
+    static const QString k_dir = [] {
         QString cache = qEnvironmentVariable("XDG_CACHE_HOME");
         if (cache.isEmpty()) {
             cache = QDir::homePath() + u"/.cache"_s;
         }
         return cache + u"/caelestia/lyrics"_s;
     }();
-    return s_dir;
+    return k_dir;
 }
 
 QString Lyrics::cachePathFor(LyricsBackend backend, const QString& id) {
@@ -1004,8 +1004,8 @@ QVector<LyricLine> Lyrics::parseLrc(const QString& text) {
         return result;
     }
 
-    static const QRegularExpression timeRegex(u"\\[(\\d+):(\\d+(?:\\.\\d+)?)\\]"_s);
-    static const QStringList creditKeywords = {
+    static const QRegularExpression k_timeRegex(u"\\[(\\d+):(\\d+(?:\\.\\d+)?)\\]"_s);
+    static const QStringList k_creditKeywords = {
         u"作词"_s,
         u"作曲"_s,
         u"编曲"_s,
@@ -1025,7 +1025,7 @@ QVector<LyricLine> Lyrics::parseLrc(const QString& text) {
     const QStringList lines = text.split(QLatin1Char('\n'));
     for (const QString& line : lines) {
         QList<QRegularExpressionMatch> matches;
-        auto it = timeRegex.globalMatch(line);
+        auto it = k_timeRegex.globalMatch(line);
         while (it.hasNext()) {
             matches.append(it.next());
         }
@@ -1034,14 +1034,14 @@ QVector<LyricLine> Lyrics::parseLrc(const QString& text) {
         }
 
         QString lyric = line;
-        lyric.replace(timeRegex, QString());
+        lyric.replace(k_timeRegex, QString());
         lyric = lyric.trimmed();
 
         const qreal firstTime = matches.first().captured(1).toInt() * 60.0 + matches.first().captured(2).toDouble();
 
         if (firstTime < 20.0) {
             bool isCredit = false;
-            for (const QString& k : creditKeywords) {
+            for (const QString& k : k_creditKeywords) {
                 if (lyric.contains(k, Qt::CaseInsensitive)) {
                     isCredit = true;
                     break;

--- a/plugin/src/Caelestia/Services/lyrics.cpp
+++ b/plugin/src/Caelestia/Services/lyrics.cpp
@@ -703,7 +703,7 @@ void Lyrics::searchNetEaseCandidates(int reqId) {
 }
 
 void Lyrics::fetchLrclibById(const QString& id, int reqId) {
-    QUrl url(u"https://lrclib.net/api/get/"_s + id);
+    const QUrl url(u"https://lrclib.net/api/get/"_s + id);
     auto* reply = getJson(url, lrclibHeaders());
     trackReply(reqId, reply);
 

--- a/plugin/src/Caelestia/Services/lyrics.cpp
+++ b/plugin/src/Caelestia/Services/lyrics.cpp
@@ -11,7 +11,11 @@
 #include "config/serviceconfig.hpp"
 #include "config/userpaths.hpp"
 
+namespace {
+
 Q_LOGGING_CATEGORY(lcLyrics, "caelestia.lyrics", QtInfoMsg)
+
+} // namespace
 
 namespace caelestia::services {
 

--- a/plugin/src/Caelestia/Services/lyrics.cpp
+++ b/plugin/src/Caelestia/Services/lyrics.cpp
@@ -1054,7 +1054,7 @@ QVector<LyricLine> Lyrics::parseLrc(const QString& text) {
 
         for (const auto& m : matches) {
             const qreal t = m.captured(1).toInt() * 60.0 + m.captured(2).toDouble();
-            result.append(LyricLine{ t, lyric });
+            result.append(LyricLine{ .time = t, .text = lyric });
         }
     }
 

--- a/plugin/src/Caelestia/Services/lyrics.cpp
+++ b/plugin/src/Caelestia/Services/lyrics.cpp
@@ -419,13 +419,13 @@ void Lyrics::doLoad() {
     }
 }
 
-void Lyrics::chainNext(LyricsBackend just_failed, int reqId) {
+void Lyrics::chainNext(LyricsBackend justFailed, int reqId) {
     if (m_preferredBackend != LyricsBackend::Auto) {
         // Non-auto modes don't chain
         setLoading(false);
         return;
     }
-    switch (just_failed) {
+    switch (justFailed) {
     case LyricsBackend::Local:
         tryLrclib(reqId);
         return;

--- a/plugin/src/Caelestia/Services/lyrics.hpp
+++ b/plugin/src/Caelestia/Services/lyrics.hpp
@@ -102,8 +102,8 @@ private:
     void loadLyricsMap();
     void persistTrackPrefs();
 
-    [[nodiscard]] QString lyricsDir() const;
-    [[nodiscard]] QString lyricsMapPath() const;
+    [[nodiscard]] static QString lyricsDir();
+    [[nodiscard]] static QString lyricsMapPath();
     [[nodiscard]] QString trackKey() const;
     [[nodiscard]] static QString backendKey(LyricsBackend value);
     [[nodiscard]] static LyricsBackend backendFromKey(const QString& key);

--- a/plugin/src/Caelestia/Services/lyrics.hpp
+++ b/plugin/src/Caelestia/Services/lyrics.hpp
@@ -85,7 +85,7 @@ private:
     void tryLocal(int reqId);
     void tryLrclib(int reqId);
     void tryNetEase(int reqId);
-    void chainNext(LyricsBackend just_failed, int reqId);
+    void chainNext(LyricsBackend justFailed, int reqId);
 
     void searchLrclibCandidates(int reqId);
     void searchNetEaseCandidates(int reqId);

--- a/plugin/src/Caelestia/Services/memory.cpp
+++ b/plugin/src/Caelestia/Services/memory.cpp
@@ -28,12 +28,12 @@ void Memory::tick() {
     const QByteArray data = f.readAll();
     f.close();
 
-    static const QRegularExpression reTotal(QStringLiteral("MemTotal: *(\\d+)"));
-    static const QRegularExpression reAvail(QStringLiteral("MemAvailable: *(\\d+)"));
+    static const QRegularExpression k_reTotal(QStringLiteral("MemTotal: *(\\d+)"));
+    static const QRegularExpression k_reAvail(QStringLiteral("MemAvailable: *(\\d+)"));
     const QString text = QString::fromLatin1(data);
 
-    const auto totalMatch = reTotal.match(text);
-    const auto availMatch = reAvail.match(text);
+    const auto totalMatch = k_reTotal.match(text);
+    const auto availMatch = k_reAvail.match(text);
     if (!totalMatch.hasMatch() || !availMatch.hasMatch()) {
         return;
     }

--- a/plugin/src/Caelestia/Services/networkusage.cpp
+++ b/plugin/src/Caelestia/Services/networkusage.cpp
@@ -10,9 +10,9 @@
 
 namespace {
 
-constexpr qreal kBytesPerKiB = 1024.0;
-constexpr qreal kBytesPerMiB = 1024.0 * 1024.0;
-constexpr qreal kBytesPerGiB = 1024.0 * 1024.0 * 1024.0;
+constexpr qreal k_bytesPerKib = 1024.0;
+constexpr qreal k_bytesPerMib = 1024.0 * 1024.0;
+constexpr qreal k_bytesPerGib = 1024.0 * 1024.0 * 1024.0;
 
 } // namespace
 
@@ -68,17 +68,17 @@ NetworkFormatResult NetworkUsage::formatBytes(qreal bytes) {
         result.unit = QStringLiteral("B");
         return result;
     }
-    if (bytes < kBytesPerKiB) {
+    if (bytes < k_bytesPerKib) {
         result.value = bytes;
         result.unit = QStringLiteral("B");
-    } else if (bytes < kBytesPerMiB) {
-        result.value = bytes / kBytesPerKiB;
+    } else if (bytes < k_bytesPerMib) {
+        result.value = bytes / k_bytesPerKib;
         result.unit = QStringLiteral("KB");
-    } else if (bytes < kBytesPerGiB) {
-        result.value = bytes / kBytesPerMiB;
+    } else if (bytes < k_bytesPerGib) {
+        result.value = bytes / k_bytesPerMib;
         result.unit = QStringLiteral("MB");
     } else {
-        result.value = bytes / kBytesPerGiB;
+        result.value = bytes / k_bytesPerGib;
         result.unit = QStringLiteral("GB");
     }
     return result;

--- a/plugin/src/Caelestia/Services/networkusage.cpp
+++ b/plugin/src/Caelestia/Services/networkusage.cpp
@@ -97,7 +97,7 @@ void NetworkUsage::tick() {
     quint64 totalTx = 0;
 
     while (!f.atEnd()) {
-        QByteArray line = f.readLine();
+        const QByteArray line = f.readLine();
         const qsizetype splitIdx = line.indexOf(':');
         if (splitIdx == -1) {
             continue;

--- a/plugin/src/Caelestia/Services/networkusage.cpp
+++ b/plugin/src/Caelestia/Services/networkusage.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cmath>
 #include <cstdio>
+#include <utility>
 
 namespace {
 
@@ -107,10 +108,12 @@ void NetworkUsage::tick() {
         }
 
         std::array<unsigned long long, 9> fields{};
+        // NOLINTBEGIN(readability-container-data-pointer)
         const int parsed = std::sscanf(line.constData() + splitIdx + 1, "%llu %llu %llu %llu %llu %llu %llu %llu %llu",
             &fields[0], &fields[1], &fields[2], &fields[3], &fields[4], &fields[5], &fields[6], &fields[7], &fields[8]);
+        // NOLINTEND(readability-container-data-pointer)
 
-        if (parsed != static_cast<int>(fields.size())) {
+        if (std::cmp_not_equal(parsed, fields.size())) {
             continue;
         }
 

--- a/plugin/src/Caelestia/Services/networkusage.cpp
+++ b/plugin/src/Caelestia/Services/networkusage.cpp
@@ -54,13 +54,13 @@ CircularBuffer* NetworkUsage::uploadBuffer() const {
     return m_uploadBuffer;
 }
 
-NetworkFormatResult NetworkUsage::formatBytesRate(qreal bytes) const {
+NetworkFormatResult NetworkUsage::formatBytesRate(qreal bytes) {
     NetworkFormatResult result = formatBytes(bytes);
     result.unit = result.unit + QStringLiteral("/s");
     return result;
 }
 
-NetworkFormatResult NetworkUsage::formatBytes(qreal bytes) const {
+NetworkFormatResult NetworkUsage::formatBytes(qreal bytes) {
     NetworkFormatResult result;
 
     if (bytes < 0 || std::isnan(bytes) || !std::isfinite(bytes)) {

--- a/plugin/src/Caelestia/Services/networkusage.cpp
+++ b/plugin/src/Caelestia/Services/networkusage.cpp
@@ -4,9 +4,9 @@
 #include <qtypes.h>
 
 #include <array>
+#include <charconv>
 #include <cmath>
-#include <cstdio>
-#include <utility>
+#include <system_error>
 
 namespace {
 
@@ -89,7 +89,7 @@ void NetworkUsage::tick() {
     if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) {
         return;
     }
-    // skip headers
+    // Skip headers
     f.readLine();
     f.readLine();
 
@@ -104,18 +104,29 @@ void NetworkUsage::tick() {
         }
         const QByteArray iface = line.left(splitIdx).trimmed();
         if (iface == QByteArrayLiteral("lo")) {
-            continue; // skip loopback interface
+            continue; // Skip loopback interface
         }
+
+        // Parse every counter through tx bytes to validate the row
+        const char* pos = line.constData() + splitIdx + 1;
+        const char* const end = line.constData() + line.size();
 
         std::array<unsigned long long, 9> fields{};
-        // NOLINTBEGIN(readability-container-data-pointer)
-        const int parsed = std::sscanf(line.constData() + splitIdx + 1, "%llu %llu %llu %llu %llu %llu %llu %llu %llu",
-            &fields[0], &fields[1], &fields[2], &fields[3], &fields[4], &fields[5], &fields[6], &fields[7], &fields[8]);
-        // NOLINTEND(readability-container-data-pointer)
+        bool valid = true;
+        for (unsigned long long& field : fields) {
+            while (pos < end && (*pos == ' ' || *pos == '\t'))
+                ++pos;
 
-        if (std::cmp_not_equal(parsed, fields.size())) {
-            continue;
+            const auto [next, ec] = std::from_chars(pos, end, field);
+            if (ec != std::errc{}) {
+                valid = false;
+                break;
+            }
+            pos = next;
         }
+
+        if (!valid)
+            continue;
 
         totalRx += static_cast<quint64>(fields[0]);
         totalTx += static_cast<quint64>(fields[8]);

--- a/plugin/src/Caelestia/Services/networkusage.hpp
+++ b/plugin/src/Caelestia/Services/networkusage.hpp
@@ -43,8 +43,8 @@ public:
     [[nodiscard]] qreal uploadTotal() const;
     [[nodiscard]] int historyLength() const;
 
-    [[nodiscard]] Q_INVOKABLE NetworkFormatResult formatBytesRate(qreal bytes) const;
-    [[nodiscard]] Q_INVOKABLE NetworkFormatResult formatBytes(qreal bytes) const;
+    [[nodiscard]] Q_INVOKABLE static NetworkFormatResult formatBytesRate(qreal bytes);
+    [[nodiscard]] Q_INVOKABLE static NetworkFormatResult formatBytes(qreal bytes);
 
     [[nodiscard]] CircularBuffer* downloadBuffer() const;
     [[nodiscard]] CircularBuffer* uploadBuffer() const;

--- a/plugin/src/Caelestia/Services/sensorslib.cpp
+++ b/plugin/src/Caelestia/Services/sensorslib.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <mutex>
+#include <utility>
 
 Q_LOGGING_CATEGORY(lcSensorsLib, "caelestia.services.sensorslib", QtInfoMsg)
 
@@ -61,7 +62,7 @@ bool labelEquals(const QByteArray& label, const char* literal) {
 
 bool labelStartsWith(const QByteArray& label, const char* prefix) {
     const auto n = std::strlen(prefix);
-    return static_cast<size_t>(label.size()) >= n && std::memcmp(label.constData(), prefix, n) == 0;
+    return std::cmp_greater_equal(label.size(), n) && std::memcmp(label.constData(), prefix, n) == 0;
 }
 
 } // namespace

--- a/plugin/src/Caelestia/Services/sensorslib.cpp
+++ b/plugin/src/Caelestia/Services/sensorslib.cpp
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <cctype>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <mutex>
@@ -39,22 +40,19 @@ void doInit() {
 }
 
 [[nodiscard]] std::optional<double> readTempInput(const sensors_chip_name* chip, const sensors_feature* feat) {
-    const sensors_subfeature* sf = sensors_get_subfeature(chip, feat, SENSORS_SUBFEATURE_TEMP_INPUT);
-    if (!sf) {
+    const auto* sf = sensors_get_subfeature(chip, feat, SENSORS_SUBFEATURE_TEMP_INPUT);
+    if (!sf)
         return std::nullopt;
-    }
     double value = 0.0;
-    if (sensors_get_value(chip, sf->number, &value) != 0) {
+    if (sensors_get_value(chip, sf->number, &value) != 0)
         return std::nullopt;
-    }
     return value;
 }
 
 [[nodiscard]] QByteArray featureLabel(const sensors_chip_name* chip, const sensors_feature* feat) {
     char* raw = sensors_get_label(chip, feat);
-    if (!raw) {
+    if (!raw)
         return {};
-    }
     QByteArray out(raw);
     std::free(raw);
     return out;
@@ -69,6 +67,68 @@ bool labelStartsWith(const QByteArray& label, const char* prefix) {
     return std::cmp_greater_equal(label.size(), n) && std::memcmp(label.constData(), prefix, n) == 0;
 }
 
+// Walks every labelled temperature feature, optionally restricted to one bus type
+template <typename F> void forEachTempFeature(short busType, F&& fn) {
+    int chipNr = 0;
+    while (const auto* chip = sensors_get_detected_chips(nullptr, &chipNr)) {
+        if (busType != SENSORS_BUS_TYPE_ANY && chip->bus.type != busType)
+            continue;
+
+        int featNr = 0;
+        while (const auto* feat = sensors_get_features(chip, &featNr)) {
+            if (feat->type != SENSORS_FEATURE_TEMP)
+                continue;
+
+            const auto label = featureLabel(chip, feat);
+            if (label.isEmpty())
+                continue;
+
+            fn(chip, feat, label);
+        }
+    }
+}
+
+enum class GpuTempKind : std::uint8_t {
+    None,
+    Primary,
+    Fallback
+};
+
+// Indexed tempN labels and the vendor die labels are the reading we want,
+// junction/mem only stand in when no primary sensor exists
+GpuTempKind classifyGpuTempLabel(const QByteArray& label) {
+    if (label.isEmpty())
+        return GpuTempKind::None;
+
+    const auto tempIndexed =
+        labelStartsWith(label, "temp") && label.size() > 4 && std::isdigit(static_cast<unsigned char>(label[4]));
+    if (tempIndexed || labelEquals(label, "GPU core") || labelEquals(label, "edge"))
+        return GpuTempKind::Primary;
+    if (labelEquals(label, "junction") || labelEquals(label, "mem"))
+        return GpuTempKind::Fallback;
+
+    return GpuTempKind::None;
+}
+
+struct TempAccum {
+    double sum = 0.0;
+    int count = 0;
+
+    void add(double value);
+    [[nodiscard]] std::optional<double> average() const;
+};
+
+void TempAccum::add(double value) {
+    sum += value;
+    ++count;
+}
+
+std::optional<double> TempAccum::average() const {
+    if (count == 0)
+        return std::nullopt;
+    return sum / count;
+}
+
 } // namespace
 
 void ensureInit() {
@@ -77,97 +137,53 @@ void ensureInit() {
 
 std::optional<double> cpuPackageTemp() {
     ensureInit();
-    if (!g_initOk.load(std::memory_order_acquire)) {
+    if (!g_initOk.load(std::memory_order_acquire))
         return std::nullopt;
-    }
 
     std::optional<double> primary;  // Package id N / Tdie
     std::optional<double> fallback; // Tctl
 
-    int chipNr = 0;
-    while (const sensors_chip_name* chip = sensors_get_detected_chips(nullptr, &chipNr)) {
-        int featNr = 0;
-        while (const sensors_feature* feat = sensors_get_features(chip, &featNr)) {
-            if (feat->type != SENSORS_FEATURE_TEMP) {
-                continue;
-            }
-            const QByteArray label = featureLabel(chip, feat);
-            if (label.isEmpty()) {
-                continue;
-            }
-
+    forEachTempFeature(
+        SENSORS_BUS_TYPE_ANY, [&](const sensors_chip_name* chip, const sensors_feature* feat, const QByteArray& label) {
             if (labelStartsWith(label, "Package id ") || labelEquals(label, "Tdie")) {
-                if (auto v = readTempInput(chip, feat)) {
+                if (auto v = readTempInput(chip, feat))
                     primary = v;
-                }
             } else if (labelEquals(label, "Tctl")) {
-                if (auto v = readTempInput(chip, feat)) {
+                if (auto v = readTempInput(chip, feat))
                     fallback = v;
-                }
             }
-        }
-    }
+        });
 
     return primary.has_value() ? primary : fallback;
 }
 
 std::optional<double> gpuPciAverageTemp() {
     ensureInit();
-    if (!g_initOk.load(std::memory_order_acquire)) {
+    if (!g_initOk.load(std::memory_order_acquire))
         return std::nullopt;
-    }
 
-    double sumPrimary = 0.0;
-    int countPrimary = 0;
-    double sumFallback = 0.0;
-    int countFallback = 0;
+    TempAccum primary;
+    TempAccum fallback;
 
-    int chipNr = 0;
-    while (const sensors_chip_name* chip = sensors_get_detected_chips(nullptr, &chipNr)) {
-        if (chip->bus.type != SENSORS_BUS_TYPE_PCI) {
-            continue;
-        }
-
-        int featNr = 0;
-        while (const sensors_feature* feat = sensors_get_features(chip, &featNr)) {
-            if (feat->type != SENSORS_FEATURE_TEMP) {
-                continue;
-            }
-            const QByteArray label = featureLabel(chip, feat);
-            if (label.isEmpty()) {
-                continue;
-            }
-
-            const bool tempIndexed = labelStartsWith(label, "temp") && label.size() > 4 &&
-                                     std::isdigit(static_cast<unsigned char>(label[4]));
-            const bool isPrimary = tempIndexed || labelEquals(label, "GPU core") || labelEquals(label, "edge");
-            const bool isFallback = labelEquals(label, "junction") || labelEquals(label, "mem");
-
-            if (!isPrimary && !isFallback) {
-                continue;
-            }
+    forEachTempFeature(
+        SENSORS_BUS_TYPE_PCI, [&](const sensors_chip_name* chip, const sensors_feature* feat, const QByteArray& label) {
+            const auto kind = classifyGpuTempLabel(label);
+            if (kind == GpuTempKind::None)
+                return;
 
             const auto v = readTempInput(chip, feat);
-            if (!v) {
-                continue;
-            }
-            if (isPrimary) {
-                sumPrimary += *v;
-                ++countPrimary;
-            } else {
-                sumFallback += *v;
-                ++countFallback;
-            }
-        }
-    }
+            if (!v)
+                return;
 
-    if (countPrimary > 0) {
-        return sumPrimary / countPrimary;
-    }
-    if (countFallback > 0) {
-        return sumFallback / countFallback;
-    }
-    return std::nullopt;
+            if (kind == GpuTempKind::Primary)
+                primary.add(*v);
+            else
+                fallback.add(*v);
+        });
+
+    if (const auto avg = primary.average())
+        return avg;
+    return fallback.average();
 }
 
 } // namespace caelestia::services::sensorslib

--- a/plugin/src/Caelestia/Services/sensorslib.cpp
+++ b/plugin/src/Caelestia/Services/sensorslib.cpp
@@ -11,7 +11,11 @@
 #include <mutex>
 #include <utility>
 
+namespace {
+
 Q_LOGGING_CATEGORY(lcSensorsLib, "caelestia.services.sensorslib", QtInfoMsg)
+
+} // namespace
 
 namespace caelestia::services::sensorslib {
 

--- a/plugin/src/Caelestia/Services/service.cpp
+++ b/plugin/src/Caelestia/Services/service.cpp
@@ -1,7 +1,5 @@
 #include "service.hpp"
 
-#include <qpointer.h>
-
 namespace caelestia::services {
 
 Service::Service(QObject* parent)

--- a/plugin/src/Caelestia/Services/sessionmanager.cpp
+++ b/plugin/src/Caelestia/Services/sessionmanager.cpp
@@ -1,11 +1,11 @@
 #include "sessionmanager.hpp"
 
-#include <QtDBus/qdbusconnection.h>
-#include <QtDBus/qdbuserror.h>
-#include <QtDBus/qdbusmessage.h>
-#include <QtDBus/qdbuspendingcall.h>
-#include <QtDBus/qdbuspendingreply.h>
-#include <QtDBus/qdbusreply.h>
+#include <qdbusconnection.h>
+#include <qdbuserror.h>
+#include <qdbusmessage.h>
+#include <qdbuspendingcall.h>
+#include <qdbuspendingreply.h>
+#include <qdbusreply.h>
 #include <qloggingcategory.h>
 
 #include "core/toaster.hpp"

--- a/plugin/src/Caelestia/Services/sessionmanager.cpp
+++ b/plugin/src/Caelestia/Services/sessionmanager.cpp
@@ -127,7 +127,7 @@ void SessionManager::reboot() {
     callManager("Reboot");
 }
 
-std::optional<QDBusConnection> SessionManager::getSystemBus() const {
+std::optional<QDBusConnection> SessionManager::getSystemBus() {
     auto bus = QDBusConnection::systemBus();
     if (!bus.isConnected()) {
         qCWarning(lcSessionManager) << "Failed to connect to system bus:" << bus.lastError().message();
@@ -136,7 +136,7 @@ std::optional<QDBusConnection> SessionManager::getSystemBus() const {
     return bus;
 }
 
-bool SessionManager::queryHibernateAvailable() const {
+bool SessionManager::queryHibernateAvailable() {
     auto bus = getSystemBus();
     if (!bus)
         return false;

--- a/plugin/src/Caelestia/Services/sessionmanager.cpp
+++ b/plugin/src/Caelestia/Services/sessionmanager.cpp
@@ -20,10 +20,10 @@ namespace caelestia::services {
 
 namespace {
 
-constexpr const char* LOGIN_SERVICE = "org.freedesktop.login1";
-constexpr const char* LOGIN_PATH = "/org/freedesktop/login1";
-constexpr const char* LOGIN_IFACE = "org.freedesktop.login1.Manager";
-constexpr const char* SESSION_IFACE = "org.freedesktop.login1.Session";
+constexpr const char* k_loginService = "org.freedesktop.login1";
+constexpr const char* k_loginPath = "/org/freedesktop/login1";
+constexpr const char* k_loginIface = "org.freedesktop.login1.Manager";
+constexpr const char* k_sessionIface = "org.freedesktop.login1.Session";
 
 } // namespace
 
@@ -34,11 +34,11 @@ SessionManager::SessionManager(QObject* parent)
         return;
 
     bool ok = bus->connect(
-        LOGIN_SERVICE, LOGIN_PATH, LOGIN_IFACE, "PrepareForSleep", this, SLOT(handlePrepareForSleep(bool)));
+        k_loginService, k_loginPath, k_loginIface, "PrepareForSleep", this, SLOT(handlePrepareForSleep(bool)));
     if (!ok)
         qCWarning(lcSessionManager) << "Failed to connect to PrepareForSleep signal:" << bus->lastError().message();
 
-    auto sessionMsg = QDBusMessage::createMethodCall(LOGIN_SERVICE, LOGIN_PATH, LOGIN_IFACE, "GetSession");
+    auto sessionMsg = QDBusMessage::createMethodCall(k_loginService, k_loginPath, k_loginIface, "GetSession");
     sessionMsg.setArguments({ "auto" });
     const QDBusReply<QDBusObjectPath> sessionReply = bus->call(sessionMsg);
     if (!sessionReply.isValid()) {
@@ -47,11 +47,11 @@ SessionManager::SessionManager(QObject* parent)
     }
     m_sessionPath = sessionReply.value().path();
 
-    ok = bus->connect(LOGIN_SERVICE, m_sessionPath, SESSION_IFACE, "Lock", this, SLOT(handleLockRequested()));
+    ok = bus->connect(k_loginService, m_sessionPath, k_sessionIface, "Lock", this, SLOT(handleLockRequested()));
     if (!ok)
         qCWarning(lcSessionManager) << "Failed to connect to Lock signal:" << bus->lastError().message();
 
-    ok = bus->connect(LOGIN_SERVICE, m_sessionPath, SESSION_IFACE, "Unlock", this, SLOT(handleUnlockRequested()));
+    ok = bus->connect(k_loginService, m_sessionPath, k_sessionIface, "Unlock", this, SLOT(handleUnlockRequested()));
     if (!ok)
         qCWarning(lcSessionManager) << "Failed to connect to Unlock signal:" << bus->lastError().message();
 }
@@ -62,7 +62,7 @@ bool SessionManager::exec(const QStringList& command) {
     }
 
     using Qt::StringLiterals::operator""_s;
-    static const QHash<QString, void (SessionManager::*)()> cmds = {
+    static const QHash<QString, void (SessionManager::*)()> k_cmds = {
         { u"logout"_s, &SessionManager::logout },
         { u"suspend"_s, &SessionManager::suspend },
         { u"suspendthenhibernate"_s, &SessionManager::suspendThenHibernate },
@@ -81,7 +81,7 @@ bool SessionManager::exec(const QStringList& command) {
     // Normalise command
     cmd = cmd.remove("-").remove("_").toLower();
 
-    const auto methodPtr = cmds.value(cmd, nullptr);
+    const auto methodPtr = k_cmds.value(cmd, nullptr);
     if (methodPtr) {
         (this->*methodPtr)();
         return true;
@@ -141,7 +141,7 @@ bool SessionManager::queryHibernateAvailable() {
     if (!bus)
         return false;
 
-    auto hibernateMsg = QDBusMessage::createMethodCall(LOGIN_SERVICE, LOGIN_PATH, LOGIN_IFACE, "CanHibernate");
+    auto hibernateMsg = QDBusMessage::createMethodCall(k_loginService, k_loginPath, k_loginIface, "CanHibernate");
     const QDBusReply<QString> hibernateReply = bus->call(hibernateMsg);
     if (!hibernateReply.isValid()) {
         qCWarning(lcSessionManager) << "Failed to query hibernate support:" << hibernateReply.error().message();
@@ -158,7 +158,7 @@ void SessionManager::call(const QString& path, const QString& iface, const QStri
     if (!bus)
         return;
 
-    auto msg = QDBusMessage::createMethodCall(LOGIN_SERVICE, path, iface, method);
+    auto msg = QDBusMessage::createMethodCall(k_loginService, path, iface, method);
     msg.setArguments(args);
 
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
@@ -171,7 +171,7 @@ void SessionManager::call(const QString& path, const QString& iface, const QStri
 }
 
 void SessionManager::callManager(const QString& method) {
-    call(LOGIN_PATH, LOGIN_IFACE, method, { /* interactive = */ true });
+    call(k_loginPath, k_loginIface, method, { /* interactive = */ true });
 }
 
 void SessionManager::callSession(const QString& method) {
@@ -180,7 +180,7 @@ void SessionManager::callSession(const QString& method) {
         return;
     }
 
-    call(m_sessionPath, SESSION_IFACE, method);
+    call(m_sessionPath, k_sessionIface, method);
 }
 
 void SessionManager::handlePrepareForSleep(bool sleep) {

--- a/plugin/src/Caelestia/Services/sessionmanager.cpp
+++ b/plugin/src/Caelestia/Services/sessionmanager.cpp
@@ -10,7 +10,11 @@
 
 #include "core/toaster.hpp"
 
+namespace {
+
 Q_LOGGING_CATEGORY(lcSessionManager, "caelestia.services.sessionmanager", QtInfoMsg)
+
+} // namespace
 
 namespace caelestia::services {
 

--- a/plugin/src/Caelestia/Services/sessionmanager.cpp
+++ b/plugin/src/Caelestia/Services/sessionmanager.cpp
@@ -168,6 +168,7 @@ void SessionManager::call(const QString& path, const QString& iface, const QStri
             qCWarning(lcSessionManager) << "Call to" << method << "failed:" << reply.error().message();
         self->deleteLater();
     });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 void SessionManager::callManager(const QString& method) {

--- a/plugin/src/Caelestia/Services/sessionmanager.hpp
+++ b/plugin/src/Caelestia/Services/sessionmanager.hpp
@@ -40,8 +40,8 @@ private slots:
     void handleUnlockRequested();
 
 private:
-    [[nodiscard]] std::optional<QDBusConnection> getSystemBus() const;
-    [[nodiscard]] bool queryHibernateAvailable() const;
+    [[nodiscard]] static std::optional<QDBusConnection> getSystemBus();
+    [[nodiscard]] static bool queryHibernateAvailable();
     void call(const QString& path, const QString& iface, const QString& method, const QVariantList& args = {});
     void callManager(const QString& method);
     void callSession(const QString& method);

--- a/plugin/src/Caelestia/Services/storage.cpp
+++ b/plugin/src/Caelestia/Services/storage.cpp
@@ -154,7 +154,7 @@ DiskInfo* Storage::primaryDisk() const {
 }
 
 bool Storage::isPseudoFs(QByteArrayView fsType) {
-    static constexpr const char* kPseudo[] = {
+    static constexpr const char* k_pseudo[] = {
         "tmpfs",
         "devtmpfs",
         "proc",
@@ -180,7 +180,7 @@ bool Storage::isPseudoFs(QByteArrayView fsType) {
         "efivarfs",
         "selinuxfs",
     };
-    for (const char* p : kPseudo) {
+    for (const char* p : k_pseudo) {
         if (fsType == QByteArrayView(p)) {
             return true;
         }

--- a/plugin/src/Caelestia/Services/storage.cpp
+++ b/plugin/src/Caelestia/Services/storage.cpp
@@ -122,7 +122,7 @@ bool Storage::sameOrder(const QList<DiskInfo*>& a, const QList<DiskInfo*>& b) {
 }
 
 QQmlListProperty<DiskInfo> Storage::disksProp() {
-    return QQmlListProperty<DiskInfo>(this, nullptr, &Storage::disksCount, &Storage::disksAt);
+    return { this, nullptr, &Storage::disksCount, &Storage::disksAt };
 }
 
 qsizetype Storage::disksCount(QQmlListProperty<DiskInfo>* prop) {

--- a/plugin/src/Caelestia/Services/storage.cpp
+++ b/plugin/src/Caelestia/Services/storage.cpp
@@ -4,7 +4,6 @@
 #include <qfile.h>
 #include <qfileinfo.h>
 #include <qhash.h>
-#include <qloggingcategory.h>
 #include <qstorageinfo.h>
 
 #include <sys/stat.h>
@@ -12,8 +11,6 @@
 
 #include <algorithm>
 #include <cmath>
-
-Q_LOGGING_CATEGORY(lcStorage, "caelestia.services.storage", QtInfoMsg)
 
 namespace caelestia::services {
 

--- a/plugin/src/Caelestia/Services/storage.cpp
+++ b/plugin/src/Caelestia/Services/storage.cpp
@@ -16,12 +16,6 @@ namespace caelestia::services {
 
 namespace {
 
-struct Accum {
-    quint64 usedBytes = 0;
-    quint64 totalBytes = 0;
-    bool hasRoot = false;
-};
-
 [[nodiscard]] QString sysfsRealPath(uint major, uint minor) {
     const QString link = QStringLiteral("/sys/dev/block/%1:%2").arg(major).arg(minor);
     const QString resolved = QFileInfo(link).canonicalFilePath();
@@ -202,37 +196,21 @@ QStringList Storage::resolveToPhysicalDisks(const QString& devicePath) {
     return resolveByDevt(major(st.st_rdev), minor(st.st_rdev));
 }
 
-void Storage::tick() {
-    const qreal prevPercentage = percentage();
-    QHash<QString, Accum> byDisk;
-
-    // Multiple mounts can share a single backing filesystem (btrfs subvolumes,
-    // bind mounts, etc.) and each one reports identical bytesTotal/bytesAvailable.
-    // Dedupe by source device so the filesystem only contributes once per disk.
-    struct DeviceEntry {
-        quint64 totalBytes = 0;
-        quint64 usedBytes = 0;
-        bool hasRoot = false;
-        QByteArray device;
-        QByteArray fsType;
-    };
-
+QHash<QByteArray, Storage::DeviceEntry> Storage::collectDevices() {
     QHash<QByteArray, DeviceEntry> byDevice;
 
     const auto mountedVols = QStorageInfo::mountedVolumes();
     for (const QStorageInfo& v : mountedVols) {
-        if (!v.isReady() || !v.isValid() || v.bytesTotal() <= 0) {
+        if (!v.isReady() || !v.isValid() || v.bytesTotal() <= 0)
             continue;
-        }
-        if (isPseudoFs(QByteArrayView(v.fileSystemType()))) {
+        if (isPseudoFs(QByteArrayView(v.fileSystemType())))
             continue;
-        }
 
-        const QByteArray device = v.device();
+        const auto device = v.device();
         const auto totalBytes = static_cast<quint64>(v.bytesTotal());
         const auto availBytes = static_cast<quint64>(v.bytesAvailable());
-        const quint64 usedBytes = totalBytes > availBytes ? totalBytes - availBytes : 0;
-        const bool isRoot = v.rootPath() == QStringLiteral("/");
+        const auto usedBytes = totalBytes > availBytes ? totalBytes - availBytes : 0;
+        const auto isRoot = v.rootPath() == QStringLiteral("/");
 
         DeviceEntry& e = byDevice[device];
         e.device = device;
@@ -242,32 +220,41 @@ void Storage::tick() {
         e.hasRoot = e.hasRoot || isRoot;
     }
 
+    return byDevice;
+}
+
+QHash<QString, Storage::Accum> Storage::foldToDisks(const QHash<QByteArray, DeviceEntry>& byDevice) {
+    QHash<QString, Accum> byDisk;
+
     for (auto it = byDevice.constBegin(); it != byDevice.constEnd(); ++it) {
-        const DeviceEntry& e = it.value();
-        const QStringList disks = resolveToPhysicalDisks(QString::fromLocal8Bit(e.device));
+        const auto& e = it.value();
+        const auto disks = resolveToPhysicalDisks(QString::fromLocal8Bit(e.device));
+
         if (disks.isEmpty()) {
-            // ZFS has no /dev block device to resolve — its "device" is a
+            // ZFS has no /dev block device to resolve, its "device" is a
             // "pool/dataset" name (e.g. rpool/root), so resolveToPhysicalDisks
             // returns nothing and the whole pool would be dropped. Fall back to
             // keying by the pool name. Datasets in a pool share the pool's free
             // space, so keep a single representative entry per pool (preferring
             // the root dataset, else the largest) rather than summing them.
-            if (e.fsType == "zfs") {
-                const qsizetype slash = e.device.indexOf('/');
-                const QString pool = QString::fromLocal8Bit(slash > 0 ? e.device.left(slash) : e.device);
-                Accum& a = byDisk[pool];
-                if (!a.hasRoot && (e.hasRoot || e.totalBytes > a.totalBytes)) {
-                    a.usedBytes = e.usedBytes;
-                    a.totalBytes = e.totalBytes;
-                    a.hasRoot = e.hasRoot;
-                }
+            if (e.fsType != QByteArrayLiteral("zfs"))
+                continue;
+
+            const auto slash = e.device.indexOf('/');
+            const auto pool = QString::fromLocal8Bit(slash > 0 ? e.device.left(slash) : e.device);
+            Accum& a = byDisk[pool];
+            if (!a.hasRoot && (e.hasRoot || e.totalBytes > a.totalBytes)) {
+                a.usedBytes = e.usedBytes;
+                a.totalBytes = e.totalBytes;
+                a.hasRoot = e.hasRoot;
             }
             continue;
         }
-        for (const QString& d : disks) {
-            if (d.startsWith(QStringLiteral("zram"))) {
+
+        for (const auto& d : disks) {
+            if (d.startsWith(QStringLiteral("zram")))
                 continue;
-            }
+
             Accum& a = byDisk[d];
             a.usedBytes += e.usedBytes;
             a.totalBytes += e.totalBytes;
@@ -275,17 +262,23 @@ void Storage::tick() {
         }
     }
 
+    return byDisk;
+}
+
+void Storage::tick() {
+    const auto prevPercentage = percentage();
+    const auto byDisk = foldToDisks(collectDevices());
+
     QHash<QString, DiskInfo*> existing;
     existing.reserve(m_disks.size());
-    // NOLINTNEXTLINE(misc-const-correctness) hash value type is non const
-    for (DiskInfo* d : std::as_const(m_disks)) {
+
+    for (auto* const d : std::as_const(m_disks))
         existing.insert(d->mount(), d);
-    }
 
     QList<DiskInfo*> next;
     next.reserve(byDisk.size());
     for (auto it = byDisk.constBegin(); it != byDisk.constEnd(); ++it) {
-        if (DiskInfo* survivor = existing.take(it.key())) {
+        if (auto* const survivor = existing.take(it.key())) {
             survivor->update(it.value().usedBytes, it.value().totalBytes, it.value().hasRoot);
             next.append(survivor);
         } else {
@@ -294,37 +287,31 @@ void Storage::tick() {
     }
 
     std::ranges::sort(next, [](const DiskInfo* a, const DiskInfo* b) {
-        if (a->hasRoot() != b->hasRoot()) {
+        if (a->hasRoot() != b->hasRoot())
             return a->hasRoot();
-        }
         return a->mount() < b->mount();
     });
 
     bool manualCleared = false;
-    if (const DiskInfo* m = m_manualPrimaryDisk.data(); m && existing.contains(m->mount())) {
+    if (const auto* m = m_manualPrimaryDisk.data(); m && existing.contains(m->mount())) {
         m_manualPrimaryDisk.clear();
         manualCleared = true;
     }
-    for (DiskInfo* stale : std::as_const(existing)) {
+    for (auto* const stale : std::as_const(existing))
         stale->deleteLater();
-    }
 
-    const bool listChanged = !sameOrder(m_disks, next);
-    const DiskInfo* prevPrimary = primaryDisk();
+    const auto listChanged = !sameOrder(m_disks, next);
+    const auto* prevPrimary = primaryDisk();
     m_disks = next;
 
-    if (listChanged) {
+    if (listChanged)
         emit disksChanged();
-    }
-    if (std::abs(percentage() - prevPercentage) > 0.0001) {
+    if (std::abs(percentage() - prevPercentage) > 0.0001)
         emit percentageChanged();
-    }
-    if (manualCleared) {
+    if (manualCleared)
         emit manualPrimaryDiskChanged();
-    }
-    if (primaryDisk() != prevPrimary) {
+    if (primaryDisk() != prevPrimary)
         emit primaryDiskChanged();
-    }
 }
 
 } // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/storage.cpp
+++ b/plugin/src/Caelestia/Services/storage.cpp
@@ -293,7 +293,7 @@ void Storage::tick() {
         }
     }
 
-    std::sort(next.begin(), next.end(), [](const DiskInfo* a, const DiskInfo* b) {
+    std::ranges::sort(next, [](const DiskInfo* a, const DiskInfo* b) {
         if (a->hasRoot() != b->hasRoot()) {
             return a->hasRoot();
         }

--- a/plugin/src/Caelestia/Services/storage.cpp
+++ b/plugin/src/Caelestia/Services/storage.cpp
@@ -277,6 +277,7 @@ void Storage::tick() {
 
     QHash<QString, DiskInfo*> existing;
     existing.reserve(m_disks.size());
+    // NOLINTNEXTLINE(misc-const-correctness) hash value type is non const
     for (DiskInfo* d : std::as_const(m_disks)) {
         existing.insert(d->mount(), d);
     }
@@ -300,7 +301,7 @@ void Storage::tick() {
     });
 
     bool manualCleared = false;
-    if (DiskInfo* m = m_manualPrimaryDisk.data(); m && existing.contains(m->mount())) {
+    if (const DiskInfo* m = m_manualPrimaryDisk.data(); m && existing.contains(m->mount())) {
         m_manualPrimaryDisk.clear();
         manualCleared = true;
     }
@@ -309,7 +310,7 @@ void Storage::tick() {
     }
 
     const bool listChanged = !sameOrder(m_disks, next);
-    DiskInfo* prevPrimary = primaryDisk();
+    const DiskInfo* prevPrimary = primaryDisk();
     m_disks = next;
 
     if (listChanged) {

--- a/plugin/src/Caelestia/Services/storage.hpp
+++ b/plugin/src/Caelestia/Services/storage.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <qbytearray.h>
 #include <qbytearrayview.h>
+#include <qhash.h>
 #include <qpointer.h>
 #include <qqmlintegration.h>
 #include <qqmllist.h>
@@ -41,6 +43,25 @@ protected:
     void tick() override;
 
 private:
+    // One physical disk (or zfs pool), accumulated across the filesystems on it
+    struct Accum {
+        quint64 usedBytes = 0;
+        quint64 totalBytes = 0;
+        bool hasRoot = false;
+    };
+
+    // Mounts sharing a backing filesystem report identical usage, so they are deduped by source device first
+    struct DeviceEntry {
+        quint64 totalBytes = 0;
+        quint64 usedBytes = 0;
+        bool hasRoot = false;
+        QByteArray device;
+        QByteArray fsType;
+    };
+
+    [[nodiscard]] static QHash<QByteArray, DeviceEntry> collectDevices();
+    [[nodiscard]] static QHash<QString, Accum> foldToDisks(const QHash<QByteArray, DeviceEntry>& byDevice);
+
     [[nodiscard]] static QStringList resolveToPhysicalDisks(const QString& devicePath);
     [[nodiscard]] static bool isPseudoFs(QByteArrayView fsType);
     [[nodiscard]] static bool sameOrder(const QList<DiskInfo*>& a, const QList<DiskInfo*>& b);

--- a/plugin/src/Caelestia/Services/tickingservice.hpp
+++ b/plugin/src/Caelestia/Services/tickingservice.hpp
@@ -20,12 +20,12 @@ signals:
     void updateIntervalChanged();
 
 protected:
-    void start() final;
-    void stop() final;
-
     virtual void tick() = 0;
 
 private:
+    void start() final;
+    void stop() final;
+
     void applyInterval(int ms);
 
     QTimer* m_timer;

--- a/plugin/src/Caelestia/Services/usagefmt.cpp
+++ b/plugin/src/Caelestia/Services/usagefmt.cpp
@@ -14,7 +14,7 @@ bool finitePositive(qreal v) {
 
 namespace caelestia::services::usagefmt {
 
-FormatResult UsageFmt::formatKib(qreal kib, qreal total) const {
+FormatResult UsageFmt::formatKib(qreal kib, qreal total) {
     if (!finitePositive(kib) || !finitePositive(total)) {
         return { 0.0, 0.0, "KiB" };
     }

--- a/plugin/src/Caelestia/Services/usagefmt.cpp
+++ b/plugin/src/Caelestia/Services/usagefmt.cpp
@@ -14,20 +14,19 @@ bool finitePositive(qreal v) {
 
 namespace caelestia::services::usagefmt {
 
+using Qt::StringLiterals::operator""_s;
+
 FormatResult UsageFmt::formatKib(qreal kib, qreal total) {
-    if (!finitePositive(kib) || !finitePositive(total)) {
-        return { 0.0, 0.0, "KiB" };
-    }
-    if (total >= kGib) {
-        return { kib / kGib, total / kGib, "TiB" };
-    }
-    if (total >= kMib) {
-        return { kib / kMib, total / kMib, "GiB" };
-    }
-    if (total >= kKib) {
-        return { kib / kKib, total / kKib, "MiB" };
-    }
-    return { kib, total, "KiB" };
+    if (!finitePositive(kib) || !finitePositive(total))
+        return { .value = 0.0, .total = 0.0, .unit = u"KiB"_s };
+
+    if (total >= kGib)
+        return { .value = kib / kGib, .total = total / kGib, .unit = u"TiB"_s };
+    if (total >= kMib)
+        return { .value = kib / kMib, .total = total / kMib, .unit = u"GiB"_s };
+    if (total >= kKib)
+        return { .value = kib / kKib, .total = total / kKib, .unit = u"MiB"_s };
+    return { .value = kib, .total = total, .unit = u"KiB"_s };
 }
 
 } // namespace caelestia::services::usagefmt

--- a/plugin/src/Caelestia/Services/usagefmt.cpp
+++ b/plugin/src/Caelestia/Services/usagefmt.cpp
@@ -2,9 +2,9 @@
 
 namespace {
 
-constexpr qreal kKib = 1024.0;
-constexpr qreal kMib = kKib * 1024.0;
-constexpr qreal kGib = kMib * 1024.0;
+constexpr qreal k_kib = 1024.0;
+constexpr qreal k_mib = k_kib * 1024.0;
+constexpr qreal k_gib = k_mib * 1024.0;
 
 bool finitePositive(qreal v) {
     return std::isfinite(v) && v >= 0.0;
@@ -20,12 +20,12 @@ FormatResult UsageFmt::formatKib(qreal kib, qreal total) {
     if (!finitePositive(kib) || !finitePositive(total))
         return { .value = 0.0, .total = 0.0, .unit = u"KiB"_s };
 
-    if (total >= kGib)
-        return { .value = kib / kGib, .total = total / kGib, .unit = u"TiB"_s };
-    if (total >= kMib)
-        return { .value = kib / kMib, .total = total / kMib, .unit = u"GiB"_s };
-    if (total >= kKib)
-        return { .value = kib / kKib, .total = total / kKib, .unit = u"MiB"_s };
+    if (total >= k_gib)
+        return { .value = kib / k_gib, .total = total / k_gib, .unit = u"TiB"_s };
+    if (total >= k_mib)
+        return { .value = kib / k_mib, .total = total / k_mib, .unit = u"GiB"_s };
+    if (total >= k_kib)
+        return { .value = kib / k_kib, .total = total / k_kib, .unit = u"MiB"_s };
     return { .value = kib, .total = total, .unit = u"KiB"_s };
 }
 

--- a/plugin/src/Caelestia/Services/usagefmt.hpp
+++ b/plugin/src/Caelestia/Services/usagefmt.hpp
@@ -26,7 +26,7 @@ class UsageFmt : public QObject {
     QML_SINGLETON
 
 public:
-    Q_INVOKABLE [[nodiscard]] FormatResult formatKib(qreal kib, qreal total) const;
+    [[nodiscard]] Q_INVOKABLE FormatResult formatKib(qreal kib, qreal total) const;
 };
 
 } // namespace caelestia::services::usagefmt

--- a/plugin/src/Caelestia/Services/usagefmt.hpp
+++ b/plugin/src/Caelestia/Services/usagefmt.hpp
@@ -26,7 +26,7 @@ class UsageFmt : public QObject {
     QML_SINGLETON
 
 public:
-    [[nodiscard]] Q_INVOKABLE FormatResult formatKib(qreal kib, qreal total) const;
+    [[nodiscard]] Q_INVOKABLE static FormatResult formatKib(qreal kib, qreal total);
 };
 
 } // namespace caelestia::services::usagefmt

--- a/plugin/src/Caelestia/Settings/codecs.cpp
+++ b/plugin/src/Caelestia/Settings/codecs.cpp
@@ -44,10 +44,10 @@ ValueCodec::ValueCodec(const QMetaType& type)
 
 ValueCodec* ValueCodec::codecFor(const QMetaType& type) {
     // Cache for codecs, keyed by type id
-    static QHash<int, ValueCodec*> registry;
+    static QHash<int, ValueCodec*> s_registry;
 
     // Cached lookup
-    if (const auto it = registry.constFind(type.id()); it != registry.constEnd())
+    if (const auto it = s_registry.constFind(type.id()); it != s_registry.constEnd())
         return *it;
 
     ValueCodec* codec = nullptr;
@@ -80,7 +80,7 @@ ValueCodec* ValueCodec::codecFor(const QMetaType& type) {
 
     // Cache codec
     if (codec)
-        registry.insert(type.id(), codec);
+        s_registry.insert(type.id(), codec);
 
     return codec;
 }

--- a/plugin/src/Caelestia/Settings/codecs.cpp
+++ b/plugin/src/Caelestia/Settings/codecs.cpp
@@ -30,11 +30,11 @@ template <typename Container> ValueCodec* makeListCodec(const QMetaType& type) {
 using ListFactory = ValueCodec* (*)(const QMetaType&);
 
 const QHash<int, ListFactory>& listFactories() {
-    static const QHash<int, ListFactory> factories{
+    static const QHash<int, ListFactory> k_factories{
         { QMetaType::fromType<QStringList>().id(), &makeListCodec<QStringList> },
         { QMetaType::fromType<QList<qreal>>().id(), &makeListCodec<QList<qreal>> },
     };
-    return factories;
+    return k_factories;
 }
 
 } // namespace
@@ -111,13 +111,13 @@ DecodeResult IntCodec::decode(const QJsonValue& value) const {
     if (std::modf(num, &integral) != 0.0)
         return error(DiagnosticType::InvalidValue, QStringLiteral("Expected an integer, got the real %1").arg(num));
 
-    constexpr auto min = std::numeric_limits<int>::min();
-    constexpr auto max = std::numeric_limits<int>::max();
-    if (num < static_cast<double>(min) || num > static_cast<double>(max)) {
+    constexpr auto k_min = std::numeric_limits<int>::min();
+    constexpr auto k_max = std::numeric_limits<int>::max();
+    if (num < static_cast<double>(k_min) || num > static_cast<double>(k_max)) {
         const auto message = QStringLiteral("Integer %1 is out of range, expected between %2 and %3")
                                  .arg(num, 0, 'f', 0)
-                                 .arg(min)
-                                 .arg(max);
+                                 .arg(k_min)
+                                 .arg(k_max);
         return error(DiagnosticType::InvalidValue, message);
     }
 

--- a/plugin/src/Caelestia/Settings/codecs.cpp
+++ b/plugin/src/Caelestia/Settings/codecs.cpp
@@ -39,6 +39,9 @@ const QHash<int, ListFactory>& listFactories() {
 
 } // namespace
 
+ValueCodec::ValueCodec(const QMetaType& type)
+    : m_type(type) {}
+
 ValueCodec* ValueCodec::codecFor(const QMetaType& type) {
     // Cache for codecs, keyed by type id
     static QHash<int, ValueCodec*> registry;

--- a/plugin/src/Caelestia/Settings/codecs.cpp
+++ b/plugin/src/Caelestia/Settings/codecs.cpp
@@ -15,11 +15,11 @@ DecodeResult error(DiagnosticType::Type type, const QString& message) {
     Diagnostic error;
     error.type = type;
     error.message = message;
-    return { QVariant(), error };
+    return { .value = QVariant(), .error = error };
 }
 
 DecodeResult mismatch(const QString& expected, const QJsonValue& value) {
-    return { QVariant(), Diagnostic::mismatch(expected, value) };
+    return { .value = QVariant(), .error = Diagnostic::mismatch(expected, value) };
 }
 
 template <typename Container> ValueCodec* makeListCodec(const QMetaType& type) {
@@ -94,7 +94,7 @@ DecodeResult BoolCodec::decode(const QJsonValue& value) const {
     if (!value.isBool())
         return mismatch(QStringLiteral("a boolean"), value);
 
-    return { value.toBool(), std::nullopt };
+    return { .value = value.toBool(), .error = std::nullopt };
 }
 
 QJsonValue IntCodec::encode(const QVariant& value) const {
@@ -121,7 +121,7 @@ DecodeResult IntCodec::decode(const QJsonValue& value) const {
         return error(DiagnosticType::InvalidValue, message);
     }
 
-    return { static_cast<int>(num), std::nullopt };
+    return { .value = static_cast<int>(num), .error = std::nullopt };
 }
 
 QJsonValue RealCodec::encode(const QVariant& value) const {
@@ -132,7 +132,7 @@ DecodeResult RealCodec::decode(const QJsonValue& value) const {
     if (!value.isDouble())
         return mismatch(QStringLiteral("a number"), value);
 
-    return { QVariant::fromValue<qreal>(value.toDouble()), std::nullopt };
+    return { .value = QVariant::fromValue<qreal>(value.toDouble()), .error = std::nullopt };
 }
 
 QJsonValue StringCodec::encode(const QVariant& value) const {
@@ -143,7 +143,7 @@ DecodeResult StringCodec::decode(const QJsonValue& value) const {
     if (!value.isString())
         return mismatch(QStringLiteral("a string"), value);
 
-    return { value.toString(), std::nullopt };
+    return { .value = value.toString(), .error = std::nullopt };
 }
 
 QJsonValue VariantListCodec::encode(const QVariant& value) const {
@@ -154,7 +154,7 @@ DecodeResult VariantListCodec::decode(const QJsonValue& value) const {
     if (!value.isArray())
         return mismatch(QStringLiteral("an array"), value);
 
-    return { value.toArray().toVariantList(), std::nullopt };
+    return { .value = value.toArray().toVariantList(), .error = std::nullopt };
 }
 
 QJsonValue VariantMapCodec::encode(const QVariant& value) const {
@@ -165,7 +165,7 @@ DecodeResult VariantMapCodec::decode(const QJsonValue& value) const {
     if (!value.isObject())
         return mismatch(QStringLiteral("an object"), value);
 
-    return { value.toObject().toVariantMap(), std::nullopt };
+    return { .value = value.toObject().toVariantMap(), .error = std::nullopt };
 }
 
 EnumCodec::EnumCodec(const QMetaType& type, const QMetaEnum& metaEnum)
@@ -201,7 +201,7 @@ DecodeResult EnumCodec::decode(const QJsonValue& value) const {
                 QStringLiteral("Could not convert %1 to %2").arg(key, QString::fromUtf8(m_type.name())));
         }
 
-        return { decoded, std::nullopt };
+        return { .value = decoded, .error = std::nullopt };
     }
 
     QStringList options;

--- a/plugin/src/Caelestia/Settings/codecs.hpp
+++ b/plugin/src/Caelestia/Settings/codecs.hpp
@@ -15,9 +15,7 @@ struct DecodeResult {
 
 class ValueCodec {
 public:
-    explicit ValueCodec(const QMetaType& type)
-        : m_type(type) {}
-
+    explicit ValueCodec(const QMetaType& type);
     virtual ~ValueCodec() = default;
 
     // Returns the shared codec for a type, or nullptr if the type is unsupported

--- a/plugin/src/Caelestia/Settings/codecs.hpp
+++ b/plugin/src/Caelestia/Settings/codecs.hpp
@@ -61,7 +61,7 @@ private:
 };
 
 template <typename Container> class ListCodec : public ValueCodec {
-    using Value = typename Container::value_type;
+    using Value = Container::value_type;
 
 public:
     explicit ListCodec(const QMetaType& type, const ValueCodec* elementCodec);

--- a/plugin/src/Caelestia/Settings/common.cpp
+++ b/plugin/src/Caelestia/Settings/common.cpp
@@ -53,8 +53,11 @@ QString DiagnosticType::toString(Type t) {
 }
 
 Diagnostic Diagnostic::mismatch(const QString& expected, const QJsonValue& value, const QString& option) {
-    return { DiagnosticType::TypeMismatch, option,
-        QStringLiteral("Expected %1, got %2").arg(expected, jsonTypeName(value)) };
+    return {
+        .type = DiagnosticType::TypeMismatch,
+        .option = option,
+        .message = QStringLiteral("Expected %1, got %2").arg(expected, jsonTypeName(value)),
+    };
 }
 
 } // namespace caelestia::settings

--- a/plugin/src/Caelestia/Settings/common.cpp
+++ b/plugin/src/Caelestia/Settings/common.cpp
@@ -30,8 +30,8 @@ namespace caelestia::settings {
 Q_LOGGING_CATEGORY(lcSettings, "caelestia.settings", QtInfoMsg)
 
 WriteScope::WriteScope(Node* node, WriteOrigin origin)
-    : m_root(node->rootNode()) {
-    m_previous = m_root->m_writeOrigin;
+    : m_root(node->rootNode())
+    , m_previous(m_root->m_writeOrigin) {
     m_root->m_writeOrigin = origin;
 }
 

--- a/plugin/src/Caelestia/Settings/common.hpp
+++ b/plugin/src/Caelestia/Settings/common.hpp
@@ -46,7 +46,7 @@ public:
     };
     Q_ENUM(Type)
 
-    Q_INVOKABLE QString toString(Type t);
+    Q_INVOKABLE static QString toString(Type t);
 };
 
 struct Diagnostic {

--- a/plugin/src/Caelestia/Settings/common.hpp
+++ b/plugin/src/Caelestia/Settings/common.hpp
@@ -11,7 +11,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcSettings)
 
 class Node;
 
-enum class WriteOrigin {
+enum class WriteOrigin : quint8 {
     Init,      // On init
     File,      // From the JSON file
     FileReset, // When option not present in file
@@ -38,7 +38,7 @@ class DiagnosticType : public QObject {
     QML_SINGLETON
 
 public:
-    enum Type {
+    enum Type : quint8 {
         UnknownOption = 0,
         GlobalOption,
         TypeMismatch,

--- a/plugin/src/Caelestia/Settings/common.hpp
+++ b/plugin/src/Caelestia/Settings/common.hpp
@@ -26,8 +26,8 @@ public:
     ~WriteScope();
 
 private:
-    Node* m_root;
-    WriteOrigin m_previous;
+    Node* const m_root;
+    const WriteOrigin m_previous;
 
     Q_DISABLE_COPY_MOVE(WriteScope)
 };

--- a/plugin/src/Caelestia/Settings/listnode.cpp
+++ b/plugin/src/Caelestia/Settings/listnode.cpp
@@ -320,8 +320,8 @@ bool ListNode::recordWrite(const QString& key, bool changed) {
     return notify;
 }
 
-QString ListNode::keyOf(const Node* node) const {
-    return QString::number(m_elements.indexOf(const_cast<Node*>(node)));
+QString ListNode::keyOf(const Node* child) const {
+    return QString::number(m_elements.indexOf(const_cast<Node*>(child)));
 }
 
 Node* ListNode::elementAt(qsizetype index) const {

--- a/plugin/src/Caelestia/Settings/listnode.cpp
+++ b/plugin/src/Caelestia/Settings/listnode.cpp
@@ -189,8 +189,8 @@ QString ListNode::pathFor(const QString& key) const {
 
 const Schema& ListNode::schema() const {
     // Offset +1 so count is not registered (allow read only cause values is read only)
-    static const auto schema = Schema::build(&staticMetaObject, Node::staticMetaObject.propertyCount() + 1, true);
-    return schema;
+    static const auto k_schema = Schema::build(&staticMetaObject, Node::staticMetaObject.propertyCount() + 1, true);
+    return k_schema;
 }
 
 QVariant ListNode::value(const QString& key) const {

--- a/plugin/src/Caelestia/Settings/listnode.cpp
+++ b/plugin/src/Caelestia/Settings/listnode.cpp
@@ -198,7 +198,7 @@ QVariant ListNode::value(const QString& key) const {
         qCCritical(lcSettings,
             "Attempted to read %s on list node %s. List nodes only have a 'values' key, something is wrong.",
             qUtf8Printable(key), qUtf8Printable(path()));
-        return QVariant();
+        return {};
     }
 
     return QVariant::fromValue(m_elements);

--- a/plugin/src/Caelestia/Settings/listnode.cpp
+++ b/plugin/src/Caelestia/Settings/listnode.cpp
@@ -295,9 +295,9 @@ bool ListNode::syncJson(const QJsonValue& json, QList<Diagnostic>& diagnostics) 
         const auto p = path();
         qCWarning(lcSettings, "Global property definition %s found in overlay file, ignoring.", qUtf8Printable(p));
         diagnostics << Diagnostic{
-            DiagnosticType::GlobalOption,
-            p,
-            QStringLiteral("Global properties should not be defined in overlay files"),
+            .type = DiagnosticType::GlobalOption,
+            .option = p,
+            .message = QStringLiteral("Global properties should not be defined in overlay files"),
         };
         return false;
     }

--- a/plugin/src/Caelestia/Settings/node.cpp
+++ b/plugin/src/Caelestia/Settings/node.cpp
@@ -71,7 +71,7 @@ QVariant Node::value(const QString& key) const {
     if (!desc) {
         qCCritical(
             lcSettings, "Attempted to read an unknown key %s, something is wrong.", qUtf8Printable(pathFor(key)));
-        return QVariant();
+        return {};
     }
 
     return metaObject()->property(desc->metaIndex).read(this);
@@ -222,7 +222,7 @@ QString Node::keyOf(const Node* child) const {
             return desc.key;
     }
 
-    return QString();
+    return {};
 }
 
 void Node::onFallbackNotify(const QString& key) {

--- a/plugin/src/Caelestia/Settings/objectnode.cpp
+++ b/plugin/src/Caelestia/Settings/objectnode.cpp
@@ -111,9 +111,9 @@ QSet<QString> ObjectNode::loadFromJson(const QJsonObject& json, QList<Diagnostic
             const auto path = pathFor(key);
             qCWarning(lcSettings) << "Unknown option" << path;
             diagnostics << Diagnostic{
-                DiagnosticType::UnknownOption,
-                path,
-                QStringLiteral("Unknown option %1").arg(key),
+                .type = DiagnosticType::UnknownOption,
+                .option = path,
+                .message = QStringLiteral("Unknown option %1").arg(key),
             };
             SKIP;
         }
@@ -134,9 +134,9 @@ QSet<QString> ObjectNode::loadFromJson(const QJsonObject& json, QList<Diagnostic
             qCWarning(
                 lcSettings, "Global property definition %s found in overlay file, ignoring.", qUtf8Printable(path));
             diagnostics << Diagnostic{
-                DiagnosticType::GlobalOption,
-                path,
-                QStringLiteral("Global properties should not be defined in overlay files"),
+                .type = DiagnosticType::GlobalOption,
+                .option = path,
+                .message = QStringLiteral("Global properties should not be defined in overlay files"),
             };
             SKIP;
         }

--- a/plugin/src/Caelestia/Settings/objectnode.cpp
+++ b/plugin/src/Caelestia/Settings/objectnode.cpp
@@ -49,7 +49,7 @@ QJsonValue ObjectNode::toJson(bool sparse) const {
         if (sparse && !isOverride(desc.key))
             continue;
 
-        const auto codec = ValueCodec::codecFor(desc.type);
+        auto* const codec = ValueCodec::codecFor(desc.type);
         if (!codec) { // This should not happen
             qCCritical(lcSettings, "No codec found for type %s, not serialising %s", desc.type.name(),
                 qUtf8Printable(pathFor(desc.key)));
@@ -141,7 +141,7 @@ QSet<QString> ObjectNode::loadFromJson(const QJsonObject& json, QList<Diagnostic
             SKIP;
         }
 
-        const auto codec = ValueCodec::codecFor(desc->type);
+        auto* const codec = ValueCodec::codecFor(desc->type);
         if (!codec) { // This should not happen
             qCCritical(lcSettings, "No codec found for type %s, not loading %s", desc->type.name(),
                 qUtf8Printable(pathFor(key)));

--- a/plugin/src/Caelestia/Settings/objectnode.cpp
+++ b/plugin/src/Caelestia/Settings/objectnode.cpp
@@ -28,7 +28,7 @@ Descriptor ObjectNode::descriptorFor(const QString& key) const {
     const auto* desc = schema().get(key);
     if (!desc) {
         qCWarning(lcSettings) << "Attempted to get descriptor for unknown option" << pathFor(key);
-        return Descriptor();
+        return {};
     }
 
     return *desc;

--- a/plugin/src/Caelestia/Settings/objectnode.hpp
+++ b/plugin/src/Caelestia/Settings/objectnode.hpp
@@ -15,7 +15,7 @@ public:
     explicit ObjectNode(ObjectNode* fallback, QObject* parent = nullptr, bool globalOnly = false);
 
     Q_INVOKABLE void resetOption(const QString& key);
-    Q_INVOKABLE Descriptor descriptorFor(const QString& key) const;
+    [[nodiscard]] Q_INVOKABLE Descriptor descriptorFor(const QString& key) const;
 
     [[nodiscard]] QJsonValue toJson(bool sparse = true) const override;
     bool syncJson(const QJsonValue& json, QList<Diagnostic>& diagnostics) override;

--- a/plugin/src/Caelestia/Settings/schema.cpp
+++ b/plugin/src/Caelestia/Settings/schema.cpp
@@ -2,9 +2,13 @@
 
 #include "node.hpp"
 
-namespace caelestia::settings {
+namespace {
 
 Q_LOGGING_CATEGORY(lcSchema, "caelestia.settings.schema", QtInfoMsg)
+
+} // namespace
+
+namespace caelestia::settings {
 
 namespace {
 

--- a/plugin/src/Caelestia/Settings/schema.cpp
+++ b/plugin/src/Caelestia/Settings/schema.cpp
@@ -15,8 +15,8 @@ namespace {
 // Descriptor annotations are stored here by Schema::annotate, which is called in the CONFIG_XXX macros.
 // Schema::build then takes them from here.
 QHash<const QMetaObject*, QHash<QString, Annotation>>& annotationCache() {
-    static QHash<const QMetaObject*, QHash<QString, Annotation>> cache;
-    return cache;
+    static QHash<const QMetaObject*, QHash<QString, Annotation>> s_cache;
+    return s_cache;
 }
 
 bool isNodeType(const QMetaType& type) {

--- a/plugin/src/Caelestia/Settings/settingsfile.cpp
+++ b/plugin/src/Caelestia/Settings/settingsfile.cpp
@@ -9,6 +9,8 @@
 #include <qloggingcategory.h>
 #include <qsavefile.h>
 
+#include <utility>
+
 namespace {
 
 Q_LOGGING_CATEGORY(lcSettingsFile, "caelestia.settings.file", QtInfoMsg)
@@ -24,9 +26,9 @@ constexpr int kMaxLoadRetries = 3;
 
 } // namespace
 
-SettingsFile::SettingsFile(const QString& path, QObject* parent)
+SettingsFile::SettingsFile(QString path, QObject* parent)
     : QObject(parent)
-    , m_path(path)
+    , m_path(std::move(path))
     , m_watcher(new QFileSystemWatcher(this))
     , m_saveDebounce(new QTimer(this))
     , m_loadDebounce(new QTimer(this))

--- a/plugin/src/Caelestia/Settings/settingsfile.cpp
+++ b/plugin/src/Caelestia/Settings/settingsfile.cpp
@@ -163,6 +163,7 @@ void SettingsFile::save() {
     if (m_saveDebounce->isActive()) {
         // Queue save for debounce end
         QObject::connect(m_saveDebounce, &QTimer::timeout, this, &SettingsFile::save,
+            // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange) ConnectionType is OR-able by design
             static_cast<Qt::ConnectionType>(Qt::UniqueConnection | Qt::SingleShotConnection));
         return;
     }

--- a/plugin/src/Caelestia/Settings/settingsfile.cpp
+++ b/plugin/src/Caelestia/Settings/settingsfile.cpp
@@ -9,9 +9,13 @@
 #include <qloggingcategory.h>
 #include <qsavefile.h>
 
-namespace caelestia::settings {
+namespace {
 
 Q_LOGGING_CATEGORY(lcSettingsFile, "caelestia.settings.file", QtInfoMsg)
+
+} // namespace
+
+namespace caelestia::settings {
 
 namespace {
 

--- a/plugin/src/Caelestia/Settings/settingsfile.cpp
+++ b/plugin/src/Caelestia/Settings/settingsfile.cpp
@@ -22,7 +22,7 @@ namespace caelestia::settings {
 namespace {
 
 // Max retries for loads which fail due to malformed JSON, e.g. partial writes
-constexpr int kMaxLoadRetries = 3;
+constexpr int k_maxLoadRetries = 3;
 
 } // namespace
 
@@ -92,12 +92,12 @@ void SettingsFile::scheduleLoad() {
 }
 
 void SettingsFile::onLoadDebounced() {
-    const auto isFinalTry = m_loadRetries >= kMaxLoadRetries;
+    const auto isFinalTry = m_loadRetries >= k_maxLoadRetries;
 
     if (load(isFinalTry) == LoadResult::ParseError && !isFinalTry) {
         // Likely a partial write, retry after another debounce
         ++m_loadRetries;
-        qCDebug(lcSettingsFile, "Retrying load of %s (%d/%d)", qUtf8Printable(m_path), m_loadRetries, kMaxLoadRetries);
+        qCDebug(lcSettingsFile, "Retrying load of %s (%d/%d)", qUtf8Printable(m_path), m_loadRetries, k_maxLoadRetries);
         m_loadDebounce->start();
     }
 }

--- a/plugin/src/Caelestia/Settings/settingsfile.hpp
+++ b/plugin/src/Caelestia/Settings/settingsfile.hpp
@@ -23,7 +23,7 @@ public:
     [[nodiscard]] std::optional<QJsonValue> read() const;
     void write(const QJsonValue& json);
 
-    LoadResult load(bool emitErrors = true);
+    LoadResult load(bool reportErrors = true);
 
 signals:
     void changed(); // Data changed, not file watcher event

--- a/plugin/src/Caelestia/Settings/settingsfile.hpp
+++ b/plugin/src/Caelestia/Settings/settingsfile.hpp
@@ -11,7 +11,7 @@ class SettingsFile : public QObject {
     Q_OBJECT
 
 public:
-    enum class LoadResult {
+    enum class LoadResult : quint8 {
         Unchanged,
         Changed,
         ParseError,

--- a/plugin/src/Caelestia/Settings/settingsfile.hpp
+++ b/plugin/src/Caelestia/Settings/settingsfile.hpp
@@ -18,7 +18,7 @@ public:
         Error
     };
 
-    explicit SettingsFile(const QString& path, QObject* parent = nullptr);
+    explicit SettingsFile(QString path, QObject* parent = nullptr);
 
     [[nodiscard]] std::optional<QJsonValue> read() const;
     void write(const QJsonValue& json);

--- a/plugin/src/Caelestia/circularbuffer.cpp
+++ b/plugin/src/Caelestia/circularbuffer.cpp
@@ -12,8 +12,7 @@ int CircularBuffer::capacity() const {
 }
 
 void CircularBuffer::setCapacity(int capacity) {
-    if (capacity < 0)
-        capacity = 0;
+    capacity = std::max(capacity, 0);
     if (m_capacity == capacity)
         return;
 

--- a/plugin/src/Caelestia/circularbuffer.hpp
+++ b/plugin/src/Caelestia/circularbuffer.hpp
@@ -27,7 +27,7 @@ public:
 
     Q_INVOKABLE void push(qreal value);
     Q_INVOKABLE void clear();
-    Q_INVOKABLE [[nodiscard]] qreal at(int index) const;
+    [[nodiscard]] Q_INVOKABLE qreal at(int index) const;
 
 signals:
     void capacityChanged();

--- a/plugin/src/Caelestia/cutils.cpp
+++ b/plugin/src/Caelestia/cutils.cpp
@@ -13,7 +13,11 @@
 
 #include "util/metaenum.hpp"
 
+namespace {
+
 Q_LOGGING_CATEGORY(lcCUtils, "caelestia.cutils", QtInfoMsg)
+
+} // namespace
 
 namespace caelestia {
 

--- a/plugin/src/Caelestia/cutils.cpp
+++ b/plugin/src/Caelestia/cutils.cpp
@@ -2,7 +2,6 @@
 
 #include <qdir.h>
 #include <qfileinfo.h>
-#include <qfuturewatcher.h>
 #include <qloggingcategory.h>
 #include <qmetaobject.h>
 #include <qqmlengine.h>
@@ -43,53 +42,31 @@ void CUtils::saveItem(
     }
 
     auto scaledRect = rect;
-    const qreal scale = target->window()->devicePixelRatio();
+    const auto scale = target->window()->devicePixelRatio();
     if (rect.isValid() && !qFuzzyCompare(scale + 1.0, 2.0)) {
         scaledRect =
             QRectF(rect.left() * scale, rect.top() * scale, rect.width() * scale, rect.height() * scale).toRect();
     }
 
-    const QSharedPointer<const QQuickItemGrabResult> grabResult = target->grabToImage();
+    const auto grabResult = target->grabToImage();
 
-    QObject::connect(grabResult.data(), &QQuickItemGrabResult::ready, this,
-        [grabResult, scaledRect, path, onSaved, onFailed, this]() {
-            const auto future = QtConcurrent::run([=]() {
-                QImage image = grabResult->image();
-
-                if (scaledRect.isValid()) {
+    QObject::connect(
+        grabResult.data(), &QQuickItemGrabResult::ready, this, [grabResult, scaledRect, path, onSaved, onFailed, this] {
+            QtConcurrent::run([grabResult, scaledRect, file = path.toLocalFile()] {
+                auto image = grabResult->image();
+                if (scaledRect.isValid())
                     image = image.copy(scaledRect);
-                }
 
-                const QString file = path.toLocalFile();
-                const QString parent = QFileInfo(file).absolutePath();
+                const auto parent = QFileInfo(file).absolutePath();
                 return QDir().mkpath(parent) && image.save(file);
-            });
-
-            auto* watcher = new QFutureWatcher<bool>(this);
-            auto* engine = qmlEngine(this);
-
-            QObject::connect(watcher, &QFutureWatcher<bool>::finished, this, [=]() {
-                if (watcher->result()) {
-                    if (onSaved.isCallable()) {
-                        QJSValueList args = { QJSValue(path.toLocalFile()) };
-                        if (engine) {
-                            args << engine->toScriptValue(QVariant::fromValue(path));
-                        }
-                        onSaved.call(args);
-                    }
-                } else {
+            }).then(this, [path, onSaved, onFailed](bool ok) {
+                const auto* cb = ok ? &onSaved : &onFailed;
+                if (!ok)
                     qCWarning(lcCUtils) << "saveItem: failed to save" << path;
-                    if (onFailed.isCallable()) {
-                        if (engine) {
-                            onFailed.call({ engine->toScriptValue(QVariant::fromValue(path)) });
-                        } else {
-                            onFailed.call();
-                        }
-                    }
-                }
-                watcher->deleteLater();
+
+                if (cb->isCallable())
+                    cb->call({ path.toLocalFile() });
             });
-            watcher->setFuture(future);
         });
 }
 

--- a/plugin/src/Caelestia/cutils.cpp
+++ b/plugin/src/Caelestia/cutils.cpp
@@ -140,7 +140,7 @@ bool CUtils::deleteFile(const QUrl& path) {
 QString CUtils::toLocalFile(const QUrl& url) {
     if (!url.isLocalFile()) {
         qCWarning(lcCUtils) << "toLocalFile: given url is not a local file" << url;
-        return QString();
+        return {};
     }
 
     return url.toLocalFile();

--- a/plugin/src/Caelestia/cutils.cpp
+++ b/plugin/src/Caelestia/cutils.cpp
@@ -29,19 +29,20 @@ void CUtils::saveItem(QQuickItem* target, const QUrl& path, const QRect& rect) {
     this->saveItem(target, path, rect, QJSValue(), QJSValue());
 }
 
-void CUtils::saveItem(QQuickItem* target, const QUrl& path, QJSValue onSaved) {
+void CUtils::saveItem(QQuickItem* target, const QUrl& path, const QJSValue& onSaved) {
     this->saveItem(target, path, QRect(), onSaved, QJSValue());
 }
 
-void CUtils::saveItem(QQuickItem* target, const QUrl& path, QJSValue onSaved, QJSValue onFailed) {
+void CUtils::saveItem(QQuickItem* target, const QUrl& path, const QJSValue& onSaved, const QJSValue& onFailed) {
     this->saveItem(target, path, QRect(), onSaved, onFailed);
 }
 
-void CUtils::saveItem(QQuickItem* target, const QUrl& path, const QRect& rect, QJSValue onSaved) {
+void CUtils::saveItem(QQuickItem* target, const QUrl& path, const QRect& rect, const QJSValue& onSaved) {
     this->saveItem(target, path, rect, onSaved, QJSValue());
 }
 
-void CUtils::saveItem(QQuickItem* target, const QUrl& path, const QRect& rect, QJSValue onSaved, QJSValue onFailed) {
+void CUtils::saveItem(
+    QQuickItem* target, const QUrl& path, const QRect& rect, const QJSValue& onSaved, const QJSValue& onFailed) {
     if (!target) {
         qCWarning(lcCUtils) << "saveItem: a target is required";
         return;

--- a/plugin/src/Caelestia/cutils.cpp
+++ b/plugin/src/Caelestia/cutils.cpp
@@ -21,24 +21,8 @@ Q_LOGGING_CATEGORY(lcCUtils, "caelestia.cutils", QtInfoMsg)
 
 namespace caelestia {
 
-void CUtils::saveItem(QQuickItem* target, const QUrl& path) {
-    this->saveItem(target, path, QRect(), QJSValue(), QJSValue());
-}
-
-void CUtils::saveItem(QQuickItem* target, const QUrl& path, const QRect& rect) {
-    this->saveItem(target, path, rect, QJSValue(), QJSValue());
-}
-
-void CUtils::saveItem(QQuickItem* target, const QUrl& path, const QJSValue& onSaved) {
-    this->saveItem(target, path, QRect(), onSaved, QJSValue());
-}
-
 void CUtils::saveItem(QQuickItem* target, const QUrl& path, const QJSValue& onSaved, const QJSValue& onFailed) {
     this->saveItem(target, path, QRect(), onSaved, onFailed);
-}
-
-void CUtils::saveItem(QQuickItem* target, const QUrl& path, const QRect& rect, const QJSValue& onSaved) {
-    this->saveItem(target, path, rect, onSaved, QJSValue());
 }
 
 void CUtils::saveItem(

--- a/plugin/src/Caelestia/cutils.cpp
+++ b/plugin/src/Caelestia/cutils.cpp
@@ -1,15 +1,15 @@
 #include "cutils.hpp"
 
-#include <QtConcurrent/qtconcurrentrun.h>
-#include <QtQuick/qquickitemgrabresult.h>
-#include <QtQuick/qquickwindow.h>
 #include <qdir.h>
 #include <qfileinfo.h>
 #include <qfuturewatcher.h>
 #include <qloggingcategory.h>
 #include <qmetaobject.h>
 #include <qqmlengine.h>
+#include <qquickitemgrabresult.h>
+#include <qquickwindow.h>
 #include <qregularexpression.h>
+#include <qtconcurrentrun.h>
 
 #include "util/metaenum.hpp"
 

--- a/plugin/src/Caelestia/cutils.cpp
+++ b/plugin/src/Caelestia/cutils.cpp
@@ -252,11 +252,11 @@ QList<QQuickItem*> CUtils::findChildrenMatching(QQuickItem* root, const QString&
 #define CAELESTIA_VERSION ""
 #endif
 
-QString CUtils::version() const {
+QString CUtils::version() {
     return QStringLiteral(CAELESTIA_VERSION);
 }
 
-QString CUtils::qtVersion() const {
+QString CUtils::qtVersion() {
     return QStringLiteral(QT_VERSION_STR);
 }
 

--- a/plugin/src/Caelestia/cutils.hpp
+++ b/plugin/src/Caelestia/cutils.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <QtQuick/qquickitem.h>
 #include <qlist.h>
 #include <qobject.h>
 #include <qqmlintegration.h>
+#include <qquickitem.h>
 #include <qvariant.h>
 
 namespace caelestia {

--- a/plugin/src/Caelestia/cutils.hpp
+++ b/plugin/src/Caelestia/cutils.hpp
@@ -17,14 +17,10 @@ class CUtils : public QObject {
     Q_PROPERTY(QString qtVersion READ qtVersion CONSTANT)
 
 public:
-    // clang-format off
-    Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path);
-    Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path, const QRect& rect);
-    Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path, const QJSValue& onSaved);
-    Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path, const QJSValue& onSaved, const QJSValue& onFailed);
-    Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path, const QRect& rect, const QJSValue& onSaved);
-    Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path, const QRect& rect, const QJSValue& onSaved, const QJSValue& onFailed);
-    // clang-format on
+    Q_INVOKABLE void saveItem(
+        QQuickItem* target, const QUrl& path, const QJSValue& onSaved = {}, const QJSValue& onFailed = {});
+    Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path, const QRect& rect, const QJSValue& onSaved = {},
+        const QJSValue& onFailed = {});
 
     Q_INVOKABLE static bool copyFile(const QUrl& source, const QUrl& target, bool overwrite = true);
     Q_INVOKABLE static bool deleteFile(const QUrl& path);
@@ -32,8 +28,7 @@ public:
 
     Q_INVOKABLE static qreal clamp(qreal value, qreal min, qreal max);
 
-    Q_INVOKABLE static QString enumToString(
-        QObject* target, const QString& property, const QVariant& value = QVariant());
+    Q_INVOKABLE static QString enumToString(QObject* target, const QString& property, const QVariant& value = {});
 
     Q_INVOKABLE static QQuickItem* findChild(QQuickItem* root, const QString& name);
     Q_INVOKABLE static QList<QQuickItem*> findChildren(QQuickItem* root, const QString& name);

--- a/plugin/src/Caelestia/cutils.hpp
+++ b/plugin/src/Caelestia/cutils.hpp
@@ -39,8 +39,8 @@ public:
     Q_INVOKABLE static QList<QQuickItem*> findChildren(QQuickItem* root, const QString& name);
     Q_INVOKABLE static QList<QQuickItem*> findChildrenMatching(QQuickItem* root, const QString& pattern);
 
-    [[nodiscard]] QString version() const;
-    [[nodiscard]] QString qtVersion() const;
+    [[nodiscard]] static QString version();
+    [[nodiscard]] static QString qtVersion();
 };
 
 } // namespace caelestia

--- a/plugin/src/Caelestia/cutils.hpp
+++ b/plugin/src/Caelestia/cutils.hpp
@@ -20,10 +20,10 @@ public:
     // clang-format off
     Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path);
     Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path, const QRect& rect);
-    Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path, QJSValue onSaved);
-    Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path, QJSValue onSaved, QJSValue onFailed);
-    Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path, const QRect& rect, QJSValue onSaved);
-    Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path, const QRect& rect, QJSValue onSaved, QJSValue onFailed);
+    Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path, const QJSValue& onSaved);
+    Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path, const QJSValue& onSaved, const QJSValue& onFailed);
+    Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path, const QRect& rect, const QJSValue& onSaved);
+    Q_INVOKABLE void saveItem(QQuickItem* target, const QUrl& path, const QRect& rect, const QJSValue& onSaved, const QJSValue& onFailed);
     // clang-format on
 
     Q_INVOKABLE static bool copyFile(const QUrl& source, const QUrl& target, bool overwrite = true);

--- a/plugin/src/Caelestia/qalculator.cpp
+++ b/plugin/src/Caelestia/qalculator.cpp
@@ -23,7 +23,7 @@ Qalculator::Qalculator(QObject* parent)
 
 QString Qalculator::eval(const QString& expr, bool printExpr) const {
     if (expr.isEmpty()) {
-        return QString();
+        return {};
     }
 
     QMutexLocker locker(&s_calculatorMutex);

--- a/plugin/src/Caelestia/qalculator.cpp
+++ b/plugin/src/Caelestia/qalculator.cpp
@@ -13,7 +13,7 @@ Qalculator::Qalculator(QObject* parent)
     if (!CALCULATOR) {
         // Calculator constructor sets the global `calculator` pointer (CALCULATOR macro),
         // but we need to assign it to a var so compiler doesn't flag it as a leak
-        static const auto* const instance = new Calculator();
+        static const auto* instance = new Calculator();
         Q_UNUSED(instance)
         CALCULATOR->loadExchangeRates();
         CALCULATOR->loadGlobalDefinitions();
@@ -26,13 +26,13 @@ QString Qalculator::eval(const QString& expr, bool printExpr) const {
         return {};
     }
 
-    QMutexLocker locker(&s_calculatorMutex);
+    const QMutexLocker locker(&s_calculatorMutex);
 
-    EvaluationOptions eo;
-    PrintOptions po;
+    const EvaluationOptions eo;
+    const PrintOptions po;
 
     std::string parsed;
-    std::string result = CALCULATOR->calculateAndPrint(
+    const std::string result = CALCULATOR->calculateAndPrint(
         CALCULATOR->unlocalizeExpression(expr.toStdString(), eo.parse_options), 100, eo, po, &parsed);
 
     std::string error;
@@ -83,13 +83,13 @@ void Qalculator::evalAsync(const QString& expr) {
     }
 
     QtConcurrent::run([expr]() -> QPair<QString, QString> {
-        QMutexLocker locker(&s_calculatorMutex);
+        const QMutexLocker locker(&s_calculatorMutex);
 
-        EvaluationOptions eo;
-        PrintOptions po;
+        const EvaluationOptions eo;
+        const PrintOptions po;
 
         std::string parsed;
-        std::string result = CALCULATOR->calculateAndPrint(
+        const std::string result = CALCULATOR->calculateAndPrint(
             CALCULATOR->unlocalizeExpression(expr.toStdString(), eo.parse_options), 100, eo, po, &parsed);
 
         std::string error;

--- a/plugin/src/Caelestia/qalculator.cpp
+++ b/plugin/src/Caelestia/qalculator.cpp
@@ -26,6 +26,41 @@ QString Qalculator::eval(const QString& expr, bool printExpr) {
         return {};
     }
 
+    const auto [formatted, raw] = evaluate(expr);
+    return printExpr ? formatted : raw;
+}
+
+void Qalculator::evalAsync(const QString& expr) {
+    const auto gen = ++m_generation;
+
+    if (expr.isEmpty()) {
+        clearResult();
+        setBusy(false);
+        return;
+    }
+
+    setBusy(true);
+
+    QtConcurrent::run([expr] {
+        return evaluate(expr);
+    }).then(this, [this, gen](const QPair<QString, QString>& result) {
+        applyResult(gen, result);
+    });
+}
+
+QString Qalculator::result() const {
+    return m_result;
+}
+
+QString Qalculator::rawResult() const {
+    return m_rawResult;
+}
+
+bool Qalculator::busy() const {
+    return m_busy;
+}
+
+QPair<QString, QString> Qalculator::evaluate(const QString& expr) {
     const QMutexLocker locker(&s_calculatorMutex);
 
     const EvaluationOptions eo;
@@ -47,103 +82,50 @@ QString Qalculator::eval(const QString& expr, bool printExpr) {
         }
         CALCULATOR->nextMessage();
     }
+
     if (!error.empty()) {
-        return QString::fromStdString(error);
+        const auto errorStr = QString::fromStdString(error);
+        return { errorStr, errorStr };
     }
 
-    if (printExpr) {
-        return QString("%1 = %2").arg(parsed).arg(result);
-    }
-
-    return QString::fromStdString(result);
+    return { QStringLiteral("%1 = %2").arg(parsed).arg(result), QString::fromStdString(result) };
 }
 
-void Qalculator::evalAsync(const QString& expr) {
-    const quint64 gen = ++m_generation;
-
-    if (expr.isEmpty()) {
-        if (!m_result.isEmpty()) {
-            m_result.clear();
-            emit resultChanged();
-        }
-        if (!m_rawResult.isEmpty()) {
-            m_rawResult.clear();
-            emit rawResultChanged();
-        }
-        if (m_busy) {
-            m_busy = false;
-            emit busyChanged();
-        }
+void Qalculator::applyResult(quint64 gen, const QPair<QString, QString>& result) {
+    if (gen != m_generation)
         return;
+
+    const auto& [formatted, raw] = result;
+
+    if (m_result != formatted) {
+        m_result = formatted;
+        emit resultChanged();
+    }
+    if (m_rawResult != raw) {
+        m_rawResult = raw;
+        emit rawResultChanged();
     }
 
-    if (!m_busy) {
-        m_busy = true;
-        emit busyChanged();
+    setBusy(false);
+}
+
+void Qalculator::clearResult() {
+    if (!m_result.isEmpty()) {
+        m_result.clear();
+        emit resultChanged();
     }
-
-    QtConcurrent::run([expr]() -> QPair<QString, QString> {
-        const QMutexLocker locker(&s_calculatorMutex);
-
-        const EvaluationOptions eo;
-        const PrintOptions po;
-
-        std::string parsed;
-        const std::string result = CALCULATOR->calculateAndPrint(
-            CALCULATOR->unlocalizeExpression(expr.toStdString(), eo.parse_options), 100, eo, po, &parsed);
-
-        std::string error;
-        while (CALCULATOR->message()) {
-            if (!CALCULATOR->message()->message().empty()) {
-                if (CALCULATOR->message()->type() == MESSAGE_ERROR) {
-                    error += "error: ";
-                } else if (CALCULATOR->message()->type() == MESSAGE_WARNING) {
-                    error += "warning: ";
-                }
-                error += CALCULATOR->message()->message();
-            }
-            CALCULATOR->nextMessage();
-        }
-
-        if (!error.empty()) {
-            const QString errorStr = QString::fromStdString(error);
-            return { errorStr, errorStr };
-        }
-
-        const QString rawStr = QString::fromStdString(result);
-        return { QString("%1 = %2").arg(parsed).arg(result), rawStr };
-    }).then(this, [this, gen](const QPair<QString, QString>& result) {
-        if (gen != m_generation) {
-            return;
-        }
-
-        const auto& [formatted, raw] = result;
-
-        if (m_result != formatted) {
-            m_result = formatted;
-            emit resultChanged();
-        }
-        if (m_rawResult != raw) {
-            m_rawResult = raw;
-            emit rawResultChanged();
-        }
-        if (m_busy) {
-            m_busy = false;
-            emit busyChanged();
-        }
-    });
+    if (!m_rawResult.isEmpty()) {
+        m_rawResult.clear();
+        emit rawResultChanged();
+    }
 }
 
-QString Qalculator::result() const {
-    return m_result;
-}
+void Qalculator::setBusy(bool busy) {
+    if (m_busy == busy)
+        return;
 
-QString Qalculator::rawResult() const {
-    return m_rawResult;
-}
-
-bool Qalculator::busy() const {
-    return m_busy;
+    m_busy = busy;
+    emit busyChanged();
 }
 
 } // namespace caelestia

--- a/plugin/src/Caelestia/qalculator.cpp
+++ b/plugin/src/Caelestia/qalculator.cpp
@@ -21,7 +21,7 @@ Qalculator::Qalculator(QObject* parent)
     }
 }
 
-QString Qalculator::eval(const QString& expr, bool printExpr) const {
+QString Qalculator::eval(const QString& expr, bool printExpr) {
     if (expr.isEmpty()) {
         return {};
     }

--- a/plugin/src/Caelestia/qalculator.cpp
+++ b/plugin/src/Caelestia/qalculator.cpp
@@ -112,7 +112,7 @@ void Qalculator::evalAsync(const QString& expr) {
 
         const QString rawStr = QString::fromStdString(result);
         return { QString("%1 = %2").arg(parsed).arg(result), rawStr };
-    }).then(this, [this, gen](QPair<QString, QString> result) {
+    }).then(this, [this, gen](const QPair<QString, QString>& result) {
         if (gen != m_generation) {
             return;
         }

--- a/plugin/src/Caelestia/qalculator.cpp
+++ b/plugin/src/Caelestia/qalculator.cpp
@@ -13,8 +13,8 @@ Qalculator::Qalculator(QObject* parent)
     if (!CALCULATOR) {
         // Calculator constructor sets the global `calculator` pointer (CALCULATOR macro),
         // but we need to assign it to a var so compiler doesn't flag it as a leak
-        static const auto* instance = new Calculator();
-        Q_UNUSED(instance)
+        static const auto* s_instance = new Calculator();
+        Q_UNUSED(s_instance)
         CALCULATOR->loadExchangeRates();
         CALCULATOR->loadGlobalDefinitions();
         CALCULATOR->loadLocalDefinitions();

--- a/plugin/src/Caelestia/qalculator.hpp
+++ b/plugin/src/Caelestia/qalculator.hpp
@@ -2,6 +2,7 @@
 
 #include <qmutex.h>
 #include <qobject.h>
+#include <qpair.h>
 #include <qqmlintegration.h>
 
 namespace caelestia {
@@ -32,6 +33,12 @@ signals:
 
 private:
     static QMutex s_calculatorMutex;
+
+    [[nodiscard]] static QPair<QString, QString> evaluate(const QString& expr);
+
+    void applyResult(quint64 gen, const QPair<QString, QString>& result);
+    void clearResult();
+    void setBusy(bool busy);
 
     QString m_result;
     QString m_rawResult;

--- a/plugin/src/Caelestia/qalculator.hpp
+++ b/plugin/src/Caelestia/qalculator.hpp
@@ -18,7 +18,7 @@ class Qalculator : public QObject {
 public:
     explicit Qalculator(QObject* parent = nullptr);
 
-    Q_INVOKABLE QString eval(const QString& expr, bool printExpr = true) const;
+    [[nodiscard]] Q_INVOKABLE QString eval(const QString& expr, bool printExpr = true) const;
     Q_INVOKABLE void evalAsync(const QString& expr);
 
     [[nodiscard]] QString result() const;

--- a/plugin/src/Caelestia/qalculator.hpp
+++ b/plugin/src/Caelestia/qalculator.hpp
@@ -18,7 +18,7 @@ class Qalculator : public QObject {
 public:
     explicit Qalculator(QObject* parent = nullptr);
 
-    [[nodiscard]] Q_INVOKABLE QString eval(const QString& expr, bool printExpr = true) const;
+    [[nodiscard]] Q_INVOKABLE static QString eval(const QString& expr, bool printExpr = true);
     Q_INVOKABLE void evalAsync(const QString& expr);
 
     [[nodiscard]] QString result() const;

--- a/plugin/src/Caelestia/requests.cpp
+++ b/plugin/src/Caelestia/requests.cpp
@@ -54,7 +54,7 @@ void Requests::get(const QUrl& url, QJSValue onSuccess, QJSValue onError, QJSVal
         }
     }
 
-    auto reply = m_manager->get(request);
+    auto* reply = m_manager->get(request);
 
     QObject::connect(reply, &QNetworkReply::finished, this, [this, reply, onSuccess, onError]() {
         const QString body = QString::fromUtf8(reply->readAll());

--- a/plugin/src/Caelestia/requests.cpp
+++ b/plugin/src/Caelestia/requests.cpp
@@ -37,7 +37,7 @@ Requests::Requests(QObject* parent)
     : QObject(parent)
     , m_manager(new QNetworkAccessManager(this)) {}
 
-void Requests::get(const QUrl& url, QJSValue onSuccess, QJSValue onError, QJSValue headers) const {
+void Requests::get(const QUrl& url, const QJSValue& onSuccess, const QJSValue& onError, const QJSValue& headers) const {
     if (!onSuccess.isCallable()) {
         qCWarning(lcRequests) << "get: onSuccess is not callable";
         return;

--- a/plugin/src/Caelestia/requests.cpp
+++ b/plugin/src/Caelestia/requests.cpp
@@ -10,7 +10,11 @@
 #include <qqmlengine.h>
 #include <qvariant.h>
 
+namespace {
+
 Q_LOGGING_CATEGORY(lcRequests, "caelestia.requests", QtInfoMsg)
+
+} // namespace
 
 namespace caelestia {
 

--- a/plugin/src/Caelestia/requests.hpp
+++ b/plugin/src/Caelestia/requests.hpp
@@ -14,8 +14,8 @@ class Requests : public QObject {
 public:
     explicit Requests(QObject* parent = nullptr);
 
-    Q_INVOKABLE void get(
-        const QUrl& url, QJSValue onSuccess, QJSValue onError = QJSValue(), QJSValue headers = QJSValue()) const;
+    Q_INVOKABLE void get(const QUrl& url, const QJSValue& onSuccess, const QJSValue& onError = QJSValue(),
+        const QJSValue& headers = QJSValue()) const;
     Q_INVOKABLE void resetCookies() const;
 
 private:

--- a/plugin/src/Caelestia/requests.hpp
+++ b/plugin/src/Caelestia/requests.hpp
@@ -15,7 +15,7 @@ public:
     explicit Requests(QObject* parent = nullptr);
 
     Q_INVOKABLE void get(
-        const QUrl& url, QJSValue callback, QJSValue onError = QJSValue(), QJSValue headers = QJSValue()) const;
+        const QUrl& url, QJSValue onSuccess, QJSValue onError = QJSValue(), QJSValue headers = QJSValue()) const;
     Q_INVOKABLE void resetCookies() const;
 
 private:

--- a/plugin/src/Caelestia/toaster.cpp
+++ b/plugin/src/Caelestia/toaster.cpp
@@ -3,14 +3,16 @@
 #include <qlogging.h>
 #include <qtimer.h>
 
+#include <utility>
+
 namespace caelestia {
 
-Toast::Toast(const QString& title, const QString& message, const QString& icon, Type type, int timeout, QObject* parent)
+Toast::Toast(QString title, QString message, QString icon, Type type, int timeout, QObject* parent)
     : QObject(parent)
     , m_closed(false)
-    , m_title(title)
-    , m_message(message)
-    , m_icon(icon)
+    , m_title(std::move(title))
+    , m_message(std::move(message))
+    , m_icon(std::move(icon))
     , m_type(type)
     , m_timeout(timeout) {
     QTimer::singleShot(timeout, this, &Toast::close);

--- a/plugin/src/Caelestia/toaster.cpp
+++ b/plugin/src/Caelestia/toaster.cpp
@@ -101,7 +101,10 @@ Toaster* Toaster::instance() {
     return &instance;
 }
 
-Toaster* Toaster::create(QQmlEngine*, QJSEngine*) {
+Toaster* Toaster::create(QQmlEngine* engine, QJSEngine* jsEngine) {
+    Q_UNUSED(engine);
+    Q_UNUSED(jsEngine);
+
     QQmlEngine::setObjectOwnership(instance(), QQmlEngine::CppOwnership);
     return instance();
 }

--- a/plugin/src/Caelestia/toaster.cpp
+++ b/plugin/src/Caelestia/toaster.cpp
@@ -1,6 +1,5 @@
 #include "toaster.hpp"
 
-#include <qlogging.h>
 #include <qtimer.h>
 
 #include <utility>

--- a/plugin/src/Caelestia/toaster.cpp
+++ b/plugin/src/Caelestia/toaster.cpp
@@ -99,8 +99,8 @@ Toaster::Toaster(QObject* parent)
     : QObject(parent) {}
 
 Toaster* Toaster::instance() {
-    static Toaster instance;
-    return &instance;
+    static Toaster s_instance;
+    return &s_instance;
 }
 
 Toaster* Toaster::create(QQmlEngine* engine, QJSEngine* jsEngine) {

--- a/plugin/src/Caelestia/toaster.cpp
+++ b/plugin/src/Caelestia/toaster.cpp
@@ -110,7 +110,7 @@ Toaster* Toaster::create(QQmlEngine* engine, QJSEngine* jsEngine) {
 }
 
 QQmlListProperty<Toast> Toaster::toasts() {
-    return QQmlListProperty<Toast>(this, &m_toasts);
+    return { this, &m_toasts };
 }
 
 void Toaster::toast(const QString& title, const QString& message, const QString& icon, Toast::Type type, int timeout) {

--- a/plugin/src/Caelestia/toaster.hpp
+++ b/plugin/src/Caelestia/toaster.hpp
@@ -22,7 +22,7 @@ class Toast : public QObject {
     Q_PROPERTY(Type type READ type CONSTANT)
 
 public:
-    enum class Type {
+    enum class Type : quint8 {
         Info = 0,
         Success,
         Warning,

--- a/plugin/src/Caelestia/toaster.hpp
+++ b/plugin/src/Caelestia/toaster.hpp
@@ -30,8 +30,7 @@ public:
     };
     Q_ENUM(Type)
 
-    explicit Toast(const QString& title, const QString& message, const QString& icon, Type type, int timeout,
-        QObject* parent = nullptr);
+    explicit Toast(QString title, QString message, QString icon, Type type, int timeout, QObject* parent = nullptr);
 
     [[nodiscard]] bool closed() const;
     [[nodiscard]] QString title() const;

--- a/plugin/src/Caelestia/toaster.hpp
+++ b/plugin/src/Caelestia/toaster.hpp
@@ -68,7 +68,7 @@ class Toaster : public QObject {
 
 public:
     static Toaster* instance();
-    static Toaster* create(QQmlEngine*, QJSEngine*);
+    static Toaster* create(QQmlEngine* engine, QJSEngine* jsEngine);
 
     [[nodiscard]] QQmlListProperty<Toast> toasts();
 


### PR DESCRIPTION
Add `clang-tidy` to lint C++ and fix all issues caught by it. Also adds a new job to the lint workflow for linting C++ and renames the existing job.

People maintaining forks are gonna have fun with this one :joy: 