### PR TITLE
feat(toasts): add quick actions support

### DIFF
--- a/modules/drawers/ContentWindow.qml
+++ b/modules/drawers/ContentWindow.qml
@@ -99,6 +99,13 @@ StyledWindow {
             width: panels.osdWrapper.width * (1 - panels.osd.offsetScale) + root.borderThickness
             height: panels.osd.height
         }
+
+        Region {
+            x: panels.toasts.x + bar.implicitWidth
+            y: panels.toasts.y + root.borderThickness
+            width: panels.toasts.width
+            height: panels.toasts.height
+        }
     }
 
     Regions {

--- a/modules/drawers/Regions.qml
+++ b/modules/drawers/Regions.qml
@@ -72,6 +72,10 @@ Region {
         width: panel.width * (1 - root.panels.popoutsWrapper.offsetScale)
     }
 
+    R {
+        panel: root.panels.toasts
+    }
+
     component R: Region {
         required property Item panel
 

--- a/modules/utilities/toasts/ToastItem.qml
+++ b/modules/utilities/toasts/ToastItem.qml
@@ -1,15 +1,19 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Layouts
 import Caelestia
 import Caelestia.Config
 import qs.components
 import qs.components.effects
+import qs.components.controls
 import qs.services
 
 StyledRect {
     id: root
 
     required property Toast modelData
+    readonly property bool hasActions: root.modelData.actions.length > 0
 
     anchors.left: parent.left
     anchors.right: parent.right
@@ -125,6 +129,33 @@ StyledRect {
                 }
                 opacity: 0.8
                 elide: Text.ElideRight
+            }
+
+            RowLayout {
+                id: actionsRow
+
+                Layout.fillWidth: true
+                Layout.topMargin: Tokens.spacing.medium
+                visible: root.hasActions
+                spacing: Tokens.spacing.small
+
+                Repeater {
+                    model: root.modelData.actions
+
+                    IconTextButton {
+                        required property var modelData
+
+                        isRound: true
+                        text: modelData.text
+                        icon: modelData.icon
+                        iconLabel.visible: modelData.icon.length > 0
+
+                        onClicked: {
+                            modelData.invoke();
+                            root.modelData.close();
+                        }
+                    }
+                }
             }
         }
     }

--- a/plugin/src/Caelestia/toaster.cpp
+++ b/plugin/src/Caelestia/toaster.cpp
@@ -1,5 +1,8 @@
 #include "toaster.hpp"
 
+#include <qjsvalue.h>
+#include <qlist.h>
+#include <qlogging.h>
 #include <qtimer.h>
 
 #include <utility>
