### PR TITLE
refactor(utils): simplify icon matching

### DIFF
--- a/utils/Icons.qml
+++ b/utils/Icons.qml
@@ -79,11 +79,19 @@ Singleton {
             Office: "content_paste"
         })
 
-    // Checks if a name matches an icon config. Icon configs can have the following keys:
-    // - name: The exact name of the icon
-    // - regex: A regex to match against the name (takes priority over name)
-    // - flags: The regex flags (only used if regex is set)
-    // - icon: The icon to use
+    readonly property list<string> networkIcons: ["signal_wifi_0_bar", "network_wifi_1_bar", "network_wifi_2_bar", "network_wifi_3_bar", "network_wifi"]
+
+    readonly property var bluetoothIconRules: [[["headset", "headphones"], "headphones"], [["audio"], "speaker"], [["phone"], "smartphone"], [["mouse"], "mouse"], [["keyboard"], "keyboard"]]
+
+    readonly property var notifIconRules: [[["reboot"], "restart_alt"], [["recording"], "screen_record"], [["battery"], "power"], [["screenshot"], "screenshot_monitor"], [["welcome"], "waving_hand"], [["time", "a break"], "schedule"], [["installed"], "download"], [["update"], "update"], [["unable to"], "deployed_code_alert"], [["profile"], "person"], [["file"], "folder_copy"]]
+
+    /**
+     * Checks if a name matches an icon config. Icon configs can have the following keys:
+     * - name: The exact name of the icon
+     * - regex: A regex to match against the name (takes priority over name)
+     * - flags: The regex flags (only used if regex is set)
+     * - icon: The icon to use
+     */
     function matchIconConfig(name: string, iconConfig: var): bool {
         if (!iconConfig.icon)
             return false;
@@ -120,77 +128,36 @@ Singleton {
         return fallback;
     }
 
+    /**
+     * Accepts a list of tables containing matching rules (strings) and their corresponding results.
+     * If any of the strings are found in the text, returns the result associated with them. Otherwise returns the fallback.
+     */
+    function matchIcon(text: string, rules: var, fallback: string): string {
+        for (const [needles, result] of rules)
+            if (needles.some(n => text.includes(n)))
+                return result;
+
+        return fallback;
+    }
+
     function getNetworkIcon(strength: int, isSecure = false): string {
-        if (isSecure) {
-            if (strength >= 80)
-                return "network_wifi_locked";
-            if (strength >= 60)
-                return "network_wifi_3_bar_locked";
-            if (strength >= 40)
-                return "network_wifi_2_bar_locked";
-            if (strength >= 20)
-                return "network_wifi_1_bar_locked";
-            return "signal_wifi_0_bar";
-        } else {
-            if (strength >= 80)
-                return "network_wifi";
-            if (strength >= 60)
-                return "network_wifi_3_bar";
-            if (strength >= 40)
-                return "network_wifi_2_bar";
-            if (strength >= 20)
-                return "network_wifi_1_bar";
-            return "signal_wifi_0_bar";
-        }
+        const level = Math.max(0, Math.min(4, Math.floor(strength / 20)));
+        const icon = networkIcons[level];
+
+        return isSecure && level > 0 ? `${icon}_locked` : icon;
     }
 
     function getBluetoothIcon(icon: string): string {
-        if (icon.includes("headset") || icon.includes("headphones"))
-            return "headphones";
-        if (icon.includes("audio"))
-            return "speaker";
-        if (icon.includes("phone"))
-            return "smartphone";
-        if (icon.includes("mouse"))
-            return "mouse";
-        if (icon.includes("keyboard"))
-            return "keyboard";
-        return "bluetooth";
+        return matchIcon(icon, bluetoothIconRules, "bluetooth");
     }
 
     function getWeatherIcon(code: string): string {
-        if (weatherIcons.hasOwnProperty(code))
-            return weatherIcons[code];
-        return "air";
+        return weatherIcons[code] ?? "air";
     }
 
     function getNotifIcon(summary: string, urgency: int): string {
-        summary = summary.toLowerCase();
-        if (summary.includes("reboot"))
-            return "restart_alt";
-        if (summary.includes("recording"))
-            return "screen_record";
-        if (summary.includes("battery"))
-            return "power";
-        if (summary.includes("screenshot"))
-            return "screenshot_monitor";
-        if (summary.includes("welcome"))
-            return "waving_hand";
-        if (summary.includes("time") || summary.includes("a break"))
-            return "schedule";
-        if (summary.includes("installed"))
-            return "download";
-        if (summary.includes("update"))
-            return "update";
-        if (summary.includes("unable to"))
-            return "deployed_code_alert";
-        if (summary.includes("profile"))
-            return "person";
-        if (summary.includes("file"))
-            return "folder_copy";
-        if (urgency === NotificationUrgency.Critical)
-            return "release_alert";
-        return "chat";
+        const fallback = urgency === NotificationUrgency.Critical ? "release_alert" : "chat";
+        return matchIcon(summary.toLowerCase(), notifIconRules, fallback);
     }
 
     function getVolumeIcon(volume: real, isMuted: bool): string {
@@ -204,9 +171,7 @@ Singleton {
     }
 
     function getMicVolumeIcon(volume: real, isMuted: bool): string {
-        if (!isMuted && volume > 0)
-            return "mic";
-        return "mic_off";
+        return (!isMuted && volume > 0) ? "mic" : "mic_off";
     }
 
     function getSpecialWsIcon(name: string): string {
@@ -216,17 +181,20 @@ Singleton {
             if (matchIconConfig(name, iconConfig))
                 return iconConfig.icon;
 
-        if (name === "special")
+        switch (name) {
+        case "special":
             return "star";
-        if (name === "communication")
+        case "communication":
             return "forum";
-        if (name === "music")
+        case "music":
             return "music_cast";
-        if (name === "todo")
+        case "todo":
             return "checklist";
-        if (name === "sysmon")
+        case "sysmon":
             return "monitor_heart";
-        return name[0].toUpperCase();
+        default:
+            return name[0].toUpperCase();
+        }
     }
 
     function getTrayIcon(id: string, icon: string): string {

--- a/utils/Icons.qml
+++ b/utils/Icons.qml
@@ -109,7 +109,7 @@ Singleton {
         [["profile"], "person"],
         [["file"], "folder_copy"]
     ]
-    //qmlformat on
+    // qmlformat on
 
     /**
      * Checks if a name matches an icon config. Icon configs can have the following keys:

--- a/utils/Icons.qml
+++ b/utils/Icons.qml
@@ -79,11 +79,37 @@ Singleton {
             Office: "content_paste"
         })
 
-    readonly property list<string> networkIcons: ["signal_wifi_0_bar", "network_wifi_1_bar", "network_wifi_2_bar", "network_wifi_3_bar", "network_wifi"]
+    // qmlformat off
+    readonly property list<string> networkIcons: [
+        "signal_wifi_0_bar",
+        "network_wifi_1_bar",
+        "network_wifi_2_bar",
+        "network_wifi_3_bar",
+        "network_wifi"
+    ]
 
-    readonly property var bluetoothIconRules: [[["headset", "headphones"], "headphones"], [["audio"], "speaker"], [["phone"], "smartphone"], [["mouse"], "mouse"], [["keyboard"], "keyboard"]]
+    readonly property var bluetoothIconRules: [
+        [["headset", "headphones"], "headphones"],
+        [["audio"], "speaker"],
+        [["phone"], "smartphone"],
+        [["mouse"], "mouse"],
+        [["keyboard"], "keyboard"]
+    ]
 
-    readonly property var notifIconRules: [[["reboot"], "restart_alt"], [["recording"], "screen_record"], [["battery"], "power"], [["screenshot"], "screenshot_monitor"], [["welcome"], "waving_hand"], [["time", "a break"], "schedule"], [["installed"], "download"], [["update"], "update"], [["unable to"], "deployed_code_alert"], [["profile"], "person"], [["file"], "folder_copy"]]
+    readonly property var notifIconRules: [
+        [["reboot"], "restart_alt"],
+        [["recording"], "screen_record"],
+        [["battery"], "power"],
+        [["screenshot"], "screenshot_monitor"],
+        [["welcome"], "waving_hand"],
+        [["time", "a break"], "schedule"],
+        [["installed"], "download"],
+        [["update"], "update"],
+        [["unable to"], "deployed_code_alert"],
+        [["profile"], "person"],
+        [["file"], "folder_copy"]
+    ]
+    //qmlformat on
 
     /**
      * Checks if a name matches an icon config. Icon configs can have the following keys:
@@ -171,7 +197,7 @@ Singleton {
     }
 
     function getMicVolumeIcon(volume: real, isMuted: bool): string {
-        return (!isMuted && volume > 0) ? "mic" : "mic_off";
+        return !isMuted && volume > 0 ? "mic" : "mic_off";
     }
 
     function getSpecialWsIcon(name: string): string {


### PR DESCRIPTION
## Summary

Simplifies icon lookup functions by adding a generic `matchIcon()` helper function and defining icon rules in static maps. This reduces code duplication and eliminates the lengthy `if...return` chains from `getBluetoothIcon` and `getNotifIcon`. 

Also modernizes syntax by using nullish coalescing, switch statements, and mathematical mapping. Functionality remains the same for callsites; these changes are essentially just syntax-related improvements.