### PR TITLE
fix(bar): check tray item nullability, don't show popouts for empty menus

### DIFF
--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -24,7 +24,9 @@ ColumnLayout {
             return;
 
         for (let i = 0; i < repeater.count; i++) {
-            const tray = (repeater.itemAt(i) as EntryWrapper).item as Tray;
+            const wrapper = repeater.itemAt(i) as EntryWrapper;
+            const tray = wrapper?.item as Tray;
+
             if (tray)
                 tray.expanded = false;
         }

--- a/modules/bar/popouts/Content.qml
+++ b/modules/bar/popouts/Content.qml
@@ -14,14 +14,15 @@ Item {
     required property PopoutState popouts
     readonly property Popout currentPopout: content.children.find(c => c.shouldBeActive) ?? null
     readonly property Item current: currentPopout?.item ?? null
+    readonly property bool currentReady: currentPopout?.ready ?? false
 
     readonly property var trayItemsToIndices: SystemTray.items.values.reduce((acc, item, i) => {
         acc[item.id] = i;
         return acc;
     }, {})
 
-    implicitWidth: currentPopout ? currentPopout.implicitWidth + Tokens.padding.extraLargeIncreased : 0
-    implicitHeight: currentPopout ? currentPopout.implicitHeight + Tokens.padding.extraLargeIncreased : 0
+    implicitWidth: currentReady && currentPopout ? currentPopout.implicitWidth + Tokens.padding.extraLargeIncreased : 0
+    implicitHeight: currentReady && currentPopout ? currentPopout.implicitHeight + Tokens.padding.extraLargeIncreased : 0
 
     Item {
         id: content
@@ -134,15 +135,22 @@ Item {
 
                 required property SystemTrayItem modelData
 
+                function reloadMenu(): void {
+                    if (!root.popouts.hasCurrent || root.popouts.currentName !== trayMenu.name)
+                        return;
+
+                    trayMenu.ready = false;
+                    trayMenu.sourceComponent = null;
+                    trayMenu.sourceComponent = trayMenuComp;
+                }
+
+                ready: false
                 name: `traymenu${root.trayItemsToIndices[modelData.id]}`
                 sourceComponent: trayMenuComp
 
                 Connections {
                     function onHasCurrentChanged(): void {
-                        if (root.popouts.hasCurrent && trayMenu.shouldBeActive) {
-                            trayMenu.sourceComponent = null;
-                            trayMenu.sourceComponent = trayMenuComp;
-                        }
+                        trayMenu.reloadMenu();
                     }
 
                     target: root.popouts
@@ -156,6 +164,8 @@ Item {
                         trayItem: trayMenu.modelData.menu // qmllint disable unresolved-type
 
                         onRootMenuResolved: hasEntries => {
+                            trayMenu.ready = hasEntries;
+
                             if (root.popouts.hasCurrent && trayMenu.shouldBeActive && !hasEntries)
                                 root.popouts.hasCurrent = false;
                         }
@@ -170,6 +180,7 @@ Item {
 
         required property string name
         readonly property bool shouldBeActive: root.popouts.currentName === name
+        property bool ready: true
 
         anchors.centerIn: parent
 

--- a/modules/bar/popouts/Content.qml
+++ b/modules/bar/popouts/Content.qml
@@ -154,6 +154,11 @@ Item {
                     TrayMenu {
                         popouts: root.popouts
                         trayItem: trayMenu.modelData.menu // qmllint disable unresolved-type
+
+                        onRootMenuResolved: hasEntries => {
+                            if (root.popouts.hasCurrent && trayMenu.shouldBeActive && !hasEntries)
+                                root.popouts.hasCurrent = false;
+                        }
                     }
                 }
             }

--- a/modules/bar/popouts/TrayMenu.qml
+++ b/modules/bar/popouts/TrayMenu.qml
@@ -14,6 +14,8 @@ StackView {
     required property PopoutState popouts
     required property QsMenuHandle trayItem
 
+    signal rootMenuResolved(hasEntries: bool)
+
     implicitWidth: currentItem?.implicitWidth ?? 0
     implicitHeight: currentItem?.implicitHeight ?? 0
 
@@ -43,6 +45,7 @@ StackView {
 
         required property QsMenuHandle handle
         property bool isSubMenu
+        property bool resolved
         property bool shown
 
         padding: Tokens.padding.small
@@ -70,6 +73,18 @@ StackView {
             id: menuOpener
 
             menu: menu.handle
+        }
+
+        Connections {
+            function onMenuChanged(): void {
+                if (menu.isSubMenu || menu.resolved)
+                    return;
+
+                menu.resolved = true;
+                root.rootMenuResolved(menuOpener.children.values.some(entry => !entry.isSeparator));
+            }
+
+            target: menu.handle
         }
 
         Repeater {


### PR DESCRIPTION
## Summary

Safely handles potential null wrappers when collapsing tray items by using optional chaining after casting to `EntryWrapper`.
Also checks the menu entries of system tray items before opening their associated popouts, so empty popouts aren't shown. 

Might resolve the issue in #1913; still something to fix either way. 

## Testing

- Builds successfully
- Passed QML linting checks
- Resolves warnings of null tray items
  -  e.g.,` WARN scene: @modules/bar/Bar.qml[27:-1]: TypeError: Cannot read property 'item' of null`
- Tray items that previously showed empty popouts due to not containing any menu entries no longer show popouts at all