@@ -8,14 +11,35 @@ namespace caelestia {
 
 using Qt::StringLiterals::operator""_s;
 
-Toast::Toast(QString title, QString message, QString icon, Type type, int timeout, QObject* parent)
+ToastAction::ToastAction(QString text, QString icon, Callback cb)
+    : m_text(std::move(text))
+    , m_icon(std::move(icon))
+    , m_callback(std::move(cb)) {}
+
+ToastAction::ToastAction(QString text, QString icon, QJSValue jsCb)
+    : m_text(std::move(text))
+    , m_icon(std::move(icon))
+    , m_jsCallback(std::move(jsCb)) {}
+
+void ToastAction::invoke() const {
+    if (m_callback) {
+        m_callback();
+    }
+    if (m_jsCallback.isCallable()) {
+        m_jsCallback.call();
+    }
+}
+
+Toast::Toast(
+    QString title, QString message, QString icon, Type type, int timeout, QList<ToastAction> actions, QObject* parent)
     : QObject(parent)
     , m_closed(false)
     , m_title(std::move(title))
     , m_message(std::move(message))
     , m_icon(std::move(icon))
     , m_type(type)
-    , m_timeout(timeout) {
+    , m_timeout(timeout)
+    , m_actions(std::move(actions)) {
     QTimer::singleShot(timeout, this, &Toast::close);
 
     if (m_icon.isEmpty()) {
@@ -74,6 +98,10 @@ Toast::Type Toast::type() const {
     return m_type;
 }
 
+const QList<ToastAction>& Toast::actions() const {
+    return m_actions;
+}
+
 void Toast::close() {
     if (!m_closed) {
         m_closed = true;
@@ -116,8 +144,37 @@ QQmlListProperty<Toast> Toaster::toasts() {
     return { this, &m_toasts };
 }
 
-void Toaster::toast(const QString& title, const QString& message, const QString& icon, Toast::Type type, int timeout) {
-    auto* const toast = new Toast(title, message, icon, type, timeout, this);
+// qml entry point
+void Toaster::toast(const QString& title, const QString& message, const QString& icon, const QJSValue& actionsOrType,
+    int timeout, const QJSValue& actions) {
+    Toast::Type type = Toast::Type::Info;
+    QJSValue rawActions = actions;
+
+    if (actionsOrType.isArray()) {
+        rawActions = actionsOrType;
+    } else if (actionsOrType.isNumber()) {
+        type = static_cast<Toast::Type>(actionsOrType.toInt());
+    }
+
+    QList<ToastAction> actionList;
+    if (rawActions.isArray()) {
+        const quint32 length = rawActions.property(u"length"_s).toUInt();
+        actionList.reserve(length);
+
+        for (quint32 i = 0; i < length; ++i) {
+            const QJSValue item = rawActions.property(i);
+            actionList.append(ToastAction(item.property(u"text"_s).toString(), item.property(u"icon"_s).toString(),
+                item.property(u"callback"_s)));
+        }
+    }
+
+    toast(title, message, icon, type, timeout, std::move(actionList));
+}
+
+// c++ entry point
+void Toaster::toast(const QString& title, const QString& message, const QString& icon, Toast::Type type, int timeout,
+    QList<ToastAction> actions) {
+    auto* const toast = new Toast(title, message, icon, type, timeout, std::move(actions), this);
     QObject::connect(toast, &Toast::finishedClose, this, [toast, this]() {
         if (m_toasts.removeOne(toast)) {
             emit toastsChanged();

--- a/plugin/src/Caelestia/toaster.hpp
+++ b/plugin/src/Caelestia/toaster.hpp
@@ -1,13 +1,46 @@
 #pragma once
 
 #include <qjsengine.h>
+#include <qjsvalue.h>
+#include <qlist.h>
 #include <qobject.h>
 #include <qqmlengine.h>
 #include <qqmlintegration.h>
 #include <qqmllist.h>
 #include <qset.h>
+#include <qstring.h>
+#include <qtmetamacros.h>
+
+#include <functional>
 
 namespace caelestia {
+
+struct ToastAction {
+    Q_GADGET
+    QML_ANONYMOUS
+
+    Q_PROPERTY(QString text MEMBER m_text CONSTANT)
+    Q_PROPERTY(QString icon MEMBER m_icon CONSTANT)
+
+public:
+    using Callback = std::function<void()>;
+
+    // 1. Default constructor required by Qt for Q_GADGET
+    ToastAction() = default;
+
+    // 2. C++ constructor (automatically leaves jsCallback empty)
+    ToastAction(QString text, QString icon, Callback cb);
+
+    // 3. QML constructor (automatically leaves callback empty)
+    ToastAction(QString text, QString icon, QJSValue jsCb);
+
+    QString m_text;
+    QString m_icon;
+    Callback m_callback;
+    QJSValue m_jsCallback;
+
+    Q_INVOKABLE void invoke() const;
+};
 
 class Toast : public QObject {
     Q_OBJECT
@@ -20,6 +53,7 @@ class Toast : public QObject {
     Q_PROPERTY(QString icon READ icon CONSTANT)
     Q_PROPERTY(int timeout READ timeout CONSTANT)
     Q_PROPERTY(Type type READ type CONSTANT)
+    Q_PROPERTY(QList<caelestia::ToastAction> actions READ actions CONSTANT)
 
 public:
     enum class Type : quint8 {
@@ -30,7 +64,8 @@ public:
     };
     Q_ENUM(Type)
 
-    explicit Toast(QString title, QString message, QString icon, Type type, int timeout, QObject* parent = nullptr);
+    explicit Toast(QString title, QString message, QString icon, Type type, int timeout,
+        QList<ToastAction> actions = {}, QObject* parent = nullptr);
 
     [[nodiscard]] bool closed() const;
     [[nodiscard]] QString title() const;
@@ -38,6 +73,7 @@ public:
     [[nodiscard]] QString icon() const;
     [[nodiscard]] int timeout() const;
     [[nodiscard]] Type type() const;
+    [[nodiscard]] const QList<ToastAction>& actions() const;
 
     Q_INVOKABLE void close();
     Q_INVOKABLE void lock(QObject* sender);
@@ -56,9 +92,11 @@ private:
     QString m_icon;
     Type m_type;
     int m_timeout;
+    QList<ToastAction> m_actions;
 };
 
 class Toaster : public QObject {
+
     Q_OBJECT
     QML_ELEMENT
     QML_SINGLETON
@@ -71,8 +109,13 @@ public:
 
     [[nodiscard]] QQmlListProperty<Toast> toasts();
 
+    // qml entry point
     Q_INVOKABLE void toast(const QString& title, const QString& message, const QString& icon = QString(),
-        caelestia::Toast::Type type = Toast::Type::Info, int timeout = 5000);
+        const QJSValue& actionsOrType = QJSValue(), int timeout = 5000, const QJSValue& actions = QJSValue());
+
+    // C++ entry point (with typed Toast::Type, timeout, and actions)
+    void toast(const QString& title, const QString& message, const QString& icon, caelestia::Toast::Type type,
+        int timeout = 5000, QList<caelestia::ToastAction> actions = {});
 
 signals:
     void toastsChanged();
@@ -84,3 +127,5 @@ private:
 };
 
 } // namespace caelestia
+
+Q_DECLARE_METATYPE(caelestia::ToastAction)

--- a/services/Audio.qml
+++ b/services/Audio.qml
@@ -11,8 +11,12 @@ import Caelestia.Services
 Singleton {
     id: root
 
+    property PwNode previousSink: null
+    property PwNode previousSource: null
     property string previousSinkName: ""
     property string previousSourceName: ""
+    property bool sinkInitialized: false
+    property bool sourceInitialized: false
 
     property list<PwNode> sinks: []
     property list<PwNode> sources: []
@@ -126,41 +130,86 @@ Singleton {
         root.streams = newStreams;
     }
 
-    onSinkChanged: {
+    function checkSinkChange(): void {
         if (!sink?.ready)
             return;
 
-        const newSinkName = sink.description || sink.name || qsTr("Unknown Device");
+        const newSinkName = sink.description || sink.name;
+        if (!newSinkName)
+            return;
 
-        if (previousSinkName && previousSinkName !== newSinkName && GlobalConfig.utilities.toasts.audioOutputChanged)
-            Toaster.toast(qsTr("Audio output changed"), qsTr("Now using: %1").arg(newSinkName), "volume_up");
+        if (!sinkInitialized) {
+            sinkInitialized = true;
+            previousSink = sink;
+            previousSinkName = newSinkName;
+            return;
+        }
 
+        if (previousSinkName && previousSinkName !== newSinkName && GlobalConfig.utilities.toasts.audioOutputChanged) {
+            const oldSink = previousSink;
+            const actions = oldSink ? [
+                {
+                    text: qsTr("Undo"),
+                    icon: "undo",
+                    callback: () => root.setAudioSink(oldSink)
+                }
+            ] : [];
+
+            Toaster.toast(qsTr("Audio output changed"), qsTr("Now using: %1").arg(newSinkName), "volume_up", actions);
+        }
+
+        previousSink = sink;
         previousSinkName = newSinkName;
     }
 
-    onSourceChanged: {
+    function checkSourceChange(): void {
         if (!source?.ready)
             return;
 
-        const newSourceName = source.description || source.name || qsTr("Unknown Device");
+        const newSourceName = source.description || source.name;
+        if (!newSourceName)
+            return;
 
-        if (previousSourceName && previousSourceName !== newSourceName && GlobalConfig.utilities.toasts.audioInputChanged)
-            Toaster.toast(qsTr("Audio input changed"), qsTr("Now using: %1").arg(newSourceName), "mic");
+        if (!sourceInitialized) {
+            sourceInitialized = true;
+            previousSource = source;
+            previousSourceName = newSourceName;
+            return;
+        }
 
+        if (previousSourceName && previousSourceName !== newSourceName && GlobalConfig.utilities.toasts.audioInputChanged) {
+            const oldSource = previousSource;
+            const actions = oldSource ? [
+                {
+                    text: qsTr("Undo"),
+                    icon: "undo",
+                    callback: () => root.setAudioSource(oldSource)
+                }
+            ] : [];
+
+            Toaster.toast(qsTr("Audio input changed"), qsTr("Now using: %1").arg(newSourceName), "mic", actions);
+        }
+
+        previousSource = source;
         previousSourceName = newSourceName;
     }
+
+    onSinkChanged: checkSinkChange()
+    onSourceChanged: checkSourceChange()
 
     // Populate immediately: Pipewire.nodes may already be filled by the time this
     // lazily-loaded singleton is created, so onValuesChanged would never fire.
     Component.onCompleted: {
         refreshNodes();
-        previousSinkName = sink?.description || sink?.name || qsTr("Unknown Device");
-        previousSourceName = source?.description || source?.name || qsTr("Unknown Device");
+        checkSinkChange();
+        checkSourceChange();
     }
 
     Connections {
         function onValuesChanged(): void {
             root.refreshNodes();
+            root.checkSinkChange();
+            root.checkSourceChange();
         }
 
         target: Pipewire.nodes


### PR DESCRIPTION
## Summary
This PR adds support for **interactive quick actions** in toasts across Shell, supporting both c++ callbacks and qml js callbacks. 
As an example it also adds an immediate quality-of-life improvement: an **"Undo"** action on audio input and output device change toasts to quickly revert back to the previous device.
<img width="502" height="121" alt="photo_2026-09-01_21-45-35" src="https://github.com/user-attachments/assets/d8901833-59f3-4789-9d74-ff3ced39b00e" />

## Changes
    
### 1. Core (`caelestia-core`)
* **`ToastAction` Struct**: Added a lightweight `Q_GADGET` value struct supporting both c++ lambda callbacks (`std::function<void()>`) and qml js callbacks (`QJSValue`).
* **`Toast::actions`**: Exposed action lists to qml as `QList<ToastAction>`.
* **Ergonomic `Toaster::toast` Overloads**: Streamlined `toast()` methods to allow passing actions directly from both c++ and qml without requiring unnecessary boilerplate for `type` or `timeout`.

### 2. UI (`modules/utilities/toasts`)
* **`ToastItem.qml`**: Added an action row rendering Material 3 `IconTextButton` items for each action. Clicking an action invokes the callback and dismisses the toast.
* **`Regions.qml` & `ContentWindow.qml`**: Registered `toasts` in the Wayland input region mask so buttons receive mouse clicks, hovers, and ripple animations.

### 3. Audio Service (`services/Audio.qml`)
* Added an **Undo** quick action on audio output and input change toasts, allowing one-click rollback to the previous device.

## Usage Examples

### In QML:
```javascript
Toaster.toast("Audio output changed", "Now using: Headphones", "volume_up", [
    {
        text: qsTr("Undo"),
        icon: "undo",
        callback: () => Audio.setAudioSink(previousSink)
    }
]);
```

### In C++:

```cpp
Toaster::instance()->toast(u"USB Drive Inserted"_s, u"SanDisk 32GB"_s, u"usb"_s, {
    ToastAction(u"Open Files"_s, u"folder"_s, []() {
        // launch file manager
    })
});