### PR TITLE
refactor: use scoped enums

### DIFF
--- a/plugin/src/Caelestia/Components/circularindicatormanager.hpp
+++ b/plugin/src/Caelestia/Components/circularindicatormanager.hpp
@@ -24,7 +24,7 @@ class CircularIndicatorManager : public QObject {
 public:
     explicit CircularIndicatorManager(QObject* parent = nullptr);
 
-    enum IndeterminateAnimationType : quint8 {
+    enum class IndeterminateAnimationType : quint8 {
         Advance = 0,
         Retreat
     };

--- a/plugin/src/Caelestia/Components/wavyline.cpp
+++ b/plugin/src/Caelestia/Components/wavyline.cpp
@@ -14,7 +14,7 @@ WavyLine::WavyLine(QQuickItem* parent)
     , m_fullLength(0)
     , m_color(Qt::white)
     , m_waveProgress(0)
-    , m_pathType(Linear)
+    , m_pathType(PathType::Linear)
     , m_startAngle(0)
     , m_fullAngle(360)
     , m_radius(-1)
@@ -174,7 +174,7 @@ void WavyLine::paint(QPainter* painter) {
     painter->setRenderHint(QPainter::Antialiasing);
     painter->setPen(QPen(m_color, m_lineWidth, Qt::SolidLine, Qt::RoundCap));
 
-    if (m_pathType == Arc) {
+    if (m_pathType == PathType::Arc) {
         paintArc(painter);
     } else {
         paintLinear(painter);

--- a/plugin/src/Caelestia/Components/wavyline.hpp
+++ b/plugin/src/Caelestia/Components/wavyline.hpp
@@ -24,7 +24,7 @@ class WavyLine : public QQuickPaintedItem {
     Q_PROPERTY(qreal value READ value WRITE setValue NOTIFY valueChanged FINAL)
 
 public:
-    enum PathType : quint8 {
+    enum class PathType : quint8 {
         Linear,
         Arc
     };

--- a/plugin/src/Caelestia/Models/filesystemmodel.cpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.cpp
@@ -83,7 +83,7 @@ FileSystemModel::FileSystemModel(QObject* parent)
     , m_recursive(false)
     , m_watchChanges(true)
     , m_showHidden(false)
-    , m_filter(NoFilter) {
+    , m_filter(Filter::NoFilter) {
     connect(&m_watcher, &QFileSystemWatcher::directoryChanged, this, &FileSystemModel::watchDirIfRecursive);
     connect(&m_watcher, &QFileSystemWatcher::directoryChanged, this, &FileSystemModel::updateEntriesForDir);
 }

--- a/plugin/src/Caelestia/Models/filesystemmodel.hpp
+++ b/plugin/src/Caelestia/Models/filesystemmodel.hpp
@@ -76,7 +76,7 @@ class FileSystemModel : public QAbstractListModel {
     Q_PROPERTY(QQmlListProperty<caelestia::models::FileSystemEntry> entries READ entries NOTIFY entriesChanged)
 
 public:
-    enum Filter : quint8 {
+    enum class Filter : quint8 {
         NoFilter,
         Images,
         Files,


### PR DESCRIPTION
enum class instead of enum
Except the ones in enums.hpp and DiagnosticType::Type from the settings module, those are specifically unscoped as their wrappers exist solely to contain them