### PR TITLE
refactor: disable ascii/bytearray casts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,12 @@ set(INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/caelestia" CACHE STRING "Library ins
 set(INSTALL_QMLDIR "${CMAKE_INSTALL_LIBDIR}/qt6/qml" CACHE STRING "QML install dir")
 set(INSTALL_QSCONFDIR "${CMAKE_INSTALL_SYSCONFDIR}/xdg/quickshell/caelestia" CACHE STRING "Quickshell config install dir")
 
+add_compile_definitions(
+    QT_NO_CAST_FROM_ASCII
+    QT_NO_CAST_TO_ASCII
+    QT_NO_CAST_FROM_BYTEARRAY
+)
+
 add_compile_options(
     -Wall -Wextra -Wpedantic -Wshadow -Wconversion
     -Wold-style-cast -Wnull-dereference -Wdouble-promotion

--- a/plugin/src/Caelestia/Images/imagecacher.cpp
+++ b/plugin/src/Caelestia/Images/imagecacher.cpp
@@ -34,7 +34,7 @@ QString sha256sum(const QString& path) {
     hash.addData(&file);
     file.close();
 
-    return hash.result().toHex();
+    return QString::fromLatin1(hash.result().toHex());
 }
 
 QString fillSuffix(ImageCacher::FillMode fillMode) {

--- a/plugin/src/Caelestia/Models/appdb.cpp
+++ b/plugin/src/Caelestia/Models/appdb.cpp
@@ -199,7 +199,7 @@ void AppDb::setFavouriteApps(const QStringList& favApps) {
 }
 
 QString AppDb::regexifyString(const QString& original) {
-    if (original.startsWith('^') && original.endsWith('$'))
+    if (original.startsWith(u'^') && original.endsWith(u'$'))
         return original;
 
     const QString escaped = QRegularExpression::escape(original);

--- a/plugin/src/Caelestia/Services/gpu.cpp
+++ b/plugin/src/Caelestia/Services/gpu.cpp
@@ -42,12 +42,12 @@ QString cleanName(QString s) {
 }
 
 QString parseNvidiaName(const QByteArray& out) {
-    const QString first = QString::fromUtf8(out).split('\n').value(0).trimmed();
+    const QString first = QString::fromUtf8(out).split(u'\n').value(0).trimmed();
     return first.isEmpty() ? QString() : cleanName(first);
 }
 
 QString parseGlxinfoName(const QByteArray& out) {
-    const QStringList lines = QString::fromUtf8(out).split('\n');
+    const QStringList lines = QString::fromUtf8(out).split(u'\n');
     for (const QString& line : lines) {
         const qsizetype idx = line.indexOf(u"Device:"_s);
         if (idx < 0) {
@@ -55,7 +55,7 @@ QString parseGlxinfoName(const QByteArray& out) {
         }
 
         QString rest = line.mid(idx + 7);
-        const qsizetype paren = rest.indexOf('(');
+        const qsizetype paren = rest.indexOf(u'(');
         if (paren >= 0) {
             rest = rest.left(paren);
         }
@@ -72,7 +72,7 @@ QString parseGlxinfoName(const QByteArray& out) {
 QString parseLspciName(const QByteArray& out) {
     static const QRegularExpression k_lineRe(u"vga|3d controller|display"_s, QRegularExpression::CaseInsensitiveOption);
 
-    const QStringList lines = QString::fromUtf8(out).split('\n');
+    const QStringList lines = QString::fromUtf8(out).split(u'\n');
     QString match;
     for (const QString& line : lines) {
         if (k_lineRe.match(line).hasMatch()) {

--- a/plugin/src/Caelestia/Services/hyprextras.cpp
+++ b/plugin/src/Caelestia/Services/hyprextras.cpp
@@ -185,9 +185,9 @@ void HyprExtras::readEvent() {
 }
 
 void HyprExtras::handleEvent(const QString& event) {
-    if (event == "configreloaded") {
+    if (event == u"configreloaded"_s) {
         refreshOptions();
-    } else if (event == "activelayout") {
+    } else if (event == u"activelayout"_s) {
         refreshDevices();
     }
 }

--- a/plugin/src/Caelestia/Services/sessionmanager.cpp
+++ b/plugin/src/Caelestia/Services/sessionmanager.cpp
@@ -22,10 +22,10 @@ using Qt::StringLiterals::operator""_s;
 
 namespace {
 
-constexpr const char* k_loginService = "org.freedesktop.login1";
-constexpr const char* k_loginPath = "/org/freedesktop/login1";
-constexpr const char* k_loginIface = "org.freedesktop.login1.Manager";
-constexpr const char* k_sessionIface = "org.freedesktop.login1.Session";
+const QString k_loginService = u"org.freedesktop.login1"_s;
+const QString k_loginPath = u"/org/freedesktop/login1"_s;
+const QString k_loginIface = u"org.freedesktop.login1.Manager"_s;
+const QString k_sessionIface = u"org.freedesktop.login1.Session"_s;
 
 } // namespace
 
@@ -80,7 +80,7 @@ bool SessionManager::exec(const QStringList& command) {
         cmd = u"logout"_s; // Manual alias `loginctl terminate-user ''` -> logout
 
     // Normalise command
-    cmd = cmd.remove('-').remove('_').toLower();
+    cmd = cmd.remove(u'-').remove(u'_').toLower();
 
     const auto methodPtr = k_cmds.value(cmd, nullptr);
     if (methodPtr) {

--- a/plugin/src/Caelestia/Settings/schema.cpp
+++ b/plugin/src/Caelestia/Settings/schema.cpp
@@ -35,7 +35,7 @@ QVariant DefaultSpec::resolve(const Node* self) const {
 }
 
 QString Descriptor::typeString() const {
-    return type.name();
+    return QString::fromUtf8(type.name());
 }
 
 QVariant Descriptor::defaultValue(const Node* self) const {


### PR DESCRIPTION
Add `QT_NO_CAST_TO_ASCII`, `QT_NO_CAST_FROM_ASCII` and `QT_NO_CAST_FROM_BYTEARRAY` compile defs. To enforce using `QStringLiteral`/`u""_s` (`u""_s` is preferred unless impossible to use, e.g. with macro values). Also to enforce `u''`, and catch other potential bugs due to encoding mismatches.