### PR TITLE
refactor: nmcli service

### DIFF
--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -121,7 +121,7 @@ StyledRect {
                     delegate: EntryWrapper {
                         MaterialIcon {
                             animate: true
-                            text: Nmcli.activeEthernet ? "cable" : Nmcli.active ? Icons.getNetworkIcon(Nmcli.active.strength ?? 0) : "wifi_off"
+                            text: Nmcli.onEthernet ? "cable" : Nmcli.active ? Icons.getNetworkIcon(Nmcli.active.strength ?? 0) : "wifi_off"
                             color: root.colour
                         }
                     }

--- a/modules/bar/components/StatusIcons.qml
+++ b/modules/bar/components/StatusIcons.qml
@@ -119,10 +119,56 @@ StyledRect {
                 DelegateChoice {
                     roleValue: "network"
                     delegate: EntryWrapper {
-                        MaterialIcon {
-                            animate: true
-                            text: Nmcli.onEthernet ? "cable" : Nmcli.active ? Icons.getNetworkIcon(Nmcli.active.strength ?? 0) : "wifi_off"
-                            color: root.colour
+                        Item {
+                            implicitWidth: networkIcon.implicitWidth
+                            implicitHeight: networkIcon.implicitHeight
+
+                            MaterialIcon {
+                                id: networkIcon
+
+                                animate: true
+                                text: Nmcli.onEthernet ? "cable" : Nmcli.active ? Icons.getNetworkIcon(Nmcli.active.strength ?? 0) : "wifi_off"
+                                color: root.colour
+                            }
+
+                            // A tunnel doesn't replace the link, it sits on top
+                            // of it - so this badges the icon that's already
+                            // saying which link, rather than taking its place.
+                            // The enabled check comes first deliberately:
+                            // reading VPN otherwise starts the service for
+                            // someone who has it turned off.
+                            StyledRect {
+                                id: vpnBadge
+
+                                anchors.left: parent.left
+                                anchors.top: parent.top
+                                anchors.leftMargin: -implicitWidth / 4
+                                anchors.topMargin: -implicitHeight / 4
+
+                                implicitWidth: vpnIcon.implicitHeight
+                                implicitHeight: implicitWidth
+
+                                radius: Tokens.rounding.full
+                                // Backed so the glyph stays legible over the
+                                // icon underneath it.
+                                color: Colours.tPalette.m3surfaceContainer
+                                visible: opacity > 0
+                                opacity: GlobalConfig.utilities.vpn.enabled && (VPN.connected || VPN.connecting) ? 1 : 0
+
+                                Behavior on opacity {
+                                    Anim {}
+                                }
+
+                                MaterialIcon {
+                                    id: vpnIcon
+
+                                    anchors.centerIn: parent
+                                    text: VPN.connecting ? "more_horiz" : "vpn_key"
+                                    color: root.colour
+                                    fontStyle: Tokens.font.icon.builders.small.scale(0.5).build()
+                                    fill: 1
+                                }
+                            }
                         }
                     }
                 }

--- a/modules/bar/popouts/Content.qml
+++ b/modules/bar/popouts/Content.qml
@@ -37,7 +37,7 @@ Item {
             name: "network"
             sourceComponent: Network {
                 popouts: root.popouts
-                view: Nmcli.activeEthernet ? "ethernet" : "wireless"
+                view: Nmcli.onEthernet ? "ethernet" : "wireless"
             }
         }
 

--- a/modules/bar/popouts/Network.qml
+++ b/modules/bar/popouts/Network.qml
@@ -63,7 +63,7 @@ ColumnLayout {
         RowLayout {
             id: networkItem
 
-            required property Nmcli.AccessPoint modelData
+            required property var modelData
             readonly property bool isConnecting: root.connectingToSsid === modelData.ssid
             readonly property bool loading: networkItem.isConnecting
 

--- a/modules/bar/popouts/WirelessPassword.qml
+++ b/modules/bar/popouts/WirelessPassword.qml
@@ -15,10 +15,6 @@ ColumnLayout {
     required property PopoutState popouts
     property var network: null
     property bool isClosing: false
-    // Whether a profile for this network existed before the dialog opened.
-    // Only one this dialog created may be cleaned up on failure; an existing
-    // profile belongs to the user.
-    property bool wasSaved: false
 
     readonly property bool shouldBeVisible: root.popouts.currentName === "wirelesspassword"
 
@@ -48,7 +44,7 @@ ColumnLayout {
                 connectButton.text = qsTr("Connect");
                 passwordContainer.passwordBuffer = "";
                 // Delete the failed connection
-                if (!root.wasSaved && root.network && root.network.ssid) {
+                if (root.network && root.network.ssid) {
                     Nmcli.forgetNetwork(root.network.ssid);
                 }
             }
@@ -66,11 +62,6 @@ ColumnLayout {
         connectButton.hasError = false;
         connectButton.text = qsTr("Connect");
         connectionMonitor.stop();
-
-        // A failed attempt can leave a profile behind; take it with us, but
-        // only if this dialog is what created it.
-        if (!root.wasSaved && root.network && root.network.ssid && Nmcli.hasSavedProfile(root.network.ssid))
-            Nmcli.forgetNetwork(root.network.ssid);
 
         // Return to network popout
         if (root.popouts.currentName === "wirelesspassword") {
@@ -98,9 +89,6 @@ ColumnLayout {
             focusTimer.start();
         }
     }
-
-    // Captured as the dialog opens, before any attempt can create a profile.
-    onNetworkChanged: root.wasSaved = !!root.network && Nmcli.hasSavedProfile(root.network.ssid)
 
     Keys.onEscapePressed: closeDialog()
 
@@ -540,7 +528,7 @@ ColumnLayout {
                                 text = qsTr("Connect");
                                 passwordContainer.passwordBuffer = "";
                                 // Delete the failed connection
-                                if (!root.wasSaved && root.network && root.network.ssid) {
+                                if (root.network && root.network.ssid) {
                                     Nmcli.forgetNetwork(root.network.ssid);
                                 }
                             } else {
@@ -552,7 +540,7 @@ ColumnLayout {
                                 text = qsTr("Connect");
                                 passwordContainer.passwordBuffer = "";
                                 // Delete the failed connection
-                                if (!root.wasSaved && root.network && root.network.ssid) {
+                                if (root.network && root.network.ssid) {
                                     Nmcli.forgetNetwork(root.network.ssid);
                                 }
                             }

--- a/modules/bar/popouts/WirelessPassword.qml
+++ b/modules/bar/popouts/WirelessPassword.qml
@@ -15,6 +15,10 @@ ColumnLayout {
     required property PopoutState popouts
     property var network: null
     property bool isClosing: false
+    // Whether a profile for this network existed before the dialog opened.
+    // Only one this dialog created may be cleaned up on failure; an existing
+    // profile belongs to the user.
+    property bool wasSaved: false
 
     readonly property bool shouldBeVisible: root.popouts.currentName === "wirelesspassword"
 
@@ -44,7 +48,7 @@ ColumnLayout {
                 connectButton.text = qsTr("Connect");
                 passwordContainer.passwordBuffer = "";
                 // Delete the failed connection
-                if (root.network && root.network.ssid) {
+                if (!root.wasSaved && root.network && root.network.ssid) {
                     Nmcli.forgetNetwork(root.network.ssid);
                 }
             }
@@ -62,6 +66,11 @@ ColumnLayout {
         connectButton.hasError = false;
         connectButton.text = qsTr("Connect");
         connectionMonitor.stop();
+
+        // A failed attempt can leave a profile behind; take it with us, but
+        // only if this dialog is what created it.
+        if (!root.wasSaved && root.network && root.network.ssid && Nmcli.hasSavedProfile(root.network.ssid))
+            Nmcli.forgetNetwork(root.network.ssid);
 
         // Return to network popout
         if (root.popouts.currentName === "wirelesspassword") {
@@ -89,6 +98,9 @@ ColumnLayout {
             focusTimer.start();
         }
     }
+
+    // Captured as the dialog opens, before any attempt can create a profile.
+    onNetworkChanged: root.wasSaved = !!root.network && Nmcli.hasSavedProfile(root.network.ssid)
 
     Keys.onEscapePressed: closeDialog()
 
@@ -528,7 +540,7 @@ ColumnLayout {
                                 text = qsTr("Connect");
                                 passwordContainer.passwordBuffer = "";
                                 // Delete the failed connection
-                                if (root.network && root.network.ssid) {
+                                if (!root.wasSaved && root.network && root.network.ssid) {
                                     Nmcli.forgetNetwork(root.network.ssid);
                                 }
                             } else {
@@ -540,7 +552,7 @@ ColumnLayout {
                                 text = qsTr("Connect");
                                 passwordContainer.passwordBuffer = "";
                                 // Delete the failed connection
-                                if (root.network && root.network.ssid) {
+                                if (!root.wasSaved && root.network && root.network.ssid) {
                                     Nmcli.forgetNetwork(root.network.ssid);
                                 }
                             }

--- a/modules/bar/popouts/WirelessPassword.qml
+++ b/modules/bar/popouts/WirelessPassword.qml
@@ -15,6 +15,10 @@ ColumnLayout {
     required property PopoutState popouts
     property var network: null
     property bool isClosing: false
+    // Whether a profile for this network existed before the dialog opened.
+    // Only one this dialog created may be cleaned up after a failure; an
+    // existing profile is the user's, with whatever they set on it.
+    property bool wasSaved: false
 
     readonly property bool shouldBeVisible: root.popouts.currentName === "wirelesspassword"
 
@@ -43,8 +47,9 @@ ColumnLayout {
                 connectButton.enabled = true;
                 connectButton.text = qsTr("Connect");
                 passwordContainer.passwordBuffer = "";
-                // Delete the failed connection
-                if (root.network && root.network.ssid) {
+                // Remove the half-created profile, but only if this dialog
+                // is what created it.
+                if (!root.wasSaved && root.network && root.network.ssid) {
                     Nmcli.forgetNetwork(root.network.ssid);
                 }
             }
@@ -89,6 +94,9 @@ ColumnLayout {
             focusTimer.start();
         }
     }
+
+    // Captured as the dialog opens, before any attempt can create a profile.
+    onNetworkChanged: root.wasSaved = !!root.network && Nmcli.hasSavedProfile(root.network.ssid)
 
     Keys.onEscapePressed: closeDialog()
 
@@ -527,8 +535,9 @@ ColumnLayout {
                                 enabled = true;
                                 text = qsTr("Connect");
                                 passwordContainer.passwordBuffer = "";
-                                // Delete the failed connection
-                                if (root.network && root.network.ssid) {
+                                // Remove the half-created profile, but only if
+                                // this dialog is what created it.
+                                if (!root.wasSaved && root.network && root.network.ssid) {
                                     Nmcli.forgetNetwork(root.network.ssid);
                                 }
                             } else {
@@ -539,8 +548,9 @@ ColumnLayout {
                                 enabled = true;
                                 text = qsTr("Connect");
                                 passwordContainer.passwordBuffer = "";
-                                // Delete the failed connection
-                                if (root.network && root.network.ssid) {
+                                // Remove the half-created profile, but only if
+                                // this dialog is what created it.
+                                if (!root.wasSaved && root.network && root.network.ssid) {
                                     Nmcli.forgetNetwork(root.network.ssid);
                                 }
                             }
@@ -612,8 +622,10 @@ ColumnLayout {
                 connectButton.enabled = true;
                 connectButton.text = qsTr("Connect");
                 passwordContainer.passwordBuffer = "";
-                // Delete the failed connection
-                Nmcli.forgetNetwork(ssid);
+                // Remove the half-created profile, but only if this dialog is
+                // what created it.
+                if (!root.wasSaved)
+                    Nmcli.forgetNetwork(ssid);
             }
         }
 

--- a/modules/nexus/common/EthernetSection.qml
+++ b/modules/nexus/common/EthernetSection.qml
@@ -25,13 +25,10 @@ ColumnLayout {
         triggeredOnStart: true
         interval: 5000
         onTriggered: {
-            // The device list is a live binding now; only the nmcli-backed
-            // details and the sysfs counters still need polling.
-            if (Nmcli.activeEthernet) {
-                Nmcli.getEthernetDeviceDetails(Nmcli.activeEthernet.iface, () => {});
+            // Everything else is a live binding; only the sysfs byte counters
+            // still have to be re-read.
+            if (Nmcli.activeEthernet)
                 Nmcli.getEthernetDataUsage(Nmcli.activeEthernet.iface);
-                Nmcli.getEthernetSpeed(Nmcli.activeEthernet.iface);
-            }
         }
     }
 

--- a/modules/nexus/common/EthernetSection.qml
+++ b/modules/nexus/common/EthernetSection.qml
@@ -81,8 +81,7 @@ ColumnLayout {
         id: ethRepeater
 
         model: ScriptModel {
-            // NM_DEVICE_STATE_UNAVAILABLE is 20: anything past it has a carrier.
-            values: Nmcli.ethernetDevices.filter(d => d.state > 20)
+            values: Nmcli.ethernetDevices.filter(d => d.carrier)
         }
 
         delegate: ConnectedRect {

--- a/modules/nexus/common/EthernetSection.qml
+++ b/modules/nexus/common/EthernetSection.qml
@@ -25,10 +25,11 @@ ColumnLayout {
         triggeredOnStart: true
         interval: 5000
         onTriggered: {
-            Nmcli.getEthernetInterfaces(() => {});
+            // The device list is a live binding now; only the nmcli-backed
+            // details and the sysfs counters still need polling.
             if (Nmcli.activeEthernet) {
                 Nmcli.getEthernetDeviceDetails(Nmcli.activeEthernet.iface, () => {});
-                Nmcli.getEthernetDataUsage(Nmcli.activeEthernet.iface, () => {});
+                Nmcli.getEthernetDataUsage(Nmcli.activeEthernet.iface);
                 Nmcli.getEthernetSpeed(Nmcli.activeEthernet.iface);
             }
         }
@@ -80,13 +81,14 @@ ColumnLayout {
         id: ethRepeater
 
         model: ScriptModel {
-            values: Nmcli.ethernetDevices.filter(d => d.state !== "unavailable")
+            // NM_DEVICE_STATE_UNAVAILABLE is 20: anything past it has a carrier.
+            values: Nmcli.ethernetDevices.filter(d => d.state > 20)
         }
 
         delegate: ConnectedRect {
             id: ethRow
 
-            required property Nmcli.EthernetDevice modelData
+            required property var modelData
             required property int index
 
             readonly property bool isConnected: modelData.connected

--- a/modules/nexus/common/NetworkList.qml
+++ b/modules/nexus/common/NetworkList.qml
@@ -17,9 +17,9 @@ ItemList {
     property int limit: 0 // 0 = show all
     property bool enableFilter
 
-    signal networkSelected(ap: Nmcli.AccessPoint)
+    signal networkSelected(ap: var)
 
-    function networkFilter(ap: Nmcli.AccessPoint): bool {
+    function networkFilter(ap: var): bool {
         return true;
     }
 
@@ -88,7 +88,7 @@ ItemList {
         }
 
         Connections {
-            function onNetworkSelected(ap: Nmcli.AccessPoint): void {
+            function onNetworkSelected(ap: var): void {
                 if (ap !== network.modelData)
                     network.currentSelected = false;
             }

--- a/modules/nexus/pages/network/AddNetworkPage.qml
+++ b/modules/nexus/pages/network/AddNetworkPage.qml
@@ -16,6 +16,9 @@ PageBase {
     // Security model: index 0 = none, 1 = WPA/WPA2/WPA3 personal.
     readonly property bool secured: securitySelect.active !== noneItem
     property bool connecting: false
+    // SSID of a profile this page created. Only that may be cleaned up; a
+    // profile that was already saved belongs to the user.
+    property string createdSsid: ""
     property bool failed: false
     property bool success: false
 
@@ -35,17 +38,23 @@ PageBase {
         root.failed = false;
         root.connecting = true;
 
+        root.createdSsid = Nmcli.hasSavedProfile(ssid) ? "" : ssid;
+
         Nmcli.addHiddenNetwork(ssid, root.secured ? passwordField.text : "", root.secured ? "wpa" : "none", hiddenToggle.checked, result => {
             root.connecting = false;
             if (result && result.success) {
                 root.success = true;
+                root.createdSsid = "";
                 root.nState.closeSubPage();
             } else {
                 root.failed = true;
                 if (root.secured)
                     passwordField.isError = true;
                 // Clean up the half-created profile so a retry starts fresh.
-                Nmcli.forgetNetwork(ssid);
+                if (root.createdSsid) {
+                    Nmcli.forgetNetwork(root.createdSsid);
+                    root.createdSsid = "";
+                }
             }
         });
     }
@@ -60,13 +69,16 @@ PageBase {
         spacing: Tokens.spacing.large
 
         Connections {
+            // Backing out of a half-finished attempt leaves the profile
+            // behind, so remove it - but only the one this page created.
+            // Deleting by whatever is typed in the field wipes the user's
+            // saved profile if they happen to type an SSID they already have.
             function onSubPageClosed(): void {
-                if (root.success)
+                if (!root.createdSsid)
                     return;
 
-                const ssid = ssidField.text.trim();
-                if (ssid)
-                    Nmcli.forgetNetwork(ssid);
+                Nmcli.forgetNetwork(root.createdSsid);
+                root.createdSsid = "";
             }
 
             target: root.nState

--- a/modules/nexus/pages/network/AllNetworksPage.qml
+++ b/modules/nexus/pages/network/AllNetworksPage.qml
@@ -58,7 +58,7 @@ PageBase {
                 FilterButton {
                     id: savedFilter
 
-                    function internalFilter(ap: Nmcli.AccessPoint): bool {
+                    function internalFilter(ap: var): bool {
                         return Nmcli.hasSavedProfile(ap.ssid);
                     }
 
@@ -82,7 +82,7 @@ PageBase {
                 FilterButton {
                     id: secureFilter
 
-                    function internalFilter(ap: Nmcli.AccessPoint): bool {
+                    function internalFilter(ap: var): bool {
                         return ap.security !== "none";
                     }
 
@@ -92,7 +92,7 @@ PageBase {
                 FilterButton {
                     id: highFreqFilter
 
-                    function internalFilter(ap: Nmcli.AccessPoint): bool {
+                    function internalFilter(ap: var): bool {
                         return ap.frequency >= 4900 && ap.frequency <= 5900;
                     }
 
@@ -102,7 +102,7 @@ PageBase {
                 FilterButton {
                     id: lowFreqFilter
 
-                    function internalFilter(ap: Nmcli.AccessPoint): bool {
+                    function internalFilter(ap: var): bool {
                         return ap.frequency >= 2400 && ap.frequency <= 2500;
                     }
 
@@ -128,7 +128,7 @@ PageBase {
         NetworkList {
             id: networkList
 
-            function networkFilter(ap: Nmcli.AccessPoint): bool {
+            function networkFilter(ap: var): bool {
                 return savedFilter.filter(ap) && secureFilter.filter(ap) && highFreqFilter.filter(ap) && lowFreqFilter.filter(ap);
             }
 
@@ -143,7 +143,7 @@ PageBase {
 
         property int filterState // 0 = default, 1 = on, 2 = negate
 
-        function filter(ap: Nmcli.AccessPoint): bool {
+        function filter(ap: var): bool {
             if (filterState === 0)
                 return true;
             if (filterState === 1)
@@ -151,7 +151,7 @@ PageBase {
             return !internalFilter(ap);
         }
 
-        function internalFilter(ap: Nmcli.AccessPoint): bool {
+        function internalFilter(ap: var): bool {
             return true;
         }
 

--- a/modules/nexus/pages/network/EthernetDetailPage.qml
+++ b/modules/nexus/pages/network/EthernetDetailPage.qml
@@ -98,11 +98,7 @@ PageBase {
     title: root.device?.connection || root.ifaceName || qsTr("Ethernet")
     isSubPage: true
 
-    Component.onCompleted: {
-        Nmcli.getEthernetDeviceDetails(root.ifaceName, () => {});
-        Nmcli.getEthernetSpeed(root.ifaceName);
-        loadIpConfig();
-    }
+    Component.onCompleted: loadIpConfig()
 
     ColumnLayout {
         anchors.horizontalCenter: parent.horizontalCenter

--- a/modules/nexus/pages/network/EthernetDetailPage.qml
+++ b/modules/nexus/pages/network/EthernetDetailPage.qml
@@ -15,7 +15,7 @@ PageBase {
     id: root
 
     readonly property string ifaceName: nState.selectedEthernetInterface
-    readonly property Nmcli.EthernetDevice device: Nmcli.ethernetDevices.find(d => d.iface === root.ifaceName) ?? null
+    readonly property var device: Nmcli.ethernetDevices.find(d => d.iface === root.ifaceName) ?? null
     readonly property var details: Nmcli.ethernetDeviceDetails
     readonly property string connectionName: root.device?.connection ?? ""
 

--- a/modules/nexus/pages/network/NetworkDetailPage.qml
+++ b/modules/nexus/pages/network/NetworkDetailPage.qml
@@ -90,10 +90,7 @@ PageBase {
     title: root.ssid || qsTr("Network")
     isSubPage: true
 
-    Component.onCompleted: {
-        Nmcli.getWirelessDeviceDetails("", () => {});
-        loadIpConfig();
-    }
+    Component.onCompleted: loadIpConfig()
 
     ColumnLayout {
         anchors.horizontalCenter: parent.horizontalCenter

--- a/modules/nexus/pages/network/SavedNetworksPage.qml
+++ b/modules/nexus/pages/network/SavedNetworksPage.qml
@@ -93,7 +93,7 @@ PageBase {
                                 if (saved.ap)
                                     security = saved.ap.security || qsTr("Open");
                                 else
-                                    security = Nmcli.securityLabel(Nmcli.savedSecurityFor(saved.modelData)) || qsTr("Unknown");
+                                    security = Nmcli.securityLabel(Nmcli.savedSecurityFor(saved.modelData));
                                 if (saved.isActive)
                                     return qsTr("Connected • %1").arg(security);
                                 return security;

--- a/plugin/src/Caelestia/Config/enums.hpp
+++ b/plugin/src/Caelestia/Config/enums.hpp
@@ -23,6 +23,7 @@ ENUM(BarWorkspaceCapitalisation, Preserve, Upper, Lower)
 ENUM(LyricsBackend, Auto, Local, LRCLIB, NetEase)
 ENUM(GpuType, Auto, Nvidia, Generic, None)
 ENUM(NotifsFullscreen, On, Off)
+ENUM(NetworkTransport, None, Ethernet, Wifi, Other)
 
 #undef ENUM
 

--- a/plugin/src/Caelestia/Services/CMakeLists.txt
+++ b/plugin/src/Caelestia/Services/CMakeLists.txt
@@ -19,6 +19,7 @@ qml_module(caelestia-services
         lyrics.cpp
         sessionmanager.cpp
         networkusage.cpp
+        networkroute.cpp
         hyprdevices.cpp
         hyprextras.cpp
     LIBRARIES

--- a/plugin/src/Caelestia/Services/CMakeLists.txt
+++ b/plugin/src/Caelestia/Services/CMakeLists.txt
@@ -20,6 +20,7 @@ qml_module(caelestia-services
         sessionmanager.cpp
         networkusage.cpp
         networkroute.cpp
+        networkwalker.cpp
         networkmanager.cpp
         networkprofiles.cpp
         hyprdevices.cpp

--- a/plugin/src/Caelestia/Services/CMakeLists.txt
+++ b/plugin/src/Caelestia/Services/CMakeLists.txt
@@ -21,6 +21,7 @@ qml_module(caelestia-services
         networkusage.cpp
         networkroute.cpp
         networkmanager.cpp
+        networkprofiles.cpp
         hyprdevices.cpp
         hyprextras.cpp
     LIBRARIES

--- a/plugin/src/Caelestia/Services/CMakeLists.txt
+++ b/plugin/src/Caelestia/Services/CMakeLists.txt
@@ -20,6 +20,7 @@ qml_module(caelestia-services
         sessionmanager.cpp
         networkusage.cpp
         networkroute.cpp
+        networkmanager.cpp
         hyprdevices.cpp
         hyprextras.cpp
     LIBRARIES

--- a/plugin/src/Caelestia/Services/networkmanager.cpp
+++ b/plugin/src/Caelestia/Services/networkmanager.cpp
@@ -423,12 +423,13 @@ void NetworkManager::readRoot() {
         QList<QDBusObjectPath> paths;
         devices >> paths;
 
-        for (const auto& path : paths) {
+        for (const auto& path : std::as_const(paths)) {
             readDevice(path.path());
         }
 
         step(-1);
     });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 void NetworkManager::readDevice(const QString& path) {
@@ -492,6 +493,7 @@ void NetworkManager::readDevice(const QString& path) {
 
         step(-1);
     });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 void NetworkManager::readConnection(const QString& devicePath, const QString& connectionPath) {
@@ -524,6 +526,7 @@ void NetworkManager::readConnection(const QString& devicePath, const QString& co
 
         step(-1);
     });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 void NetworkManager::readWired(const QString& devicePath) {
@@ -557,6 +560,7 @@ void NetworkManager::readWired(const QString& devicePath) {
 
         step(-1);
     });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 void NetworkManager::readWireless(const QString& devicePath) {
@@ -599,7 +603,7 @@ void NetworkManager::readWireless(const QString& devicePath) {
         }
 
         QSet<QString> seen;
-        for (const auto& path : paths) {
+        for (const auto& path : std::as_const(paths)) {
             seen.insert(path.path());
 
             auto* accessPoint = device->accessPoint(path.path());
@@ -616,6 +620,7 @@ void NetworkManager::readWireless(const QString& devicePath) {
 
         step(-1);
     });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 void NetworkManager::readAccessPoint(const QString& devicePath, const QString& accessPointPath) {
@@ -655,6 +660,7 @@ void NetworkManager::readAccessPoint(const QString& devicePath, const QString& a
 
             step(-1);
         });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 void NetworkManager::readIp4Config(const QString& devicePath, const QString& configPath) {
@@ -713,6 +719,7 @@ void NetworkManager::readIp4Config(const QString& devicePath, const QString& con
 
         step(-1);
     });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 } // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkmanager.cpp
+++ b/plugin/src/Caelestia/Services/networkmanager.cpp
@@ -16,52 +16,52 @@ namespace {
 
 Q_LOGGING_CATEGORY(logNetworkManager, "caelestia.services.networkmanager", QtWarningMsg);
 
-constexpr const char* kService = "org.freedesktop.NetworkManager";
-constexpr const char* kManagerPath = "/org/freedesktop/NetworkManager";
-constexpr const char* kManagerIface = "org.freedesktop.NetworkManager";
-constexpr const char* kDeviceIface = "org.freedesktop.NetworkManager.Device";
-constexpr const char* kActiveIface = "org.freedesktop.NetworkManager.Connection.Active";
-constexpr const char* kWiredIface = "org.freedesktop.NetworkManager.Device.Wired";
-constexpr const char* kWirelessIface = "org.freedesktop.NetworkManager.Device.Wireless";
-constexpr const char* kApIface = "org.freedesktop.NetworkManager.AccessPoint";
-constexpr const char* kIp4Iface = "org.freedesktop.NetworkManager.IP4Config";
-constexpr const char* kPropsIface = "org.freedesktop.DBus.Properties";
+constexpr const char* k_service = "org.freedesktop.NetworkManager";
+constexpr const char* k_managerPath = "/org/freedesktop/NetworkManager";
+constexpr const char* k_managerIface = "org.freedesktop.NetworkManager";
+constexpr const char* k_deviceIface = "org.freedesktop.NetworkManager.Device";
+constexpr const char* k_activeIface = "org.freedesktop.NetworkManager.Connection.Active";
+constexpr const char* k_wiredIface = "org.freedesktop.NetworkManager.Device.Wired";
+constexpr const char* k_wirelessIface = "org.freedesktop.NetworkManager.Device.Wireless";
+constexpr const char* k_apIface = "org.freedesktop.NetworkManager.AccessPoint";
+constexpr const char* k_ip4Iface = "org.freedesktop.NetworkManager.IP4Config";
+constexpr const char* k_propsIface = "org.freedesktop.DBus.Properties";
 
 // From NMDeviceType; only the two we classify are named.
-constexpr uint kDeviceTypeEthernet = 1;
-constexpr uint kDeviceTypeWifi = 2;
+constexpr uint k_deviceTypeEthernet = 1;
+constexpr uint k_deviceTypeWifi = 2;
 
 // NM_DEVICE_STATE_ACTIVATED
-constexpr uint kStateActivated = 100;
+constexpr uint k_stateActivated = 100;
 
 // From NM80211ApFlags and NM80211ApSecurityFlags.
-constexpr uint kApFlagPrivacy = 0x1;
-constexpr uint kApSecKeyMgmt8021X = 0x200;
-constexpr uint kApSecKeyMgmtSae = 0x400;
-constexpr uint kApSecKeyMgmtOwe = 0x800;
-constexpr uint kApSecKeyMgmtOweTm = 0x1000;
+constexpr uint k_apFlagPrivacy = 0x1;
+constexpr uint k_apSecKeyMgmt8021X = 0x200;
+constexpr uint k_apSecKeyMgmtSae = 0x400;
+constexpr uint k_apSecKeyMgmtOwe = 0x800;
+constexpr uint k_apSecKeyMgmtOweTm = 0x1000;
 
 // Builds the label nmcli printed in its SECURITY column, so the string the UI
 // shows doesn't change now that it comes from dbus rather than parsed output.
 QString securityLabel(uint flags, uint wpaFlags, uint rsnFlags) {
     if (wpaFlags == 0 && rsnFlags == 0) {
-        return (flags & kApFlagPrivacy) != 0 ? QStringLiteral("WEP") : QString();
+        return (flags & k_apFlagPrivacy) != 0 ? QStringLiteral("WEP") : QString();
     }
 
     QStringList parts;
     if (wpaFlags != 0) {
         parts << QStringLiteral("WPA1");
     }
-    if ((rsnFlags & ~(kApSecKeyMgmtSae | kApSecKeyMgmtOwe | kApSecKeyMgmtOweTm)) != 0) {
+    if ((rsnFlags & ~(k_apSecKeyMgmtSae | k_apSecKeyMgmtOwe | k_apSecKeyMgmtOweTm)) != 0) {
         parts << QStringLiteral("WPA2");
     }
-    if ((rsnFlags & kApSecKeyMgmtSae) != 0) {
+    if ((rsnFlags & k_apSecKeyMgmtSae) != 0) {
         parts << QStringLiteral("WPA3");
     }
-    if ((rsnFlags & (kApSecKeyMgmtOwe | kApSecKeyMgmtOweTm)) != 0) {
+    if ((rsnFlags & (k_apSecKeyMgmtOwe | k_apSecKeyMgmtOweTm)) != 0) {
         parts << QStringLiteral("OWE");
     }
-    if (((wpaFlags | rsnFlags) & kApSecKeyMgmt8021X) != 0) {
+    if (((wpaFlags | rsnFlags) & k_apSecKeyMgmt8021X) != 0) {
         parts << QStringLiteral("802.1X");
     }
 
@@ -70,9 +70,12 @@ QString securityLabel(uint flags, uint wpaFlags, uint rsnFlags) {
 
 Transport transportForDeviceType(uint deviceType) {
     switch (deviceType) {
-    case kDeviceTypeEthernet: return config::NetworkTransport::Ethernet;
-    case kDeviceTypeWifi: return config::NetworkTransport::Wifi;
-    default: return config::NetworkTransport::Other;
+    case k_deviceTypeEthernet:
+        return config::NetworkTransport::Ethernet;
+    case k_deviceTypeWifi:
+        return config::NetworkTransport::Wifi;
+    default:
+        return config::NetworkTransport::Other;
     }
 }
 
@@ -175,20 +178,15 @@ void NmAccessPoint::watch() {
         return;
     }
 
-    bus.connect(
-        QString::fromUtf8(kService),
-        m_path,
-        QString::fromUtf8(kPropsIface),
-        QStringLiteral("PropertiesChanged"),
-        this,
-        SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)));
+    bus.connect(QString::fromUtf8(k_service), m_path, QString::fromUtf8(k_propsIface),
+        QStringLiteral("PropertiesChanged"), this, SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)));
 }
 
 void NmAccessPoint::handlePropertiesChanged(
     const QString& iface, const QVariantMap& properties, const QStringList& invalidated) {
     Q_UNUSED(invalidated);
 
-    if (iface == QString::fromUtf8(kApIface)) {
+    if (iface == QString::fromUtf8(k_apIface)) {
         update(properties);
     }
 }
@@ -214,7 +212,7 @@ uint NmDevice::state() const {
 }
 
 bool NmDevice::connected() const {
-    return m_state == kStateActivated;
+    return m_state == k_stateActivated;
 }
 
 QString NmDevice::connection() const {
@@ -315,7 +313,7 @@ void NmDevice::addAccessPoint(NmAccessPoint* accessPoint) {
 bool NmDevice::retainAccessPoints(const QSet<QString>& keep) {
     bool removed = false;
 
-    for (int i = m_accessPoints.size() - 1; i >= 0; i--) {
+    for (qsizetype i = m_accessPoints.size() - 1; i >= 0; i--) {
         auto* accessPoint = m_accessPoints.at(i);
         if (!keep.contains(accessPoint->path())) {
             m_apByPath.remove(accessPoint->path());
@@ -350,15 +348,15 @@ void NmDevice::update(const QVariantMap& props) {
 }
 
 NetworkManager::NetworkManager(QObject* parent)
-    : NmWalker(QString::fromUtf8(kManagerPath), parent) {}
+    : NmWalker(QString::fromUtf8(k_managerPath), parent) {}
 
 // Access points and the profile name track themselves, so this only needs to
 // catch the tree moving: devices appearing, changing state, or swapping their
 // wired link, wireless membership or ip config.
 bool NetworkManager::triggersRefresh(const QString& iface) const {
-    return iface == QString::fromUtf8(kManagerIface) || iface == QString::fromUtf8(kDeviceIface) ||
-        iface == QString::fromUtf8(kWiredIface) || iface == QString::fromUtf8(kWirelessIface) ||
-        iface == QString::fromUtf8(kIp4Iface);
+    return iface == QString::fromUtf8(k_managerIface) || iface == QString::fromUtf8(k_deviceIface) ||
+           iface == QString::fromUtf8(k_wiredIface) || iface == QString::fromUtf8(k_wirelessIface) ||
+           iface == QString::fromUtf8(k_ip4Iface);
 }
 
 void NetworkManager::clearItems() {
@@ -371,7 +369,7 @@ void NetworkManager::clearItems() {
 
 // Anything not seen by this walk is gone.
 void NetworkManager::pruneUnseen() {
-    for (int i = m_devices.size() - 1; i >= 0; i--) {
+    for (qsizetype i = m_devices.size() - 1; i >= 0; i--) {
         auto* device = m_devices.at(i);
         if (!seen().contains(device->path())) {
             m_byPath.remove(device->path());
@@ -397,12 +395,9 @@ void NetworkManager::readRoot() {
         return;
     }
 
-    auto msg = QDBusMessage::createMethodCall(
-        QString::fromUtf8(kService),
-        QString::fromUtf8(kManagerPath),
-        QString::fromUtf8(kPropsIface),
-        QStringLiteral("GetAll"));
-    msg << QString::fromUtf8(kManagerIface);
+    auto msg = QDBusMessage::createMethodCall(QString::fromUtf8(k_service), QString::fromUtf8(k_managerPath),
+        QString::fromUtf8(k_propsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(k_managerIface);
 
     step(1);
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
@@ -445,8 +440,8 @@ void NetworkManager::readDevice(const QString& path) {
     watchObject(path);
 
     auto msg = QDBusMessage::createMethodCall(
-        QString::fromUtf8(kService), path, QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
-    msg << QString::fromUtf8(kDeviceIface);
+        QString::fromUtf8(k_service), path, QString::fromUtf8(k_propsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(k_deviceIface);
 
     step(1);
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
@@ -506,8 +501,8 @@ void NetworkManager::readConnection(const QString& devicePath, const QString& co
     }
 
     auto msg = QDBusMessage::createMethodCall(
-        QString::fromUtf8(kService), connectionPath, QString::fromUtf8(kPropsIface), QStringLiteral("Get"));
-    msg << QString::fromUtf8(kActiveIface) << QStringLiteral("Id");
+        QString::fromUtf8(k_service), connectionPath, QString::fromUtf8(k_propsIface), QStringLiteral("Get"));
+    msg << QString::fromUtf8(k_activeIface) << QStringLiteral("Id");
 
     step(1);
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
@@ -538,8 +533,8 @@ void NetworkManager::readWired(const QString& devicePath) {
     }
 
     auto msg = QDBusMessage::createMethodCall(
-        QString::fromUtf8(kService), devicePath, QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
-    msg << QString::fromUtf8(kWiredIface);
+        QString::fromUtf8(k_service), devicePath, QString::fromUtf8(k_propsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(k_wiredIface);
 
     step(1);
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
@@ -571,8 +566,8 @@ void NetworkManager::readWireless(const QString& devicePath) {
     }
 
     auto msg = QDBusMessage::createMethodCall(
-        QString::fromUtf8(kService), devicePath, QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
-    msg << QString::fromUtf8(kWirelessIface);
+        QString::fromUtf8(k_service), devicePath, QString::fromUtf8(k_propsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(k_wirelessIface);
 
     step(1);
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
@@ -630,15 +625,12 @@ void NetworkManager::readAccessPoint(const QString& devicePath, const QString& a
     }
 
     auto msg = QDBusMessage::createMethodCall(
-        QString::fromUtf8(kService), accessPointPath, QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
-    msg << QString::fromUtf8(kApIface);
+        QString::fromUtf8(k_service), accessPointPath, QString::fromUtf8(k_propsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(k_apIface);
 
     step(1);
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
-    connect(
-        watcher,
-        &QDBusPendingCallWatcher::finished,
-        this,
+    connect(watcher, &QDBusPendingCallWatcher::finished, this,
         [this, devicePath, accessPointPath](QDBusPendingCallWatcher* call) {
             call->deleteLater();
 
@@ -672,8 +664,8 @@ void NetworkManager::readIp4Config(const QString& devicePath, const QString& con
     }
 
     auto msg = QDBusMessage::createMethodCall(
-        QString::fromUtf8(kService), configPath, QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
-    msg << QString::fromUtf8(kIp4Iface);
+        QString::fromUtf8(k_service), configPath, QString::fromUtf8(k_propsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(k_ip4Iface);
 
     step(1);
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
@@ -685,8 +677,7 @@ void NetworkManager::readIp4Config(const QString& devicePath, const QString& con
         if (reply.isError() || device == nullptr) {
             if (reply.isError()) {
                 // Addresses come and go with the link; that's expected.
-                qCDebug(logNetworkManager) << "Skipping ip4 config for" << devicePath << ":"
-                                           << reply.error().message();
+                qCDebug(logNetworkManager) << "Skipping ip4 config for" << devicePath << ":" << reply.error().message();
             }
             step(-1);
             return;

--- a/plugin/src/Caelestia/Services/networkmanager.cpp
+++ b/plugin/src/Caelestia/Services/networkmanager.cpp
@@ -232,6 +232,19 @@ QList<NmAccessPoint*> NmDevice::accessPoints() const {
     return m_accessPoints;
 }
 
+qlonglong NmDevice::lastScan() const {
+    return m_lastScan;
+}
+
+void NmDevice::setLastScan(qlonglong lastScan) {
+    if (lastScan == m_lastScan) {
+        return;
+    }
+
+    m_lastScan = lastScan;
+    emit changed();
+}
+
 NmAccessPoint* NmDevice::accessPoint(const QString& path) const {
     return m_apByPath.value(path);
 }
@@ -610,8 +623,14 @@ void NetworkManager::readWireless(const QString& devicePath) {
         QList<QDBusObjectPath> paths;
         props.value(QStringLiteral("AccessPoints")).value<QDBusArgument>() >> paths;
 
-        const auto activePath =
-            props.value(QStringLiteral("ActiveAccessPoint")).value<QDBusObjectPath>().path();
+        const auto activePath = props.value(QStringLiteral("ActiveAccessPoint")).value<QDBusObjectPath>().path();
+
+        // Absent on older NetworkManager; leave it at -1 rather than reading a
+        // missing key as "scanned at boot".
+        const auto lastScan = props.find(QStringLiteral("LastScan"));
+        if (lastScan != props.end()) {
+            device->setLastScan(lastScan.value().toLongLong());
+        }
 
         QSet<QString> seen;
         for (const auto& path : paths) {

--- a/plugin/src/Caelestia/Services/networkmanager.cpp
+++ b/plugin/src/Caelestia/Services/networkmanager.cpp
@@ -21,6 +21,8 @@ constexpr const char* kManagerPath = "/org/freedesktop/NetworkManager";
 constexpr const char* kManagerIface = "org.freedesktop.NetworkManager";
 constexpr const char* kDeviceIface = "org.freedesktop.NetworkManager.Device";
 constexpr const char* kActiveIface = "org.freedesktop.NetworkManager.Connection.Active";
+constexpr const char* kWirelessIface = "org.freedesktop.NetworkManager.Device.Wireless";
+constexpr const char* kApIface = "org.freedesktop.NetworkManager.AccessPoint";
 constexpr const char* kPropsIface = "org.freedesktop.DBus.Properties";
 
 // From NMDeviceType; only the two we classify are named.
@@ -29,6 +31,40 @@ constexpr uint kDeviceTypeWifi = 2;
 
 // NM_DEVICE_STATE_ACTIVATED
 constexpr uint kStateActivated = 100;
+
+// From NM80211ApFlags and NM80211ApSecurityFlags.
+constexpr uint kApFlagPrivacy = 0x1;
+constexpr uint kApSecKeyMgmt8021X = 0x200;
+constexpr uint kApSecKeyMgmtSae = 0x400;
+constexpr uint kApSecKeyMgmtOwe = 0x800;
+constexpr uint kApSecKeyMgmtOweTm = 0x1000;
+
+// Builds the label nmcli printed in its SECURITY column, so the string the UI
+// shows doesn't change now that it comes from dbus rather than parsed output.
+QString securityLabel(uint flags, uint wpaFlags, uint rsnFlags) {
+    if (wpaFlags == 0 && rsnFlags == 0) {
+        return (flags & kApFlagPrivacy) != 0 ? QStringLiteral("WEP") : QString();
+    }
+
+    QStringList parts;
+    if (wpaFlags != 0) {
+        parts << QStringLiteral("WPA1");
+    }
+    if ((rsnFlags & ~(kApSecKeyMgmtSae | kApSecKeyMgmtOwe | kApSecKeyMgmtOweTm)) != 0) {
+        parts << QStringLiteral("WPA2");
+    }
+    if ((rsnFlags & kApSecKeyMgmtSae) != 0) {
+        parts << QStringLiteral("WPA3");
+    }
+    if ((rsnFlags & (kApSecKeyMgmtOwe | kApSecKeyMgmtOweTm)) != 0) {
+        parts << QStringLiteral("OWE");
+    }
+    if (((wpaFlags | rsnFlags) & kApSecKeyMgmt8021X) != 0) {
+        parts << QStringLiteral("802.1X");
+    }
+
+    return parts.join(QLatin1Char(' '));
+}
 
 Transport transportForDeviceType(uint deviceType) {
     switch (deviceType) {
@@ -39,6 +75,121 @@ Transport transportForDeviceType(uint deviceType) {
 }
 
 } // namespace
+
+NmAccessPoint::NmAccessPoint(QString path, QObject* parent)
+    : QObject(parent)
+    , m_path(std::move(path)) {}
+
+QString NmAccessPoint::path() const {
+    return m_path;
+}
+
+QString NmAccessPoint::ssid() const {
+    return m_ssid;
+}
+
+QString NmAccessPoint::bssid() const {
+    return m_bssid;
+}
+
+int NmAccessPoint::strength() const {
+    return m_strength;
+}
+
+int NmAccessPoint::frequency() const {
+    return m_frequency;
+}
+
+QString NmAccessPoint::security() const {
+    return securityLabel(m_flags, m_wpaFlags, m_rsnFlags);
+}
+
+bool NmAccessPoint::isSecure() const {
+    return !security().isEmpty();
+}
+
+bool NmAccessPoint::active() const {
+    return m_active;
+}
+
+void NmAccessPoint::setActive(bool active) {
+    if (active == m_active) {
+        return;
+    }
+
+    m_active = active;
+    emit changed();
+}
+
+// Merges rather than replaces: PropertiesChanged carries only what moved, so a
+// missing key means unchanged, not empty.
+void NmAccessPoint::update(const QVariantMap& props) {
+    bool dirty = false;
+
+    const auto apply = [&props, &dirty](const char* key, auto& field, auto convert) {
+        const auto it = props.find(QString::fromUtf8(key));
+        if (it == props.end()) {
+            return;
+        }
+
+        const auto value = convert(it.value());
+        if (value != field) {
+            field = value;
+            dirty = true;
+        }
+    };
+
+    // Ssid is a byte array; NetworkManager doesn't promise it's valid UTF-8.
+    apply("Ssid", m_ssid, [](const QVariant& v) {
+        return QString::fromUtf8(v.toByteArray());
+    });
+    apply("HwAddress", m_bssid, [](const QVariant& v) {
+        return v.toString();
+    });
+    apply("Strength", m_strength, [](const QVariant& v) {
+        return static_cast<int>(v.toUInt());
+    });
+    apply("Frequency", m_frequency, [](const QVariant& v) {
+        return static_cast<int>(v.toUInt());
+    });
+    apply("Flags", m_flags, [](const QVariant& v) {
+        return v.toUInt();
+    });
+    apply("WpaFlags", m_wpaFlags, [](const QVariant& v) {
+        return v.toUInt();
+    });
+    apply("RsnFlags", m_rsnFlags, [](const QVariant& v) {
+        return v.toUInt();
+    });
+
+    if (dirty) {
+        emit changed();
+    }
+}
+
+void NmAccessPoint::watch() {
+    auto bus = QDBusConnection::systemBus();
+    if (!bus.isConnected()) {
+        return;
+    }
+
+    bus.connect(
+        QString::fromUtf8(kService),
+        m_path,
+        QString::fromUtf8(kPropsIface),
+        QStringLiteral("PropertiesChanged"),
+        this,
+        SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)));
+}
+
+void NmAccessPoint::handlePropertiesChanged(
+    const QString& iface, const QVariantMap& properties, const QStringList& invalidated) {
+    Q_UNUSED(invalidated);
+
+    if (iface == QString::fromUtf8(kApIface)) {
+        update(properties);
+    }
+}
 
 NmDevice::NmDevice(QString path, QObject* parent)
     : QObject(parent)
@@ -75,6 +226,44 @@ void NmDevice::setConnection(const QString& connection) {
 
     m_connection = connection;
     emit changed();
+}
+
+QList<NmAccessPoint*> NmDevice::accessPoints() const {
+    return m_accessPoints;
+}
+
+NmAccessPoint* NmDevice::accessPoint(const QString& path) const {
+    return m_apByPath.value(path);
+}
+
+void NmDevice::addAccessPoint(NmAccessPoint* accessPoint) {
+    if (accessPoint == nullptr || m_apByPath.contains(accessPoint->path())) {
+        return;
+    }
+
+    m_apByPath.insert(accessPoint->path(), accessPoint);
+    m_accessPoints.append(accessPoint);
+    emit accessPointsChanged();
+}
+
+bool NmDevice::retainAccessPoints(const QSet<QString>& keep) {
+    bool removed = false;
+
+    for (int i = m_accessPoints.size() - 1; i >= 0; i--) {
+        auto* accessPoint = m_accessPoints.at(i);
+        if (!keep.contains(accessPoint->path())) {
+            m_apByPath.remove(accessPoint->path());
+            m_accessPoints.removeAt(i);
+            accessPoint->deleteLater();
+            removed = true;
+        }
+    }
+
+    if (removed) {
+        emit accessPointsChanged();
+    }
+
+    return removed;
 }
 
 void NmDevice::update(const QVariantMap& props) {
@@ -160,7 +349,10 @@ void NetworkManager::handlePropertiesChanged(
     Q_UNUSED(properties);
     Q_UNUSED(invalidated);
 
-    if (iface == QString::fromUtf8(kManagerIface) || iface == QString::fromUtf8(kDeviceIface)) {
+    // Access points keep themselves up to date, so this only needs to catch
+    // membership changes on the wireless interface, not per-AP churn.
+    if (iface == QString::fromUtf8(kManagerIface) || iface == QString::fromUtf8(kDeviceIface) ||
+        iface == QString::fromUtf8(kWirelessIface)) {
         scheduleRefresh();
     }
 }
@@ -348,6 +540,10 @@ void NetworkManager::readDevice(const QString& path) {
             readConnection(path, connectionPath);
         }
 
+        if (device->type() == config::NetworkTransport::Wifi) {
+            readWireless(path);
+        }
+
         step(-1);
     });
 }
@@ -382,6 +578,101 @@ void NetworkManager::readConnection(const QString& devicePath, const QString& co
 
         step(-1);
     });
+}
+
+void NetworkManager::readWireless(const QString& devicePath) {
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    auto msg = QDBusMessage::createMethodCall(
+        QString::fromUtf8(kService), devicePath, QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(kWirelessIface);
+
+    step(1);
+    auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, devicePath](QDBusPendingCallWatcher* call) {
+        call->deleteLater();
+
+        const QDBusPendingReply<QVariantMap> reply = *call;
+        auto* device = m_byPath.value(devicePath);
+        if (reply.isError() || device == nullptr) {
+            if (reply.isError()) {
+                qCDebug(logNetworkManager) << "Skipping wireless" << devicePath << ":" << reply.error().message();
+            }
+            step(-1);
+            return;
+        }
+
+        const auto props = reply.value();
+
+        QList<QDBusObjectPath> paths;
+        props.value(QStringLiteral("AccessPoints")).value<QDBusArgument>() >> paths;
+
+        const auto activePath =
+            props.value(QStringLiteral("ActiveAccessPoint")).value<QDBusObjectPath>().path();
+
+        QSet<QString> seen;
+        for (const auto& path : paths) {
+            seen.insert(path.path());
+
+            auto* accessPoint = device->accessPoint(path.path());
+            if (accessPoint == nullptr) {
+                // Only new access points cost a read; the ones already held
+                // track their own properties.
+                readAccessPoint(devicePath, path.path());
+            } else {
+                accessPoint->setActive(path.path() == activePath);
+            }
+        }
+
+        device->retainAccessPoints(seen);
+
+        step(-1);
+    });
+}
+
+void NetworkManager::readAccessPoint(const QString& devicePath, const QString& accessPointPath) {
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    auto msg = QDBusMessage::createMethodCall(
+        QString::fromUtf8(kService), accessPointPath, QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(kApIface);
+
+    step(1);
+    auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
+    connect(
+        watcher,
+        &QDBusPendingCallWatcher::finished,
+        this,
+        [this, devicePath, accessPointPath](QDBusPendingCallWatcher* call) {
+            call->deleteLater();
+
+            const QDBusPendingReply<QVariantMap> reply = *call;
+            auto* device = m_byPath.value(devicePath);
+            if (reply.isError() || device == nullptr) {
+                if (reply.isError()) {
+                    // Access points come and go between scans; that's expected.
+                    qCDebug(logNetworkManager)
+                        << "Skipping access point" << accessPointPath << ":" << reply.error().message();
+                }
+                step(-1);
+                return;
+            }
+
+            if (device->accessPoint(accessPointPath) == nullptr) {
+                auto* accessPoint = new NmAccessPoint(accessPointPath, device);
+                accessPoint->update(reply.value());
+                accessPoint->watch();
+                device->addAccessPoint(accessPoint);
+            }
+
+            step(-1);
+        });
 }
 
 } // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkmanager.cpp
+++ b/plugin/src/Caelestia/Services/networkmanager.cpp
@@ -1,0 +1,331 @@
+#include "networkmanager.hpp"
+
+#include <qdbusargument.h>
+#include <qdbusextratypes.h>
+#include <qdbusmessage.h>
+#include <qdbuspendingcall.h>
+#include <qdbuspendingreply.h>
+#include <qloggingcategory.h>
+#include <qtimer.h>
+
+#include <utility>
+
+namespace caelestia::services {
+
+namespace {
+
+Q_LOGGING_CATEGORY(logNetworkManager, "caelestia.services.networkmanager", QtWarningMsg);
+
+constexpr const char* kService = "org.freedesktop.NetworkManager";
+constexpr const char* kManagerPath = "/org/freedesktop/NetworkManager";
+constexpr const char* kManagerIface = "org.freedesktop.NetworkManager";
+constexpr const char* kDeviceIface = "org.freedesktop.NetworkManager.Device";
+constexpr const char* kPropsIface = "org.freedesktop.DBus.Properties";
+
+// From NMDeviceType; only the two we classify are named.
+constexpr uint kDeviceTypeEthernet = 1;
+constexpr uint kDeviceTypeWifi = 2;
+
+// NM_DEVICE_STATE_ACTIVATED
+constexpr uint kStateActivated = 100;
+
+Transport transportForDeviceType(uint deviceType) {
+    switch (deviceType) {
+    case kDeviceTypeEthernet: return config::NetworkTransport::Ethernet;
+    case kDeviceTypeWifi: return config::NetworkTransport::Wifi;
+    default: return config::NetworkTransport::Other;
+    }
+}
+
+} // namespace
+
+NmDevice::NmDevice(QString path, QObject* parent)
+    : QObject(parent)
+    , m_path(std::move(path)) {}
+
+QString NmDevice::path() const {
+    return m_path;
+}
+
+QString NmDevice::interface() const {
+    return m_interface;
+}
+
+Transport NmDevice::type() const {
+    return m_type;
+}
+
+uint NmDevice::state() const {
+    return m_state;
+}
+
+bool NmDevice::connected() const {
+    return m_state == kStateActivated;
+}
+
+void NmDevice::update(const QVariantMap& props) {
+    const auto interface = props.value(QStringLiteral("Interface")).toString();
+    const auto type = transportForDeviceType(props.value(QStringLiteral("DeviceType")).toUInt());
+    const auto state = props.value(QStringLiteral("State")).toUInt();
+
+    if (interface == m_interface && type == m_type && state == m_state) {
+        return;
+    }
+
+    m_interface = interface;
+    m_type = type;
+    m_state = state;
+    emit changed();
+}
+
+NetworkManager::NetworkManager(QObject* parent)
+    : QObject(parent) {
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    // NetworkManager may not be up yet, or may restart under us.
+    bus->connect(
+        QStringLiteral("org.freedesktop.DBus"),
+        QStringLiteral("/org/freedesktop/DBus"),
+        QStringLiteral("org.freedesktop.DBus"),
+        QStringLiteral("NameOwnerChanged"),
+        QStringLiteral("sss"),
+        this,
+        SLOT(handleNameOwnerChanged(QString, QString, QString)));
+
+    watchObject(QString::fromUtf8(kManagerPath));
+    scheduleRefresh();
+}
+
+bool NetworkManager::ready() const {
+    return m_ready;
+}
+
+QList<NmDevice*> NetworkManager::devices() const {
+    return m_devices;
+}
+
+bool NetworkManager::wirelessEnabled() const {
+    return m_wirelessEnabled;
+}
+
+std::optional<QDBusConnection> NetworkManager::systemBus() {
+    auto bus = QDBusConnection::systemBus();
+    if (!bus.isConnected()) {
+        qCWarning(logNetworkManager) << "System bus unavailable";
+        return std::nullopt;
+    }
+    return bus;
+}
+
+void NetworkManager::watchObject(const QString& path) {
+    if (path.isEmpty() || path == QStringLiteral("/") || m_watched.contains(path)) {
+        return;
+    }
+
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    if (bus->connect(
+            QString::fromUtf8(kService),
+            path,
+            QString::fromUtf8(kPropsIface),
+            QStringLiteral("PropertiesChanged"),
+            this,
+            SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
+        m_watched.insert(path);
+    }
+}
+
+void NetworkManager::handlePropertiesChanged(
+    const QString& iface, const QVariantMap& properties, const QStringList& invalidated) {
+    Q_UNUSED(properties);
+    Q_UNUSED(invalidated);
+
+    if (iface == QString::fromUtf8(kManagerIface) || iface == QString::fromUtf8(kDeviceIface)) {
+        scheduleRefresh();
+    }
+}
+
+void NetworkManager::handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner) {
+    Q_UNUSED(oldOwner);
+
+    if (name != QString::fromUtf8(kService)) {
+        return;
+    }
+
+    m_watched.clear();
+
+    if (newOwner.isEmpty()) {
+        // NetworkManager went away; report nothing rather than stale devices.
+        clearDevices();
+        m_ready = false;
+        emit devicesChanged();
+        emit changed();
+        return;
+    }
+
+    // Fresh objects on the new owner, so the old subscriptions are worthless.
+    watchObject(QString::fromUtf8(kManagerPath));
+    scheduleRefresh();
+}
+
+void NetworkManager::clearDevices() {
+    for (auto* device : std::as_const(m_devices)) {
+        device->deleteLater();
+    }
+    m_devices.clear();
+    m_byPath.clear();
+}
+
+void NetworkManager::scheduleRefresh() {
+    if (m_refreshing) {
+        m_refreshQueued = true;
+        return;
+    }
+
+    m_refreshing = true;
+    QTimer::singleShot(0, this, [this]() {
+        refresh();
+    });
+}
+
+void NetworkManager::refresh() {
+    m_seen.clear();
+    m_listChanged = false;
+    m_pending = 0;
+
+    readManager();
+}
+
+// Each async read holds a reference; the result is published when the last one
+// lands, so a partial walk is never visible.
+void NetworkManager::step(int delta) {
+    m_pending += delta;
+    if (m_pending > 0) {
+        return;
+    }
+
+    finish();
+}
+
+void NetworkManager::finish() {
+    // Anything not seen by this walk is gone.
+    for (int i = m_devices.size() - 1; i >= 0; i--) {
+        auto* device = m_devices.at(i);
+        if (!m_seen.contains(device->path())) {
+            m_byPath.remove(device->path());
+            m_devices.removeAt(i);
+            device->deleteLater();
+            m_listChanged = true;
+        }
+    }
+
+    const bool wasReady = m_ready;
+    m_ready = true;
+
+    if (m_listChanged) {
+        emit devicesChanged();
+    }
+    if (!wasReady || m_listChanged) {
+        emit changed();
+    }
+
+    m_refreshing = false;
+    if (m_refreshQueued) {
+        m_refreshQueued = false;
+        scheduleRefresh();
+    }
+}
+
+void NetworkManager::readManager() {
+    auto bus = systemBus();
+    if (!bus) {
+        finish();
+        return;
+    }
+
+    auto msg = QDBusMessage::createMethodCall(
+        QString::fromUtf8(kService),
+        QString::fromUtf8(kManagerPath),
+        QString::fromUtf8(kPropsIface),
+        QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(kManagerIface);
+
+    step(1);
+    auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* call) {
+        call->deleteLater();
+
+        const QDBusPendingReply<QVariantMap> reply = *call;
+        if (reply.isError()) {
+            qCWarning(logNetworkManager) << "Failed to read NetworkManager properties:" << reply.error().message();
+            step(-1);
+            return;
+        }
+
+        const auto props = reply.value();
+
+        const auto wireless = props.value(QStringLiteral("WirelessEnabled")).toBool();
+        if (wireless != m_wirelessEnabled) {
+            m_wirelessEnabled = wireless;
+            emit changed();
+        }
+
+        const auto devices = props.value(QStringLiteral("Devices")).value<QDBusArgument>();
+        QList<QDBusObjectPath> paths;
+        devices >> paths;
+
+        for (const auto& path : paths) {
+            readDevice(path.path());
+        }
+
+        step(-1);
+    });
+}
+
+void NetworkManager::readDevice(const QString& path) {
+    auto bus = systemBus();
+    if (!bus || path.isEmpty() || path == QStringLiteral("/")) {
+        return;
+    }
+
+    watchObject(path);
+
+    auto msg = QDBusMessage::createMethodCall(
+        QString::fromUtf8(kService), path, QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(kDeviceIface);
+
+    step(1);
+    auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, path](QDBusPendingCallWatcher* call) {
+        call->deleteLater();
+
+        const QDBusPendingReply<QVariantMap> reply = *call;
+        if (reply.isError()) {
+            // Devices come and go while we're walking; that's expected.
+            qCDebug(logNetworkManager) << "Skipping device" << path << ":" << reply.error().message();
+            step(-1);
+            return;
+        }
+
+        m_seen.insert(path);
+
+        auto* device = m_byPath.value(path);
+        if (device == nullptr) {
+            device = new NmDevice(path, this);
+            m_byPath.insert(path, device);
+            m_devices.append(device);
+            m_listChanged = true;
+        }
+        device->update(reply.value());
+
+        step(-1);
+    });
+}
+
+} // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkmanager.cpp
+++ b/plugin/src/Caelestia/Services/networkmanager.cpp
@@ -350,28 +350,36 @@ void NmDevice::update(const QVariantMap& props) {
 }
 
 NetworkManager::NetworkManager(QObject* parent)
-    : QObject(parent) {
-    auto bus = systemBus();
-    if (!bus) {
-        return;
-    }
+    : NmWalker(QString::fromUtf8(kManagerPath), parent) {}
 
-    // NetworkManager may not be up yet, or may restart under us.
-    bus->connect(
-        QStringLiteral("org.freedesktop.DBus"),
-        QStringLiteral("/org/freedesktop/DBus"),
-        QStringLiteral("org.freedesktop.DBus"),
-        QStringLiteral("NameOwnerChanged"),
-        QStringLiteral("sss"),
-        this,
-        SLOT(handleNameOwnerChanged(QString, QString, QString)));
-
-    watchObject(QString::fromUtf8(kManagerPath));
-    scheduleRefresh();
+// Access points and the profile name track themselves, so this only needs to
+// catch the tree moving: devices appearing, changing state, or swapping their
+// wired link, wireless membership or ip config.
+bool NetworkManager::triggersRefresh(const QString& iface) const {
+    return iface == QString::fromUtf8(kManagerIface) || iface == QString::fromUtf8(kDeviceIface) ||
+        iface == QString::fromUtf8(kWiredIface) || iface == QString::fromUtf8(kWirelessIface) ||
+        iface == QString::fromUtf8(kIp4Iface);
 }
 
-bool NetworkManager::ready() const {
-    return m_ready;
+void NetworkManager::clearItems() {
+    for (auto* device : std::as_const(m_devices)) {
+        device->deleteLater();
+    }
+    m_devices.clear();
+    m_byPath.clear();
+}
+
+// Anything not seen by this walk is gone.
+void NetworkManager::pruneUnseen() {
+    for (int i = m_devices.size() - 1; i >= 0; i--) {
+        auto* device = m_devices.at(i);
+        if (!seen().contains(device->path())) {
+            m_byPath.remove(device->path());
+            m_devices.removeAt(i);
+            device->deleteLater();
+            setListChanged();
+        }
+    }
 }
 
 QQmlListProperty<NmDevice> NetworkManager::devices() {
@@ -382,144 +390,10 @@ bool NetworkManager::wirelessEnabled() const {
     return m_wirelessEnabled;
 }
 
-std::optional<QDBusConnection> NetworkManager::systemBus() {
-    auto bus = QDBusConnection::systemBus();
-    if (!bus.isConnected()) {
-        qCWarning(logNetworkManager) << "System bus unavailable";
-        return std::nullopt;
-    }
-    return bus;
-}
-
-void NetworkManager::watchObject(const QString& path) {
-    if (path.isEmpty() || path == QStringLiteral("/") || m_watched.contains(path)) {
-        return;
-    }
-
+void NetworkManager::readRoot() {
     auto bus = systemBus();
     if (!bus) {
-        return;
-    }
-
-    if (bus->connect(
-            QString::fromUtf8(kService),
-            path,
-            QString::fromUtf8(kPropsIface),
-            QStringLiteral("PropertiesChanged"),
-            this,
-            SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
-        m_watched.insert(path);
-    }
-}
-
-void NetworkManager::handlePropertiesChanged(
-    const QString& iface, const QVariantMap& properties, const QStringList& invalidated) {
-    Q_UNUSED(properties);
-    Q_UNUSED(invalidated);
-
-    // Access points keep themselves up to date, so this only needs to catch
-    // membership changes on the wireless interface, not per-AP churn.
-    if (iface == QString::fromUtf8(kManagerIface) || iface == QString::fromUtf8(kDeviceIface) ||
-        iface == QString::fromUtf8(kWirelessIface)) {
-        scheduleRefresh();
-    }
-}
-
-void NetworkManager::handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner) {
-    Q_UNUSED(oldOwner);
-
-    if (name != QString::fromUtf8(kService)) {
-        return;
-    }
-
-    m_watched.clear();
-
-    if (newOwner.isEmpty()) {
-        // NetworkManager went away; report nothing rather than stale devices.
-        clearDevices();
-        m_ready = false;
-        emit devicesChanged();
-        emit changed();
-        return;
-    }
-
-    // Fresh objects on the new owner, so the old subscriptions are worthless.
-    watchObject(QString::fromUtf8(kManagerPath));
-    scheduleRefresh();
-}
-
-void NetworkManager::clearDevices() {
-    for (auto* device : std::as_const(m_devices)) {
-        device->deleteLater();
-    }
-    m_devices.clear();
-    m_byPath.clear();
-}
-
-void NetworkManager::scheduleRefresh() {
-    if (m_refreshing) {
-        m_refreshQueued = true;
-        return;
-    }
-
-    m_refreshing = true;
-    QTimer::singleShot(0, this, [this]() {
-        refresh();
-    });
-}
-
-void NetworkManager::refresh() {
-    m_seen.clear();
-    m_listChanged = false;
-    m_pending = 0;
-
-    readManager();
-}
-
-// Each async read holds a reference; the result is published when the last one
-// lands, so a partial walk is never visible.
-void NetworkManager::step(int delta) {
-    m_pending += delta;
-    if (m_pending > 0) {
-        return;
-    }
-
-    finish();
-}
-
-void NetworkManager::finish() {
-    // Anything not seen by this walk is gone.
-    for (int i = m_devices.size() - 1; i >= 0; i--) {
-        auto* device = m_devices.at(i);
-        if (!m_seen.contains(device->path())) {
-            m_byPath.remove(device->path());
-            m_devices.removeAt(i);
-            device->deleteLater();
-            m_listChanged = true;
-        }
-    }
-
-    const bool wasReady = m_ready;
-    m_ready = true;
-
-    if (m_listChanged) {
-        emit devicesChanged();
-    }
-    if (!wasReady || m_listChanged) {
-        emit changed();
-    }
-
-    m_refreshing = false;
-    if (m_refreshQueued) {
-        m_refreshQueued = false;
-        scheduleRefresh();
-    }
-}
-
-void NetworkManager::readManager() {
-    auto bus = systemBus();
-    if (!bus) {
-        finish();
+        abandonWalk();
         return;
     }
 
@@ -587,14 +461,14 @@ void NetworkManager::readDevice(const QString& path) {
             return;
         }
 
-        m_seen.insert(path);
+        seen().insert(path);
 
         auto* device = m_byPath.value(path);
         if (device == nullptr) {
             device = new NmDevice(path, this);
             m_byPath.insert(path, device);
             m_devices.append(device);
-            m_listChanged = true;
+            setListChanged();
         }
         const auto props = reply.value();
         device->update(props);

--- a/plugin/src/Caelestia/Services/networkmanager.cpp
+++ b/plugin/src/Caelestia/Services/networkmanager.cpp
@@ -21,6 +21,7 @@ constexpr const char* kManagerPath = "/org/freedesktop/NetworkManager";
 constexpr const char* kManagerIface = "org.freedesktop.NetworkManager";
 constexpr const char* kDeviceIface = "org.freedesktop.NetworkManager.Device";
 constexpr const char* kActiveIface = "org.freedesktop.NetworkManager.Connection.Active";
+constexpr const char* kWiredIface = "org.freedesktop.NetworkManager.Device.Wired";
 constexpr const char* kWirelessIface = "org.freedesktop.NetworkManager.Device.Wireless";
 constexpr const char* kApIface = "org.freedesktop.NetworkManager.AccessPoint";
 constexpr const char* kIp4Iface = "org.freedesktop.NetworkManager.IP4Config";
@@ -235,6 +236,24 @@ QQmlListProperty<NmAccessPoint> NmDevice::accessPoints() {
 
 qlonglong NmDevice::lastScan() const {
     return m_lastScan;
+}
+
+bool NmDevice::carrier() const {
+    return m_carrier;
+}
+
+uint NmDevice::speed() const {
+    return m_speed;
+}
+
+void NmDevice::setWired(bool carrier, uint speed) {
+    if (carrier == m_carrier && speed == m_speed) {
+        return;
+    }
+
+    m_carrier = carrier;
+    m_speed = speed;
+    emit changed();
 }
 
 QString NmDevice::hwAddress() const {
@@ -589,7 +608,9 @@ void NetworkManager::readDevice(const QString& path) {
             readConnection(path, connectionPath);
         }
 
-        if (device->type() == config::NetworkTransport::Wifi) {
+        if (device->type() == config::NetworkTransport::Ethernet) {
+            readWired(path);
+        } else if (device->type() == config::NetworkTransport::Wifi) {
             readWireless(path);
         }
 
@@ -631,6 +652,39 @@ void NetworkManager::readConnection(const QString& devicePath, const QString& co
         if (device != nullptr) {
             device->setConnection(reply.isError() ? QString() : reply.value().variant().toString());
         }
+
+        step(-1);
+    });
+}
+
+void NetworkManager::readWired(const QString& devicePath) {
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    auto msg = QDBusMessage::createMethodCall(
+        QString::fromUtf8(kService), devicePath, QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(kWiredIface);
+
+    step(1);
+    auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, devicePath](QDBusPendingCallWatcher* call) {
+        call->deleteLater();
+
+        const QDBusPendingReply<QVariantMap> reply = *call;
+        auto* device = m_byPath.value(devicePath);
+        if (reply.isError() || device == nullptr) {
+            if (reply.isError()) {
+                qCDebug(logNetworkManager) << "Skipping wired" << devicePath << ":" << reply.error().message();
+            }
+            step(-1);
+            return;
+        }
+
+        const auto props = reply.value();
+        device->setWired(
+            props.value(QStringLiteral("Carrier")).toBool(), props.value(QStringLiteral("Speed")).toUInt());
 
         step(-1);
     });

--- a/plugin/src/Caelestia/Services/networkmanager.cpp
+++ b/plugin/src/Caelestia/Services/networkmanager.cpp
@@ -228,8 +228,8 @@ void NmDevice::setConnection(const QString& connection) {
     emit changed();
 }
 
-QList<NmAccessPoint*> NmDevice::accessPoints() const {
-    return m_accessPoints;
+QQmlListProperty<NmAccessPoint> NmDevice::accessPoints() {
+    return { this, &m_accessPoints };
 }
 
 qlonglong NmDevice::lastScan() const {
@@ -319,8 +319,8 @@ bool NetworkManager::ready() const {
     return m_ready;
 }
 
-QList<NmDevice*> NetworkManager::devices() const {
-    return m_devices;
+QQmlListProperty<NmDevice> NetworkManager::devices() {
+    return { this, &m_devices };
 }
 
 bool NetworkManager::wirelessEnabled() const {

--- a/plugin/src/Caelestia/Services/networkmanager.cpp
+++ b/plugin/src/Caelestia/Services/networkmanager.cpp
@@ -70,12 +70,9 @@ QString securityLabel(uint flags, uint wpaFlags, uint rsnFlags) {
 
 Transport transportForDeviceType(uint deviceType) {
     switch (deviceType) {
-    case kDeviceTypeEthernet:
-        return config::NetworkTransport::Ethernet;
-    case kDeviceTypeWifi:
-        return config::NetworkTransport::Wifi;
-    default:
-        return config::NetworkTransport::Other;
+    case kDeviceTypeEthernet: return config::NetworkTransport::Ethernet;
+    case kDeviceTypeWifi: return config::NetworkTransport::Wifi;
+    default: return config::NetworkTransport::Other;
     }
 }
 
@@ -178,8 +175,13 @@ void NmAccessPoint::watch() {
         return;
     }
 
-    bus.connect(QString::fromUtf8(kService), m_path, QString::fromUtf8(kPropsIface),
-        QStringLiteral("PropertiesChanged"), this, SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)));
+    bus.connect(
+        QString::fromUtf8(kService),
+        m_path,
+        QString::fromUtf8(kPropsIface),
+        QStringLiteral("PropertiesChanged"),
+        this,
+        SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)));
 }
 
 void NmAccessPoint::handlePropertiesChanged(
@@ -355,8 +357,13 @@ NetworkManager::NetworkManager(QObject* parent)
     }
 
     // NetworkManager may not be up yet, or may restart under us.
-    bus->connect(QStringLiteral("org.freedesktop.DBus"), QStringLiteral("/org/freedesktop/DBus"),
-        QStringLiteral("org.freedesktop.DBus"), QStringLiteral("NameOwnerChanged"), QStringLiteral("sss"), this,
+    bus->connect(
+        QStringLiteral("org.freedesktop.DBus"),
+        QStringLiteral("/org/freedesktop/DBus"),
+        QStringLiteral("org.freedesktop.DBus"),
+        QStringLiteral("NameOwnerChanged"),
+        QStringLiteral("sss"),
+        this,
         SLOT(handleNameOwnerChanged(QString, QString, QString)));
 
     watchObject(QString::fromUtf8(kManagerPath));
@@ -394,8 +401,12 @@ void NetworkManager::watchObject(const QString& path) {
         return;
     }
 
-    if (bus->connect(QString::fromUtf8(kService), path, QString::fromUtf8(kPropsIface),
-            QStringLiteral("PropertiesChanged"), this,
+    if (bus->connect(
+            QString::fromUtf8(kService),
+            path,
+            QString::fromUtf8(kPropsIface),
+            QStringLiteral("PropertiesChanged"),
+            this,
             SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
         m_watched.insert(path);
     }
@@ -512,8 +523,11 @@ void NetworkManager::readManager() {
         return;
     }
 
-    auto msg = QDBusMessage::createMethodCall(QString::fromUtf8(kService), QString::fromUtf8(kManagerPath),
-        QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
+    auto msg = QDBusMessage::createMethodCall(
+        QString::fromUtf8(kService),
+        QString::fromUtf8(kManagerPath),
+        QString::fromUtf8(kPropsIface),
+        QStringLiteral("GetAll"));
     msg << QString::fromUtf8(kManagerIface);
 
     step(1);
@@ -747,7 +761,10 @@ void NetworkManager::readAccessPoint(const QString& devicePath, const QString& a
 
     step(1);
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, this,
+    connect(
+        watcher,
+        &QDBusPendingCallWatcher::finished,
+        this,
         [this, devicePath, accessPointPath](QDBusPendingCallWatcher* call) {
             call->deleteLater();
 
@@ -794,7 +811,8 @@ void NetworkManager::readIp4Config(const QString& devicePath, const QString& con
         if (reply.isError() || device == nullptr) {
             if (reply.isError()) {
                 // Addresses come and go with the link; that's expected.
-                qCDebug(logNetworkManager) << "Skipping ip4 config for" << devicePath << ":" << reply.error().message();
+                qCDebug(logNetworkManager) << "Skipping ip4 config for" << devicePath << ":"
+                                           << reply.error().message();
             }
             step(-1);
             return;

--- a/plugin/src/Caelestia/Services/networkmanager.cpp
+++ b/plugin/src/Caelestia/Services/networkmanager.cpp
@@ -20,6 +20,7 @@ constexpr const char* kService = "org.freedesktop.NetworkManager";
 constexpr const char* kManagerPath = "/org/freedesktop/NetworkManager";
 constexpr const char* kManagerIface = "org.freedesktop.NetworkManager";
 constexpr const char* kDeviceIface = "org.freedesktop.NetworkManager.Device";
+constexpr const char* kActiveIface = "org.freedesktop.NetworkManager.Connection.Active";
 constexpr const char* kPropsIface = "org.freedesktop.DBus.Properties";
 
 // From NMDeviceType; only the two we classify are named.
@@ -61,6 +62,19 @@ uint NmDevice::state() const {
 
 bool NmDevice::connected() const {
     return m_state == kStateActivated;
+}
+
+QString NmDevice::connection() const {
+    return m_connection;
+}
+
+void NmDevice::setConnection(const QString& connection) {
+    if (connection == m_connection) {
+        return;
+    }
+
+    m_connection = connection;
+    emit changed();
 }
 
 void NmDevice::update(const QVariantMap& props) {
@@ -322,7 +336,49 @@ void NetworkManager::readDevice(const QString& path) {
             m_devices.append(device);
             m_listChanged = true;
         }
-        device->update(reply.value());
+        const auto props = reply.value();
+        device->update(props);
+
+        // The profile name isn't on the device, it's on whatever active
+        // connection is attached to it, so that's a second read.
+        const auto connectionPath = props.value(QStringLiteral("ActiveConnection")).value<QDBusObjectPath>().path();
+        if (connectionPath.isEmpty() || connectionPath == QStringLiteral("/")) {
+            device->setConnection(QString());
+        } else {
+            readConnection(path, connectionPath);
+        }
+
+        step(-1);
+    });
+}
+
+void NetworkManager::readConnection(const QString& devicePath, const QString& connectionPath) {
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    auto msg = QDBusMessage::createMethodCall(
+        QString::fromUtf8(kService), connectionPath, QString::fromUtf8(kPropsIface), QStringLiteral("Get"));
+    msg << QString::fromUtf8(kActiveIface) << QStringLiteral("Id");
+
+    step(1);
+    auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, devicePath](QDBusPendingCallWatcher* call) {
+        call->deleteLater();
+
+        const QDBusPendingReply<QDBusVariant> reply = *call;
+        if (reply.isError()) {
+            // Connections go down while we're walking; that's expected.
+            qCDebug(logNetworkManager) << "Skipping connection for" << devicePath << ":" << reply.error().message();
+        }
+
+        // Looked up again rather than captured: the walk may have dropped the
+        // device while this was in flight.
+        auto* device = m_byPath.value(devicePath);
+        if (device != nullptr) {
+            device->setConnection(reply.isError() ? QString() : reply.value().variant().toString());
+        }
 
         step(-1);
     });

--- a/plugin/src/Caelestia/Services/networkmanager.cpp
+++ b/plugin/src/Caelestia/Services/networkmanager.cpp
@@ -70,9 +70,12 @@ QString securityLabel(uint flags, uint wpaFlags, uint rsnFlags) {
 
 Transport transportForDeviceType(uint deviceType) {
     switch (deviceType) {
-    case kDeviceTypeEthernet: return config::NetworkTransport::Ethernet;
-    case kDeviceTypeWifi: return config::NetworkTransport::Wifi;
-    default: return config::NetworkTransport::Other;
+    case kDeviceTypeEthernet:
+        return config::NetworkTransport::Ethernet;
+    case kDeviceTypeWifi:
+        return config::NetworkTransport::Wifi;
+    default:
+        return config::NetworkTransport::Other;
     }
 }
 
@@ -175,13 +178,8 @@ void NmAccessPoint::watch() {
         return;
     }
 
-    bus.connect(
-        QString::fromUtf8(kService),
-        m_path,
-        QString::fromUtf8(kPropsIface),
-        QStringLiteral("PropertiesChanged"),
-        this,
-        SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)));
+    bus.connect(QString::fromUtf8(kService), m_path, QString::fromUtf8(kPropsIface),
+        QStringLiteral("PropertiesChanged"), this, SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)));
 }
 
 void NmAccessPoint::handlePropertiesChanged(
@@ -357,13 +355,8 @@ NetworkManager::NetworkManager(QObject* parent)
     }
 
     // NetworkManager may not be up yet, or may restart under us.
-    bus->connect(
-        QStringLiteral("org.freedesktop.DBus"),
-        QStringLiteral("/org/freedesktop/DBus"),
-        QStringLiteral("org.freedesktop.DBus"),
-        QStringLiteral("NameOwnerChanged"),
-        QStringLiteral("sss"),
-        this,
+    bus->connect(QStringLiteral("org.freedesktop.DBus"), QStringLiteral("/org/freedesktop/DBus"),
+        QStringLiteral("org.freedesktop.DBus"), QStringLiteral("NameOwnerChanged"), QStringLiteral("sss"), this,
         SLOT(handleNameOwnerChanged(QString, QString, QString)));
 
     watchObject(QString::fromUtf8(kManagerPath));
@@ -401,12 +394,8 @@ void NetworkManager::watchObject(const QString& path) {
         return;
     }
 
-    if (bus->connect(
-            QString::fromUtf8(kService),
-            path,
-            QString::fromUtf8(kPropsIface),
-            QStringLiteral("PropertiesChanged"),
-            this,
+    if (bus->connect(QString::fromUtf8(kService), path, QString::fromUtf8(kPropsIface),
+            QStringLiteral("PropertiesChanged"), this,
             SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
         m_watched.insert(path);
     }
@@ -523,11 +512,8 @@ void NetworkManager::readManager() {
         return;
     }
 
-    auto msg = QDBusMessage::createMethodCall(
-        QString::fromUtf8(kService),
-        QString::fromUtf8(kManagerPath),
-        QString::fromUtf8(kPropsIface),
-        QStringLiteral("GetAll"));
+    auto msg = QDBusMessage::createMethodCall(QString::fromUtf8(kService), QString::fromUtf8(kManagerPath),
+        QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
     msg << QString::fromUtf8(kManagerIface);
 
     step(1);
@@ -761,10 +747,7 @@ void NetworkManager::readAccessPoint(const QString& devicePath, const QString& a
 
     step(1);
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
-    connect(
-        watcher,
-        &QDBusPendingCallWatcher::finished,
-        this,
+    connect(watcher, &QDBusPendingCallWatcher::finished, this,
         [this, devicePath, accessPointPath](QDBusPendingCallWatcher* call) {
             call->deleteLater();
 
@@ -811,8 +794,7 @@ void NetworkManager::readIp4Config(const QString& devicePath, const QString& con
         if (reply.isError() || device == nullptr) {
             if (reply.isError()) {
                 // Addresses come and go with the link; that's expected.
-                qCDebug(logNetworkManager) << "Skipping ip4 config for" << devicePath << ":"
-                                           << reply.error().message();
+                qCDebug(logNetworkManager) << "Skipping ip4 config for" << devicePath << ":" << reply.error().message();
             }
             step(-1);
             return;

--- a/plugin/src/Caelestia/Services/networkmanager.cpp
+++ b/plugin/src/Caelestia/Services/networkmanager.cpp
@@ -23,6 +23,7 @@ constexpr const char* kDeviceIface = "org.freedesktop.NetworkManager.Device";
 constexpr const char* kActiveIface = "org.freedesktop.NetworkManager.Connection.Active";
 constexpr const char* kWirelessIface = "org.freedesktop.NetworkManager.Device.Wireless";
 constexpr const char* kApIface = "org.freedesktop.NetworkManager.AccessPoint";
+constexpr const char* kIp4Iface = "org.freedesktop.NetworkManager.IP4Config";
 constexpr const char* kPropsIface = "org.freedesktop.DBus.Properties";
 
 // From NMDeviceType; only the two we classify are named.
@@ -236,6 +237,39 @@ qlonglong NmDevice::lastScan() const {
     return m_lastScan;
 }
 
+QString NmDevice::hwAddress() const {
+    return m_hwAddress;
+}
+
+QString NmDevice::address() const {
+    return m_address;
+}
+
+int NmDevice::prefix() const {
+    return m_prefix;
+}
+
+QString NmDevice::gateway() const {
+    return m_gateway;
+}
+
+QStringList NmDevice::dns() const {
+    return m_dns;
+}
+
+void NmDevice::setIp4Config(const QString& address, int prefix, const QString& gateway, const QStringList& dns) {
+    if (address == m_address && prefix == m_prefix && gateway == m_gateway && dns == m_dns) {
+        return;
+    }
+
+    m_address = address;
+    m_prefix = prefix;
+    m_gateway = gateway;
+    m_dns = dns;
+
+    emit changed();
+}
+
 void NmDevice::setLastScan(qlonglong lastScan) {
     if (lastScan == m_lastScan) {
         return;
@@ -283,14 +317,16 @@ void NmDevice::update(const QVariantMap& props) {
     const auto interface = props.value(QStringLiteral("Interface")).toString();
     const auto type = transportForDeviceType(props.value(QStringLiteral("DeviceType")).toUInt());
     const auto state = props.value(QStringLiteral("State")).toUInt();
+    const auto hwAddress = props.value(QStringLiteral("HwAddress")).toString();
 
-    if (interface == m_interface && type == m_type && state == m_state) {
+    if (interface == m_interface && type == m_type && state == m_state && hwAddress == m_hwAddress) {
         return;
     }
 
     m_interface = interface;
     m_type = type;
     m_state = state;
+    m_hwAddress = hwAddress;
     emit changed();
 }
 
@@ -557,6 +593,13 @@ void NetworkManager::readDevice(const QString& path) {
             readWireless(path);
         }
 
+        const auto configPath = props.value(QStringLiteral("Ip4Config")).value<QDBusObjectPath>().path();
+        if (configPath.isEmpty() || configPath == QStringLiteral("/")) {
+            device->setIp4Config(QString(), 0, QString(), {});
+        } else {
+            readIp4Config(path, configPath);
+        }
+
         step(-1);
     });
 }
@@ -692,6 +735,65 @@ void NetworkManager::readAccessPoint(const QString& devicePath, const QString& a
 
             step(-1);
         });
+}
+
+void NetworkManager::readIp4Config(const QString& devicePath, const QString& configPath) {
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    auto msg = QDBusMessage::createMethodCall(
+        QString::fromUtf8(kService), configPath, QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(kIp4Iface);
+
+    step(1);
+    auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, devicePath](QDBusPendingCallWatcher* call) {
+        call->deleteLater();
+
+        const QDBusPendingReply<QVariantMap> reply = *call;
+        auto* device = m_byPath.value(devicePath);
+        if (reply.isError() || device == nullptr) {
+            if (reply.isError()) {
+                // Addresses come and go with the link; that's expected.
+                qCDebug(logNetworkManager) << "Skipping ip4 config for" << devicePath << ":"
+                                           << reply.error().message();
+            }
+            step(-1);
+            return;
+        }
+
+        const auto props = reply.value();
+
+        // AddressData and NameserverData are both aa{sv}; the older Addresses
+        // and Nameservers properties are packed uint32s and not worth reading.
+        QList<QVariantMap> addresses;
+        props.value(QStringLiteral("AddressData")).value<QDBusArgument>() >> addresses;
+
+        QString address;
+        int prefix = 0;
+        if (!addresses.isEmpty()) {
+            address = addresses.first().value(QStringLiteral("address")).toString();
+            prefix = addresses.first().value(QStringLiteral("prefix")).toInt();
+        }
+
+        QList<QVariantMap> nameservers;
+        props.value(QStringLiteral("NameserverData")).value<QDBusArgument>() >> nameservers;
+
+        QStringList dns;
+        dns.reserve(nameservers.size());
+        for (const auto& nameserver : std::as_const(nameservers)) {
+            const auto entry = nameserver.value(QStringLiteral("address")).toString();
+            if (!entry.isEmpty()) {
+                dns.append(entry);
+            }
+        }
+
+        device->setIp4Config(address, prefix, props.value(QStringLiteral("Gateway")).toString(), dns);
+
+        step(-1);
+    });
 }
 
 } // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkmanager.cpp
+++ b/plugin/src/Caelestia/Services/networkmanager.cpp
@@ -363,7 +363,7 @@ void NetworkManager::clearItems() {
 }
 
 // Anything not seen by this walk is gone.
-void NetworkManager::pruneUnseen() {
+void NetworkManager::publish() {
     for (qsizetype i = m_devices.size() - 1; i >= 0; i--) {
         auto* device = m_devices.at(i);
         if (!seen().contains(device->path())) {

--- a/plugin/src/Caelestia/Services/networkmanager.cpp
+++ b/plugin/src/Caelestia/Services/networkmanager.cpp
@@ -262,10 +262,6 @@ QString NmDevice::address() const {
     return m_address;
 }
 
-int NmDevice::prefix() const {
-    return m_prefix;
-}
-
 QString NmDevice::gateway() const {
     return m_gateway;
 }
@@ -274,13 +270,12 @@ QStringList NmDevice::dns() const {
     return m_dns;
 }
 
-void NmDevice::setIp4Config(const QString& address, int prefix, const QString& gateway, const QStringList& dns) {
-    if (address == m_address && prefix == m_prefix && gateway == m_gateway && dns == m_dns) {
+void NmDevice::setIp4Config(const QString& address, const QString& gateway, const QStringList& dns) {
+    if (address == m_address && gateway == m_gateway && dns == m_dns) {
         return;
     }
 
     m_address = address;
-    m_prefix = prefix;
     m_gateway = gateway;
     m_dns = dns;
 
@@ -486,7 +481,7 @@ void NetworkManager::readDevice(const QString& path) {
 
         const auto configPath = props.value(QStringLiteral("Ip4Config")).value<QDBusObjectPath>().path();
         if (configPath.isEmpty() || configPath == QStringLiteral("/")) {
-            device->setIp4Config(QString(), 0, QString(), {});
+            device->setIp4Config(QString(), QString(), {});
         } else {
             readIp4Config(path, configPath);
         }
@@ -697,10 +692,8 @@ void NetworkManager::readIp4Config(const QString& devicePath, const QString& con
         props.value(QStringLiteral("AddressData")).value<QDBusArgument>() >> addresses;
 
         QString address;
-        int prefix = 0;
         if (!addresses.isEmpty()) {
             address = addresses.first().value(QStringLiteral("address")).toString();
-            prefix = addresses.first().value(QStringLiteral("prefix")).toInt();
         }
 
         QList<QVariantMap> nameservers;
@@ -715,7 +708,7 @@ void NetworkManager::readIp4Config(const QString& devicePath, const QString& con
             }
         }
 
-        device->setIp4Config(address, prefix, props.value(QStringLiteral("Gateway")).toString(), dns);
+        device->setIp4Config(address, props.value(QStringLiteral("Gateway")).toString(), dns);
 
         step(-1);
     });

--- a/plugin/src/Caelestia/Services/networkmanager.cpp
+++ b/plugin/src/Caelestia/Services/networkmanager.cpp
@@ -605,7 +605,7 @@ void NetworkManager::readWireless(const QString& devicePath) {
             if (accessPoint == nullptr) {
                 // Only new access points cost a read; the ones already held
                 // track their own properties.
-                readAccessPoint(devicePath, path.path());
+                readAccessPoint(devicePath, path.path(), path.path() == activePath);
             } else {
                 accessPoint->setActive(path.path() == activePath);
             }
@@ -618,7 +618,7 @@ void NetworkManager::readWireless(const QString& devicePath) {
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
-void NetworkManager::readAccessPoint(const QString& devicePath, const QString& accessPointPath) {
+void NetworkManager::readAccessPoint(const QString& devicePath, const QString& accessPointPath, bool active) {
     auto bus = systemBus();
     if (!bus) {
         return;
@@ -631,7 +631,7 @@ void NetworkManager::readAccessPoint(const QString& devicePath, const QString& a
     step(1);
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this,
-        [this, devicePath, accessPointPath](QDBusPendingCallWatcher* call) {
+        [this, devicePath, accessPointPath, active](QDBusPendingCallWatcher* call) {
             call->deleteLater();
 
             const QDBusPendingReply<QVariantMap> reply = *call;
@@ -649,6 +649,7 @@ void NetworkManager::readAccessPoint(const QString& devicePath, const QString& a
             if (device->accessPoint(accessPointPath) == nullptr) {
                 auto* accessPoint = new NmAccessPoint(accessPointPath, device);
                 accessPoint->update(reply.value());
+                accessPoint->setActive(active);
                 accessPoint->watch();
                 device->addAccessPoint(accessPoint);
             }
@@ -663,6 +664,10 @@ void NetworkManager::readIp4Config(const QString& devicePath, const QString& con
     if (!bus) {
         return;
     }
+
+    // NetworkManager keeps the same config object across a DHCP renewal and
+    // edits it in place, so the device's own signal doesn't cover this.
+    watchObject(configPath);
 
     auto msg = QDBusMessage::createMethodCall(
         QString::fromUtf8(k_service), configPath, QString::fromUtf8(k_propsIface), QStringLiteral("GetAll"));

--- a/plugin/src/Caelestia/Services/networkmanager.hpp
+++ b/plugin/src/Caelestia/Services/networkmanager.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "networkwalker.hpp"
-
 #include <qhash.h>
 #include <qobject.h>
 #include <qqmlintegration.h>
@@ -12,6 +10,7 @@
 #include <qvariant.h>
 
 #include "config/enums.hpp"
+#include "networkwalker.hpp"
 
 namespace caelestia::services {
 
@@ -102,8 +101,8 @@ class NmDevice : public QObject {
     // This is what `nmcli device status` reported in its CONNECTION column.
     Q_PROPERTY(QString connection READ connection NOTIFY changed)
     // Only ever populated for wifi devices; empty for everything else.
-    Q_PROPERTY(QQmlListProperty<caelestia::services::NmAccessPoint> accessPoints READ accessPoints NOTIFY
-            accessPointsChanged)
+    Q_PROPERTY(
+        QQmlListProperty<caelestia::services::NmAccessPoint> accessPoints READ accessPoints NOTIFY accessPointsChanged)
     // Whether the link has a carrier, i.e. a cable is plugged in. Wired
     // devices only; false for everything else.
     Q_PROPERTY(bool carrier READ carrier NOTIFY changed)
@@ -207,7 +206,6 @@ public:
     [[nodiscard]] QQmlListProperty<NmDevice> devices();
     [[nodiscard]] bool wirelessEnabled() const;
 
-
 protected:
     void readRoot() override;
     [[nodiscard]] bool triggersRefresh(const QString& iface) const override;
@@ -222,14 +220,10 @@ private:
     void readIp4Config(const QString& devicePath, const QString& configPath);
     void readAccessPoint(const QString& devicePath, const QString& accessPointPath);
 
-
-
     bool m_wirelessEnabled = false;
 
     QList<NmDevice*> m_devices;
     QHash<QString, NmDevice*> m_byPath;
-
-
 };
 
 } // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkmanager.hpp
+++ b/plugin/src/Caelestia/Services/networkmanager.hpp
@@ -17,6 +17,69 @@ namespace caelestia::services {
 
 using Transport = config::NetworkTransport::Enum;
 
+// A wifi access point as NetworkManager sees it.
+//
+// Each one subscribes to its own D-Bus object. Signal strength changes
+// constantly, and routing every one of those through a full device walk would
+// cost far more than the update is worth.
+class NmAccessPoint : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("NmAccessPoint instances are owned by NetworkManager")
+
+    Q_PROPERTY(QString ssid READ ssid NOTIFY changed)
+    Q_PROPERTY(QString bssid READ bssid NOTIFY changed)
+    // Signal strength as a percentage.
+    Q_PROPERTY(int strength READ strength NOTIFY changed)
+    // Frequency in MHz.
+    Q_PROPERTY(int frequency READ frequency NOTIFY changed)
+    // Security label in the same shape nmcli printed, e.g. "WPA2" or "WPA1
+    // WPA2", empty on an open network.
+    Q_PROPERTY(QString security READ security NOTIFY changed)
+    Q_PROPERTY(bool isSecure READ isSecure NOTIFY changed)
+    // Whether this is the access point the device is currently associated with.
+    Q_PROPERTY(bool active READ active NOTIFY changed)
+
+public:
+    explicit NmAccessPoint(QString path, QObject* parent = nullptr);
+
+    [[nodiscard]] QString path() const;
+    [[nodiscard]] QString ssid() const;
+    [[nodiscard]] QString bssid() const;
+    [[nodiscard]] int strength() const;
+    [[nodiscard]] int frequency() const;
+    [[nodiscard]] QString security() const;
+    [[nodiscard]] bool isSecure() const;
+    [[nodiscard]] bool active() const;
+
+    // Merges a property map, which may be a full snapshot or just the keys a
+    // PropertiesChanged signal carried.
+    void update(const QVariantMap& props);
+    // Set apart from update(): which access point is active is a property of
+    // the device, not of the access point.
+    void setActive(bool active);
+
+    // Subscribes to this access point's own object on the system bus.
+    void watch();
+
+signals:
+    void changed();
+
+private slots:
+    void handlePropertiesChanged(const QString& iface, const QVariantMap& properties, const QStringList& invalidated);
+
+private:
+    QString m_path;
+    QString m_ssid;
+    QString m_bssid;
+    int m_strength = 0;
+    int m_frequency = 0;
+    uint m_flags = 0;
+    uint m_wpaFlags = 0;
+    uint m_rsnFlags = 0;
+    bool m_active = false;
+};
+
 // A network device as NetworkManager sees it.
 //
 // Held as an object rather than a plain value so consumers can bind to it and
@@ -38,6 +101,8 @@ class NmDevice : public QObject {
     // Name of the profile currently active on the device, empty when it's down.
     // This is what `nmcli device status` reported in its CONNECTION column.
     Q_PROPERTY(QString connection READ connection NOTIFY changed)
+    // Only ever populated for wifi devices; empty for everything else.
+    Q_PROPERTY(QList<caelestia::services::NmAccessPoint*> accessPoints READ accessPoints NOTIFY accessPointsChanged)
 
 public:
     explicit NmDevice(QString path, QObject* parent = nullptr);
@@ -49,9 +114,17 @@ public:
     [[nodiscard]] bool connected() const;
     [[nodiscard]] QString connection() const;
 
+    [[nodiscard]] QList<NmAccessPoint*> accessPoints() const;
+    [[nodiscard]] NmAccessPoint* accessPoint(const QString& path) const;
+
     // Set apart from update(): the name lives on the device's active connection
     // object, which is a second read.
     void setConnection(const QString& connection);
+
+    void addAccessPoint(NmAccessPoint* accessPoint);
+    // Drops any access point whose path isn't in `keep`. Returns whether the
+    // list changed.
+    bool retainAccessPoints(const QSet<QString>& keep);
 
     // Applies a property map read from the device's D-Bus object, emitting
     // changed() only when something actually differs.
@@ -59,6 +132,7 @@ public:
 
 signals:
     void changed();
+    void accessPointsChanged();
 
 private:
     QString m_path;
@@ -66,6 +140,9 @@ private:
     Transport m_type = config::NetworkTransport::None;
     uint m_state = 0;
     QString m_connection;
+
+    QList<NmAccessPoint*> m_accessPoints;
+    QHash<QString, NmAccessPoint*> m_apByPath;
 };
 
 // NetworkManager's device list, read over D-Bus.
@@ -109,6 +186,8 @@ private:
     void readManager();
     void readDevice(const QString& path);
     void readConnection(const QString& devicePath, const QString& connectionPath);
+    void readWireless(const QString& devicePath);
+    void readAccessPoint(const QString& devicePath, const QString& accessPointPath);
     void step(int delta);
     void finish();
 

--- a/plugin/src/Caelestia/Services/networkmanager.hpp
+++ b/plugin/src/Caelestia/Services/networkmanager.hpp
@@ -105,6 +105,11 @@ class NmDevice : public QObject {
     // Only ever populated for wifi devices; empty for everything else.
     Q_PROPERTY(QQmlListProperty<caelestia::services::NmAccessPoint> accessPoints READ accessPoints NOTIFY
             accessPointsChanged)
+    // Whether the link has a carrier, i.e. a cable is plugged in. Wired
+    // devices only; false for everything else.
+    Q_PROPERTY(bool carrier READ carrier NOTIFY changed)
+    // Negotiated link speed in Mb/s, 0 when there is no link. Wired only.
+    Q_PROPERTY(uint speed READ speed NOTIFY changed)
     // Hardware address of the device, e.g. "00:1a:2b:3c:4d:5e".
     Q_PROPERTY(QString hwAddress READ hwAddress NOTIFY changed)
     // Active IPv4 configuration. Empty while the device is down.
@@ -130,6 +135,8 @@ public:
 
     [[nodiscard]] QQmlListProperty<NmAccessPoint> accessPoints();
     [[nodiscard]] qlonglong lastScan() const;
+    [[nodiscard]] bool carrier() const;
+    [[nodiscard]] uint speed() const;
     [[nodiscard]] QString hwAddress() const;
     [[nodiscard]] QString address() const;
     [[nodiscard]] int prefix() const;
@@ -141,6 +148,9 @@ public:
     // object, which is a second read.
     void setConnection(const QString& connection);
     void setLastScan(qlonglong lastScan);
+    // Set apart from update(): both live on the device's Wired interface,
+    // which is a second read.
+    void setWired(bool carrier, uint speed);
     // Set apart from update(): the addresses live on the device's Ip4Config
     // object, which is a second read.
     void setIp4Config(const QString& address, int prefix, const QString& gateway, const QStringList& dns);
@@ -165,6 +175,8 @@ private:
     uint m_state = 0;
     QString m_connection;
     qlonglong m_lastScan = -1;
+    bool m_carrier = false;
+    uint m_speed = 0;
     QString m_hwAddress;
     QString m_address;
     int m_prefix = 0;
@@ -216,6 +228,7 @@ private:
     void readManager();
     void readDevice(const QString& path);
     void readConnection(const QString& devicePath, const QString& connectionPath);
+    void readWired(const QString& devicePath);
     void readWireless(const QString& devicePath);
     void readIp4Config(const QString& devicePath, const QString& configPath);
     void readAccessPoint(const QString& devicePath, const QString& accessPointPath);

--- a/plugin/src/Caelestia/Services/networkmanager.hpp
+++ b/plugin/src/Caelestia/Services/networkmanager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <qdbusconnection.h>
+#include "networkwalker.hpp"
+
 #include <qhash.h>
 #include <qobject.h>
 #include <qqmlintegration.h>
@@ -9,8 +10,6 @@
 #include <qstring.h>
 #include <qstringlist.h>
 #include <qvariant.h>
-
-#include <optional>
 
 #include "config/enums.hpp"
 
@@ -194,66 +193,43 @@ private:
 // to poll and no output format to depend on. Actions - connecting, forgetting,
 // scanning - stay on the CLI, where there's nothing to parse and nothing to
 // gain from moving them.
-class NetworkManager : public QObject {
+class NetworkManager : public NmWalker {
     Q_OBJECT
     QML_ELEMENT
     QML_SINGLETON
 
-    // False until a full snapshot has been read, so consumers can hold their
-    // previous behaviour rather than acting on an empty list.
-    Q_PROPERTY(bool ready READ ready NOTIFY changed)
-    Q_PROPERTY(QQmlListProperty<caelestia::services::NmDevice> devices READ devices NOTIFY devicesChanged)
+    Q_PROPERTY(QQmlListProperty<caelestia::services::NmDevice> devices READ devices NOTIFY itemsChanged)
     Q_PROPERTY(bool wirelessEnabled READ wirelessEnabled NOTIFY changed)
 
 public:
     explicit NetworkManager(QObject* parent = nullptr);
 
-    [[nodiscard]] bool ready() const;
     [[nodiscard]] QQmlListProperty<NmDevice> devices();
     [[nodiscard]] bool wirelessEnabled() const;
 
-signals:
-    void changed();
-    void devicesChanged();
 
-private slots:
-    void handlePropertiesChanged(const QString& iface, const QVariantMap& properties, const QStringList& invalidated);
-    void handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner);
+protected:
+    void readRoot() override;
+    [[nodiscard]] bool triggersRefresh(const QString& iface) const override;
+    void pruneUnseen() override;
+    void clearItems() override;
 
 private:
-    // One walk at a time, with a flag to run again after. Bursts of signals
-    // would otherwise each start their own and land out of order.
-    void scheduleRefresh();
-    void refresh();
-    void readManager();
     void readDevice(const QString& path);
     void readConnection(const QString& devicePath, const QString& connectionPath);
     void readWired(const QString& devicePath);
     void readWireless(const QString& devicePath);
     void readIp4Config(const QString& devicePath, const QString& configPath);
     void readAccessPoint(const QString& devicePath, const QString& accessPointPath);
-    void step(int delta);
-    void finish();
 
-    void watchObject(const QString& path);
-    void clearDevices();
 
-    [[nodiscard]] static std::optional<QDBusConnection> systemBus();
 
-    bool m_ready = false;
     bool m_wirelessEnabled = false;
 
     QList<NmDevice*> m_devices;
     QHash<QString, NmDevice*> m_byPath;
-    // Paths seen by the walk in progress; anything missing afterwards has gone.
-    QSet<QString> m_seen;
 
-    bool m_refreshing = false;
-    bool m_refreshQueued = false;
-    int m_pending = 0;
-    bool m_listChanged = false;
 
-    QSet<QString> m_watched;
 };
 
 } // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkmanager.hpp
+++ b/plugin/src/Caelestia/Services/networkmanager.hpp
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <qdbusconnection.h>
+#include <qhash.h>
+#include <qobject.h>
+#include <qqmlintegration.h>
+#include <qset.h>
+#include <qstring.h>
+#include <qstringlist.h>
+#include <qvariant.h>
+
+#include <optional>
+
+#include "config/enums.hpp"
+
+namespace caelestia::services {
+
+using Transport = config::NetworkTransport::Enum;
+
+// A network device as NetworkManager sees it.
+//
+// Held as an object rather than a plain value so consumers can bind to it and
+// have their bindings re-run when NetworkManager reports a change, instead of
+// the list being replaced wholesale on every refresh.
+class NmDevice : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("NmDevice instances are owned by NetworkManager")
+
+    Q_PROPERTY(QString interface READ interface NOTIFY changed)
+    Q_PROPERTY(caelestia::config::NetworkTransport::Enum type READ type NOTIFY changed)
+    Q_PROPERTY(uint state READ state NOTIFY changed)
+    // Whether the device has finished activating, i.e. NM state 100.
+    Q_PROPERTY(bool connected READ connected NOTIFY changed)
+
+public:
+    explicit NmDevice(QString path, QObject* parent = nullptr);
+
+    [[nodiscard]] QString path() const;
+    [[nodiscard]] QString interface() const;
+    [[nodiscard]] Transport type() const;
+    [[nodiscard]] uint state() const;
+    [[nodiscard]] bool connected() const;
+
+    // Applies a property map read from the device's D-Bus object, emitting
+    // changed() only when something actually differs.
+    void update(const QVariantMap& props);
+
+signals:
+    void changed();
+
+private:
+    QString m_path;
+    QString m_interface;
+    Transport m_type = config::NetworkTransport::None;
+    uint m_state = 0;
+};
+
+// NetworkManager's device list, read over D-Bus.
+//
+// This replaces parsing `nmcli device status`: devices arrive as typed
+// properties and NetworkManager signals when they change, so there's nothing
+// to poll and no output format to depend on. Actions - connecting, forgetting,
+// scanning - stay on the CLI, where there's nothing to parse and nothing to
+// gain from moving them.
+class NetworkManager : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+    // False until a full snapshot has been read, so consumers can hold their
+    // previous behaviour rather than acting on an empty list.
+    Q_PROPERTY(bool ready READ ready NOTIFY changed)
+    Q_PROPERTY(QList<caelestia::services::NmDevice*> devices READ devices NOTIFY devicesChanged)
+    Q_PROPERTY(bool wirelessEnabled READ wirelessEnabled NOTIFY changed)
+
+public:
+    explicit NetworkManager(QObject* parent = nullptr);
+
+    [[nodiscard]] bool ready() const;
+    [[nodiscard]] QList<NmDevice*> devices() const;
+    [[nodiscard]] bool wirelessEnabled() const;
+
+signals:
+    void changed();
+    void devicesChanged();
+
+private slots:
+    void handlePropertiesChanged(const QString& iface, const QVariantMap& properties, const QStringList& invalidated);
+    void handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner);
+
+private:
+    // One walk at a time, with a flag to run again after. Bursts of signals
+    // would otherwise each start their own and land out of order.
+    void scheduleRefresh();
+    void refresh();
+    void readManager();
+    void readDevice(const QString& path);
+    void step(int delta);
+    void finish();
+
+    void watchObject(const QString& path);
+    void clearDevices();
+
+    [[nodiscard]] static std::optional<QDBusConnection> systemBus();
+
+    bool m_ready = false;
+    bool m_wirelessEnabled = false;
+
+    QList<NmDevice*> m_devices;
+    QHash<QString, NmDevice*> m_byPath;
+    // Paths seen by the walk in progress; anything missing afterwards has gone.
+    QSet<QString> m_seen;
+
+    bool m_refreshing = false;
+    bool m_refreshQueued = false;
+    int m_pending = 0;
+    bool m_listChanged = false;
+
+    QSet<QString> m_watched;
+};
+
+} // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkmanager.hpp
+++ b/plugin/src/Caelestia/Services/networkmanager.hpp
@@ -4,6 +4,7 @@
 #include <qhash.h>
 #include <qobject.h>
 #include <qqmlintegration.h>
+#include <qqmllist.h>
 #include <qset.h>
 #include <qstring.h>
 #include <qstringlist.h>
@@ -102,7 +103,8 @@ class NmDevice : public QObject {
     // This is what `nmcli device status` reported in its CONNECTION column.
     Q_PROPERTY(QString connection READ connection NOTIFY changed)
     // Only ever populated for wifi devices; empty for everything else.
-    Q_PROPERTY(QList<caelestia::services::NmAccessPoint*> accessPoints READ accessPoints NOTIFY accessPointsChanged)
+    Q_PROPERTY(QQmlListProperty<caelestia::services::NmAccessPoint> accessPoints READ accessPoints NOTIFY
+            accessPointsChanged)
     // Boot time in milliseconds at which the device last finished a scan, or -1
     // if it never has. NetworkManager publishes no scanning flag, so this
     // moving is the only signal that a scan finished. Wifi devices only.
@@ -118,7 +120,7 @@ public:
     [[nodiscard]] bool connected() const;
     [[nodiscard]] QString connection() const;
 
-    [[nodiscard]] QList<NmAccessPoint*> accessPoints() const;
+    [[nodiscard]] QQmlListProperty<NmAccessPoint> accessPoints();
     [[nodiscard]] qlonglong lastScan() const;
     [[nodiscard]] NmAccessPoint* accessPoint(const QString& path) const;
 
@@ -167,14 +169,14 @@ class NetworkManager : public QObject {
     // False until a full snapshot has been read, so consumers can hold their
     // previous behaviour rather than acting on an empty list.
     Q_PROPERTY(bool ready READ ready NOTIFY changed)
-    Q_PROPERTY(QList<caelestia::services::NmDevice*> devices READ devices NOTIFY devicesChanged)
+    Q_PROPERTY(QQmlListProperty<caelestia::services::NmDevice> devices READ devices NOTIFY devicesChanged)
     Q_PROPERTY(bool wirelessEnabled READ wirelessEnabled NOTIFY changed)
 
 public:
     explicit NetworkManager(QObject* parent = nullptr);
 
     [[nodiscard]] bool ready() const;
-    [[nodiscard]] QList<NmDevice*> devices() const;
+    [[nodiscard]] QQmlListProperty<NmDevice> devices();
     [[nodiscard]] bool wirelessEnabled() const;
 
 signals:

--- a/plugin/src/Caelestia/Services/networkmanager.hpp
+++ b/plugin/src/Caelestia/Services/networkmanager.hpp
@@ -105,6 +105,14 @@ class NmDevice : public QObject {
     // Only ever populated for wifi devices; empty for everything else.
     Q_PROPERTY(QQmlListProperty<caelestia::services::NmAccessPoint> accessPoints READ accessPoints NOTIFY
             accessPointsChanged)
+    // Hardware address of the device, e.g. "00:1a:2b:3c:4d:5e".
+    Q_PROPERTY(QString hwAddress READ hwAddress NOTIFY changed)
+    // Active IPv4 configuration. Empty while the device is down.
+    Q_PROPERTY(QString address READ address NOTIFY changed)
+    // Prefix length of the address, e.g. 24, or 0 when there is none.
+    Q_PROPERTY(int prefix READ prefix NOTIFY changed)
+    Q_PROPERTY(QString gateway READ gateway NOTIFY changed)
+    Q_PROPERTY(QStringList dns READ dns NOTIFY changed)
     // Boot time in milliseconds at which the device last finished a scan, or -1
     // if it never has. NetworkManager publishes no scanning flag, so this
     // moving is the only signal that a scan finished. Wifi devices only.
@@ -122,12 +130,20 @@ public:
 
     [[nodiscard]] QQmlListProperty<NmAccessPoint> accessPoints();
     [[nodiscard]] qlonglong lastScan() const;
+    [[nodiscard]] QString hwAddress() const;
+    [[nodiscard]] QString address() const;
+    [[nodiscard]] int prefix() const;
+    [[nodiscard]] QString gateway() const;
+    [[nodiscard]] QStringList dns() const;
     [[nodiscard]] NmAccessPoint* accessPoint(const QString& path) const;
 
     // Set apart from update(): the name lives on the device's active connection
     // object, which is a second read.
     void setConnection(const QString& connection);
     void setLastScan(qlonglong lastScan);
+    // Set apart from update(): the addresses live on the device's Ip4Config
+    // object, which is a second read.
+    void setIp4Config(const QString& address, int prefix, const QString& gateway, const QStringList& dns);
 
     void addAccessPoint(NmAccessPoint* accessPoint);
     // Drops any access point whose path isn't in `keep`. Returns whether the
@@ -149,6 +165,11 @@ private:
     uint m_state = 0;
     QString m_connection;
     qlonglong m_lastScan = -1;
+    QString m_hwAddress;
+    QString m_address;
+    int m_prefix = 0;
+    QString m_gateway;
+    QStringList m_dns;
 
     QList<NmAccessPoint*> m_accessPoints;
     QHash<QString, NmAccessPoint*> m_apByPath;
@@ -196,6 +217,7 @@ private:
     void readDevice(const QString& path);
     void readConnection(const QString& devicePath, const QString& connectionPath);
     void readWireless(const QString& devicePath);
+    void readIp4Config(const QString& devicePath, const QString& configPath);
     void readAccessPoint(const QString& devicePath, const QString& accessPointPath);
     void step(int delta);
     void finish();

--- a/plugin/src/Caelestia/Services/networkmanager.hpp
+++ b/plugin/src/Caelestia/Services/networkmanager.hpp
@@ -28,10 +28,16 @@ class NmDevice : public QObject {
     QML_UNCREATABLE("NmDevice instances are owned by NetworkManager")
 
     Q_PROPERTY(QString interface READ interface NOTIFY changed)
+    // Alias for `interface`. QML consumers have always called this `iface`, and
+    // aliasing here is cheaper than renaming it at every use site.
+    Q_PROPERTY(QString iface READ interface NOTIFY changed)
     Q_PROPERTY(caelestia::config::NetworkTransport::Enum type READ type NOTIFY changed)
     Q_PROPERTY(uint state READ state NOTIFY changed)
     // Whether the device has finished activating, i.e. NM state 100.
     Q_PROPERTY(bool connected READ connected NOTIFY changed)
+    // Name of the profile currently active on the device, empty when it's down.
+    // This is what `nmcli device status` reported in its CONNECTION column.
+    Q_PROPERTY(QString connection READ connection NOTIFY changed)
 
 public:
     explicit NmDevice(QString path, QObject* parent = nullptr);
@@ -41,6 +47,11 @@ public:
     [[nodiscard]] Transport type() const;
     [[nodiscard]] uint state() const;
     [[nodiscard]] bool connected() const;
+    [[nodiscard]] QString connection() const;
+
+    // Set apart from update(): the name lives on the device's active connection
+    // object, which is a second read.
+    void setConnection(const QString& connection);
 
     // Applies a property map read from the device's D-Bus object, emitting
     // changed() only when something actually differs.
@@ -54,6 +65,7 @@ private:
     QString m_interface;
     Transport m_type = config::NetworkTransport::None;
     uint m_state = 0;
+    QString m_connection;
 };
 
 // NetworkManager's device list, read over D-Bus.
@@ -96,6 +108,7 @@ private:
     void refresh();
     void readManager();
     void readDevice(const QString& path);
+    void readConnection(const QString& devicePath, const QString& connectionPath);
     void step(int delta);
     void finish();
 

--- a/plugin/src/Caelestia/Services/networkmanager.hpp
+++ b/plugin/src/Caelestia/Services/networkmanager.hpp
@@ -103,6 +103,10 @@ class NmDevice : public QObject {
     Q_PROPERTY(QString connection READ connection NOTIFY changed)
     // Only ever populated for wifi devices; empty for everything else.
     Q_PROPERTY(QList<caelestia::services::NmAccessPoint*> accessPoints READ accessPoints NOTIFY accessPointsChanged)
+    // Boot time in milliseconds at which the device last finished a scan, or -1
+    // if it never has. NetworkManager publishes no scanning flag, so this
+    // moving is the only signal that a scan finished. Wifi devices only.
+    Q_PROPERTY(qlonglong lastScan READ lastScan NOTIFY changed)
 
 public:
     explicit NmDevice(QString path, QObject* parent = nullptr);
@@ -115,11 +119,13 @@ public:
     [[nodiscard]] QString connection() const;
 
     [[nodiscard]] QList<NmAccessPoint*> accessPoints() const;
+    [[nodiscard]] qlonglong lastScan() const;
     [[nodiscard]] NmAccessPoint* accessPoint(const QString& path) const;
 
     // Set apart from update(): the name lives on the device's active connection
     // object, which is a second read.
     void setConnection(const QString& connection);
+    void setLastScan(qlonglong lastScan);
 
     void addAccessPoint(NmAccessPoint* accessPoint);
     // Drops any access point whose path isn't in `keep`. Returns whether the
@@ -140,6 +146,7 @@ private:
     Transport m_type = config::NetworkTransport::None;
     uint m_state = 0;
     QString m_connection;
+    qlonglong m_lastScan = -1;
 
     QList<NmAccessPoint*> m_accessPoints;
     QHash<QString, NmAccessPoint*> m_apByPath;

--- a/plugin/src/Caelestia/Services/networkmanager.hpp
+++ b/plugin/src/Caelestia/Services/networkmanager.hpp
@@ -89,9 +89,7 @@ class NmDevice : public QObject {
     QML_ELEMENT
     QML_UNCREATABLE("NmDevice instances are owned by NetworkManager")
 
-    Q_PROPERTY(QString interface READ interface NOTIFY changed)
-    // Alias for `interface`. QML consumers have always called this `iface`, and
-    // aliasing here is cheaper than renaming it at every use site.
+    // `iface` in QML; the getter keeps the C++ spelling.
     Q_PROPERTY(QString iface READ interface NOTIFY changed)
     Q_PROPERTY(caelestia::config::NetworkTransport::Enum type READ type NOTIFY changed)
     Q_PROPERTY(uint state READ state NOTIFY changed)
@@ -112,8 +110,6 @@ class NmDevice : public QObject {
     Q_PROPERTY(QString hwAddress READ hwAddress NOTIFY changed)
     // Active IPv4 configuration. Empty while the device is down.
     Q_PROPERTY(QString address READ address NOTIFY changed)
-    // Prefix length of the address, e.g. 24, or 0 when there is none.
-    Q_PROPERTY(int prefix READ prefix NOTIFY changed)
     Q_PROPERTY(QString gateway READ gateway NOTIFY changed)
     Q_PROPERTY(QStringList dns READ dns NOTIFY changed)
     // Boot time in milliseconds at which the device last finished a scan, or -1
@@ -137,7 +133,6 @@ public:
     [[nodiscard]] uint speed() const;
     [[nodiscard]] QString hwAddress() const;
     [[nodiscard]] QString address() const;
-    [[nodiscard]] int prefix() const;
     [[nodiscard]] QString gateway() const;
     [[nodiscard]] QStringList dns() const;
     [[nodiscard]] NmAccessPoint* accessPoint(const QString& path) const;
@@ -151,7 +146,7 @@ public:
     void setWired(bool carrier, uint speed);
     // Set apart from update(): the addresses live on the device's Ip4Config
     // object, which is a second read.
-    void setIp4Config(const QString& address, int prefix, const QString& gateway, const QStringList& dns);
+    void setIp4Config(const QString& address, const QString& gateway, const QStringList& dns);
 
     void addAccessPoint(NmAccessPoint* accessPoint);
     // Drops any access point whose path isn't in `keep`. Returns whether the
@@ -177,7 +172,6 @@ private:
     uint m_speed = 0;
     QString m_hwAddress;
     QString m_address;
-    int m_prefix = 0;
     QString m_gateway;
     QStringList m_dns;
 

--- a/plugin/src/Caelestia/Services/networkmanager.hpp
+++ b/plugin/src/Caelestia/Services/networkmanager.hpp
@@ -212,7 +212,7 @@ private:
     void readWired(const QString& devicePath);
     void readWireless(const QString& devicePath);
     void readIp4Config(const QString& devicePath, const QString& configPath);
-    void readAccessPoint(const QString& devicePath, const QString& accessPointPath);
+    void readAccessPoint(const QString& devicePath, const QString& accessPointPath, bool active);
 
     bool m_wirelessEnabled = false;
 

--- a/plugin/src/Caelestia/Services/networkmanager.hpp
+++ b/plugin/src/Caelestia/Services/networkmanager.hpp
@@ -203,7 +203,7 @@ public:
 protected:
     void readRoot() override;
     [[nodiscard]] bool triggersRefresh(const QString& iface) const override;
-    void pruneUnseen() override;
+    void publish() override;
     void clearItems() override;
 
 private:

--- a/plugin/src/Caelestia/Services/networkprofiles.cpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.cpp
@@ -260,12 +260,13 @@ void NetworkProfiles::readRoot() {
         QList<QDBusObjectPath> paths;
         connections >> paths;
 
-        for (const auto& path : paths) {
+        for (const auto& path : std::as_const(paths)) {
             readProfile(path.path(), Read::Walk);
         }
 
         step(-1);
     });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 void NetworkProfiles::readProfile(const QString& path, Read read) {
@@ -327,6 +328,7 @@ void NetworkProfiles::readProfile(const QString& path, Read read) {
 
         step(-1);
     });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 } // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkprofiles.cpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.cpp
@@ -17,17 +17,17 @@ namespace {
 
 Q_LOGGING_CATEGORY(logNetworkProfiles, "caelestia.services.networkprofiles", QtWarningMsg);
 
-constexpr const char* kService = "org.freedesktop.NetworkManager";
-constexpr const char* kSettingsPath = "/org/freedesktop/NetworkManager/Settings";
-constexpr const char* kSettingsIface = "org.freedesktop.NetworkManager.Settings";
-constexpr const char* kConnectionIface = "org.freedesktop.NetworkManager.Settings.Connection";
-constexpr const char* kPropsIface = "org.freedesktop.DBus.Properties";
+constexpr const char* k_service = "org.freedesktop.NetworkManager";
+constexpr const char* k_settingsPath = "/org/freedesktop/NetworkManager/Settings";
+constexpr const char* k_settingsIface = "org.freedesktop.NetworkManager.Settings";
+constexpr const char* k_connectionIface = "org.freedesktop.NetworkManager.Settings.Connection";
+constexpr const char* k_propsIface = "org.freedesktop.DBus.Properties";
 
 // Setting group names, as NetworkManager keys them in GetSettings.
-constexpr const char* kGroupConnection = "connection";
-constexpr const char* kGroupWireless = "802-11-wireless";
-constexpr const char* kGroupWirelessSecurity = "802-11-wireless-security";
-constexpr const char* kGroupIpv4 = "ipv4";
+constexpr const char* k_groupConnection = "connection";
+constexpr const char* k_groupWireless = "802-11-wireless";
+constexpr const char* k_groupWirelessSecurity = "802-11-wireless-security";
+constexpr const char* k_groupIpv4 = "ipv4";
 
 // An `ay` inside a variant arrives as a byte array on most paths, but as a
 // nested argument on some, so both are worth handling.
@@ -61,10 +61,10 @@ QStringList packedDnsToStrings(const QVariant& value) {
     dns.reserve(packed.size());
     for (const auto address : std::as_const(packed)) {
         dns.append(QStringLiteral("%1.%2.%3.%4")
-                       .arg(address & 0xff)
-                       .arg((address >> 8) & 0xff)
-                       .arg((address >> 16) & 0xff)
-                       .arg((address >> 24) & 0xff));
+                .arg(address & 0xff)
+                .arg((address >> 8) & 0xff)
+                .arg((address >> 16) & 0xff)
+                .arg((address >> 24) & 0xff));
     }
     return dns;
 }
@@ -124,10 +124,10 @@ bool NmConnection::ipv4IgnoreAutoDns() const {
 }
 
 void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
-    const auto connection = settings.value(QString::fromUtf8(kGroupConnection));
-    const auto wireless = settings.value(QString::fromUtf8(kGroupWireless));
-    const auto security = settings.value(QString::fromUtf8(kGroupWirelessSecurity));
-    const auto ipv4 = settings.value(QString::fromUtf8(kGroupIpv4));
+    const auto connection = settings.value(QString::fromUtf8(k_groupConnection));
+    const auto wireless = settings.value(QString::fromUtf8(k_groupWireless));
+    const auto security = settings.value(QString::fromUtf8(k_groupWirelessSecurity));
+    const auto ipv4 = settings.value(QString::fromUtf8(k_groupIpv4));
 
     const auto id = connection.value(QStringLiteral("id")).toString();
     const auto uuid = connection.value(QStringLiteral("uuid")).toString();
@@ -157,8 +157,8 @@ void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
     // dns-data is what NetworkManager publishes now; dns is the deprecated
     // packed form, still sent by older daemons.
     const auto dnsData = ipv4.find(QStringLiteral("dns-data"));
-    const auto ipv4Dns = dnsData == ipv4.end() ? packedDnsToStrings(ipv4.value(QStringLiteral("dns")))
-                                               : dnsData.value().toStringList();
+    const auto ipv4Dns =
+        dnsData == ipv4.end() ? packedDnsToStrings(ipv4.value(QStringLiteral("dns"))) : dnsData.value().toStringList();
 
     if (id == m_id && uuid == m_uuid && type == m_type && ssid == m_ssid && keyMgmt == m_keyMgmt &&
         autoconnect == m_autoconnect && ipv4Method == m_ipv4Method && ipv4Address == m_ipv4Address &&
@@ -187,13 +187,8 @@ void NmConnection::watch() {
         return;
     }
 
-    bus.connect(
-        QString::fromUtf8(kService),
-        m_path,
-        QString::fromUtf8(kConnectionIface),
-        QStringLiteral("Updated"),
-        this,
-        SLOT(handleUpdated()));
+    bus.connect(QString::fromUtf8(k_service), m_path, QString::fromUtf8(k_connectionIface), QStringLiteral("Updated"),
+        this, SLOT(handleUpdated()));
 }
 
 void NmConnection::handleUpdated() {
@@ -201,7 +196,7 @@ void NmConnection::handleUpdated() {
 }
 
 NetworkProfiles::NetworkProfiles(QObject* parent)
-    : NmWalker(QString::fromUtf8(kSettingsPath), parent) {
+    : NmWalker(QString::fromUtf8(k_settingsPath), parent) {
     // GetSettings returns a{sa{sv}}, which needs registering before QtDBus will
     // demarshal it into a nested map.
     qDBusRegisterMetaType<QMap<QString, QVariantMap>>();
@@ -210,7 +205,7 @@ NetworkProfiles::NetworkProfiles(QObject* parent)
 // Profiles re-read themselves when edited, so this only needs to catch
 // profiles being added or removed.
 bool NetworkProfiles::triggersRefresh(const QString& iface) const {
-    return iface == QString::fromUtf8(kSettingsIface);
+    return iface == QString::fromUtf8(k_settingsIface);
 }
 
 void NetworkProfiles::clearItems() {
@@ -223,7 +218,7 @@ void NetworkProfiles::clearItems() {
 
 // Anything not seen by this walk is gone.
 void NetworkProfiles::pruneUnseen() {
-    for (int i = m_profiles.size() - 1; i >= 0; i--) {
+    for (qsizetype i = m_profiles.size() - 1; i >= 0; i--) {
         auto* profile = m_profiles.at(i);
         if (!seen().contains(profile->path())) {
             m_byPath.remove(profile->path());
@@ -245,12 +240,9 @@ void NetworkProfiles::readRoot() {
         return;
     }
 
-    auto msg = QDBusMessage::createMethodCall(
-        QString::fromUtf8(kService),
-        QString::fromUtf8(kSettingsPath),
-        QString::fromUtf8(kPropsIface),
-        QStringLiteral("GetAll"));
-    msg << QString::fromUtf8(kSettingsIface);
+    auto msg = QDBusMessage::createMethodCall(QString::fromUtf8(k_service), QString::fromUtf8(k_settingsPath),
+        QString::fromUtf8(k_propsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(k_settingsIface);
 
     step(1);
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
@@ -283,7 +275,7 @@ void NetworkProfiles::readProfile(const QString& path, Read read) {
     }
 
     auto msg = QDBusMessage::createMethodCall(
-        QString::fromUtf8(kService), path, QString::fromUtf8(kConnectionIface), QStringLiteral("GetSettings"));
+        QString::fromUtf8(k_service), path, QString::fromUtf8(k_connectionIface), QStringLiteral("GetSettings"));
 
     const auto walk = read == Read::Walk;
     if (walk) {

--- a/plugin/src/Caelestia/Services/networkprofiles.cpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.cpp
@@ -27,6 +27,7 @@ constexpr const char* kPropsIface = "org.freedesktop.DBus.Properties";
 constexpr const char* kGroupConnection = "connection";
 constexpr const char* kGroupWireless = "802-11-wireless";
 constexpr const char* kGroupWirelessSecurity = "802-11-wireless-security";
+constexpr const char* kGroupIpv4 = "ipv4";
 
 // An `ay` inside a variant arrives as a byte array on most paths, but as a
 // nested argument on some, so both are worth handling.
@@ -42,6 +43,30 @@ QString byteArrayToString(const QVariant& value) {
     }
 
     return {};
+}
+
+// The legacy ipv4.dns is an array of in_addr values, i.e. already in network
+// byte order, so the low byte is the first octet. NetworkManager publishes
+// dns-data alongside it as plain strings and prefers that; this is only for
+// older daemons that send the packed form.
+QStringList packedDnsToStrings(const QVariant& value) {
+    if (!value.canConvert<QDBusArgument>()) {
+        return {};
+    }
+
+    QList<uint> packed;
+    value.value<QDBusArgument>() >> packed;
+
+    QStringList dns;
+    dns.reserve(packed.size());
+    for (const auto address : std::as_const(packed)) {
+        dns.append(QStringLiteral("%1.%2.%3.%4")
+                       .arg(address & 0xff)
+                       .arg((address >> 8) & 0xff)
+                       .arg((address >> 16) & 0xff)
+                       .arg((address >> 24) & 0xff));
+    }
+    return dns;
 }
 
 } // namespace
@@ -78,10 +103,31 @@ bool NmConnection::autoconnect() const {
     return m_autoconnect;
 }
 
+QString NmConnection::ipv4Method() const {
+    return m_ipv4Method;
+}
+
+QString NmConnection::ipv4Address() const {
+    return m_ipv4Address;
+}
+
+QString NmConnection::ipv4Gateway() const {
+    return m_ipv4Gateway;
+}
+
+QStringList NmConnection::ipv4Dns() const {
+    return m_ipv4Dns;
+}
+
+bool NmConnection::ipv4IgnoreAutoDns() const {
+    return m_ipv4IgnoreAutoDns;
+}
+
 void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
     const auto connection = settings.value(QString::fromUtf8(kGroupConnection));
     const auto wireless = settings.value(QString::fromUtf8(kGroupWireless));
     const auto security = settings.value(QString::fromUtf8(kGroupWirelessSecurity));
+    const auto ipv4 = settings.value(QString::fromUtf8(kGroupIpv4));
 
     const auto id = connection.value(QStringLiteral("id")).toString();
     const auto uuid = connection.value(QStringLiteral("uuid")).toString();
@@ -94,8 +140,29 @@ void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
     const auto autoconnectValue = connection.find(QStringLiteral("autoconnect"));
     const auto autoconnect = autoconnectValue == connection.end() ? true : autoconnectValue.value().toBool();
 
+    const auto ipv4Method = ipv4.value(QStringLiteral("method")).toString();
+    const auto ipv4Gateway = ipv4.value(QStringLiteral("gateway")).toString();
+    const auto ipv4IgnoreAutoDns = ipv4.value(QStringLiteral("ignore-auto-dns")).toBool();
+
+    QList<QVariantMap> addresses;
+    ipv4.value(QStringLiteral("address-data")).value<QDBusArgument>() >> addresses;
+
+    QString ipv4Address;
+    if (!addresses.isEmpty()) {
+        ipv4Address = QStringLiteral("%1/%2")
+                          .arg(addresses.first().value(QStringLiteral("address")).toString())
+                          .arg(addresses.first().value(QStringLiteral("prefix")).toInt());
+    }
+
+    // dns-data is what NetworkManager publishes now; dns is the deprecated
+    // packed form, still sent by older daemons.
+    const auto dnsData = ipv4.find(QStringLiteral("dns-data"));
+    const auto ipv4Dns = dnsData == ipv4.end() ? packedDnsToStrings(ipv4.value(QStringLiteral("dns")))
+                                               : dnsData.value().toStringList();
+
     if (id == m_id && uuid == m_uuid && type == m_type && ssid == m_ssid && keyMgmt == m_keyMgmt &&
-        autoconnect == m_autoconnect) {
+        autoconnect == m_autoconnect && ipv4Method == m_ipv4Method && ipv4Address == m_ipv4Address &&
+        ipv4Gateway == m_ipv4Gateway && ipv4Dns == m_ipv4Dns && ipv4IgnoreAutoDns == m_ipv4IgnoreAutoDns) {
         return;
     }
 
@@ -105,6 +172,11 @@ void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
     m_ssid = ssid;
     m_keyMgmt = keyMgmt;
     m_autoconnect = autoconnect;
+    m_ipv4Method = ipv4Method;
+    m_ipv4Address = ipv4Address;
+    m_ipv4Gateway = ipv4Gateway;
+    m_ipv4Dns = ipv4Dns;
+    m_ipv4IgnoreAutoDns = ipv4IgnoreAutoDns;
 
     emit changed();
 }

--- a/plugin/src/Caelestia/Services/networkprofiles.cpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.cpp
@@ -201,104 +201,19 @@ void NmConnection::handleUpdated() {
 }
 
 NetworkProfiles::NetworkProfiles(QObject* parent)
-    : QObject(parent) {
+    : NmWalker(QString::fromUtf8(kSettingsPath), parent) {
     // GetSettings returns a{sa{sv}}, which needs registering before QtDBus will
     // demarshal it into a nested map.
     qDBusRegisterMetaType<QMap<QString, QVariantMap>>();
-
-    auto bus = systemBus();
-    if (!bus) {
-        return;
-    }
-
-    // NetworkManager may not be up yet, or may restart under us.
-    bus->connect(
-        QStringLiteral("org.freedesktop.DBus"),
-        QStringLiteral("/org/freedesktop/DBus"),
-        QStringLiteral("org.freedesktop.DBus"),
-        QStringLiteral("NameOwnerChanged"),
-        QStringLiteral("sss"),
-        this,
-        SLOT(handleNameOwnerChanged(QString, QString, QString)));
-
-    watchObject(QString::fromUtf8(kSettingsPath));
-    scheduleRefresh();
 }
 
-bool NetworkProfiles::ready() const {
-    return m_ready;
+// Profiles re-read themselves when edited, so this only needs to catch
+// profiles being added or removed.
+bool NetworkProfiles::triggersRefresh(const QString& iface) const {
+    return iface == QString::fromUtf8(kSettingsIface);
 }
 
-QQmlListProperty<NmConnection> NetworkProfiles::profiles() {
-    return { this, &m_profiles };
-}
-
-std::optional<QDBusConnection> NetworkProfiles::systemBus() {
-    auto bus = QDBusConnection::systemBus();
-    if (!bus.isConnected()) {
-        qCWarning(logNetworkProfiles) << "System bus unavailable";
-        return std::nullopt;
-    }
-    return bus;
-}
-
-void NetworkProfiles::watchObject(const QString& path) {
-    if (path.isEmpty() || path == QStringLiteral("/") || m_watched.contains(path)) {
-        return;
-    }
-
-    auto bus = systemBus();
-    if (!bus) {
-        return;
-    }
-
-    if (bus->connect(
-            QString::fromUtf8(kService),
-            path,
-            QString::fromUtf8(kPropsIface),
-            QStringLiteral("PropertiesChanged"),
-            this,
-            SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
-        m_watched.insert(path);
-    }
-}
-
-void NetworkProfiles::handlePropertiesChanged(
-    const QString& iface, const QVariantMap& properties, const QStringList& invalidated) {
-    Q_UNUSED(properties);
-    Q_UNUSED(invalidated);
-
-    // Profiles re-read themselves when edited, so this only needs to catch
-    // profiles being added or removed.
-    if (iface == QString::fromUtf8(kSettingsIface)) {
-        scheduleRefresh();
-    }
-}
-
-void NetworkProfiles::handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner) {
-    Q_UNUSED(oldOwner);
-
-    if (name != QString::fromUtf8(kService)) {
-        return;
-    }
-
-    m_watched.clear();
-
-    if (newOwner.isEmpty()) {
-        // NetworkManager went away; report nothing rather than stale profiles.
-        clearProfiles();
-        m_ready = false;
-        emit profilesChanged();
-        emit changed();
-        return;
-    }
-
-    // Fresh objects on the new owner, so the old subscriptions are worthless.
-    watchObject(QString::fromUtf8(kSettingsPath));
-    scheduleRefresh();
-}
-
-void NetworkProfiles::clearProfiles() {
+void NetworkProfiles::clearItems() {
     for (auto* profile : std::as_const(m_profiles)) {
         profile->deleteLater();
     }
@@ -306,70 +221,27 @@ void NetworkProfiles::clearProfiles() {
     m_byPath.clear();
 }
 
-void NetworkProfiles::scheduleRefresh() {
-    if (m_refreshing) {
-        m_refreshQueued = true;
-        return;
-    }
-
-    m_refreshing = true;
-    QTimer::singleShot(0, this, [this]() {
-        refresh();
-    });
-}
-
-void NetworkProfiles::refresh() {
-    m_seen.clear();
-    m_listChanged = false;
-    m_pending = 0;
-
-    readSettings();
-}
-
-// Each async read holds a reference; the result is published when the last one
-// lands, so a partial walk is never visible.
-void NetworkProfiles::step(int delta) {
-    m_pending += delta;
-    if (m_pending > 0) {
-        return;
-    }
-
-    finish();
-}
-
-void NetworkProfiles::finish() {
-    // Anything not seen by this walk is gone.
+// Anything not seen by this walk is gone.
+void NetworkProfiles::pruneUnseen() {
     for (int i = m_profiles.size() - 1; i >= 0; i--) {
         auto* profile = m_profiles.at(i);
-        if (!m_seen.contains(profile->path())) {
+        if (!seen().contains(profile->path())) {
             m_byPath.remove(profile->path());
             m_profiles.removeAt(i);
             profile->deleteLater();
-            m_listChanged = true;
+            setListChanged();
         }
-    }
-
-    const bool wasReady = m_ready;
-    m_ready = true;
-
-    if (m_listChanged) {
-        emit profilesChanged();
-    }
-    if (!wasReady || m_listChanged) {
-        emit changed();
-    }
-
-    m_refreshing = false;
-    if (m_refreshQueued) {
-        m_refreshQueued = false;
-        scheduleRefresh();
     }
 }
 
-void NetworkProfiles::readSettings() {
+QQmlListProperty<NmConnection> NetworkProfiles::profiles() {
+    return { this, &m_profiles };
+}
+
+void NetworkProfiles::readRoot() {
     auto bus = systemBus();
     if (!bus) {
-        finish();
+        abandonWalk();
         return;
     }
 
@@ -397,14 +269,14 @@ void NetworkProfiles::readSettings() {
         connections >> paths;
 
         for (const auto& path : paths) {
-            readProfile(path.path());
+            readProfile(path.path(), Read::Walk);
         }
 
         step(-1);
     });
 }
 
-void NetworkProfiles::readProfile(const QString& path) {
+void NetworkProfiles::readProfile(const QString& path, Read read) {
     auto bus = systemBus();
     if (!bus) {
         return;
@@ -413,34 +285,50 @@ void NetworkProfiles::readProfile(const QString& path) {
     auto msg = QDBusMessage::createMethodCall(
         QString::fromUtf8(kService), path, QString::fromUtf8(kConnectionIface), QStringLiteral("GetSettings"));
 
-    step(1);
+    const auto walk = read == Read::Walk;
+    if (walk) {
+        step(1);
+    }
+
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, path](QDBusPendingCallWatcher* call) {
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, path, walk](QDBusPendingCallWatcher* call) {
         call->deleteLater();
 
         const QDBusPendingReply<QMap<QString, QVariantMap>> reply = *call;
         if (reply.isError()) {
-            // Profiles get deleted while a walk is in flight; that's expected.
+            // Profiles get deleted while a read is in flight; that's expected.
             qCDebug(logNetworkProfiles) << "Skipping profile" << path << ":" << reply.error().message();
-            step(-1);
+            if (walk) {
+                step(-1);
+            }
             return;
         }
 
-        m_seen.insert(path);
-
         auto* profile = m_byPath.value(path);
+
+        if (!walk) {
+            // A reread only refreshes what's already held. If the profile has
+            // gone, the walk that noticed will deal with it.
+            if (profile != nullptr) {
+                profile->update(reply.value());
+            }
+            return;
+        }
+
+        seen().insert(path);
+
         if (profile == nullptr) {
             profile = new NmConnection(path, this);
             profile->watch();
-            // An edit only affects the one profile, so re-read it rather than
-            // walking everything.
+            // An edit only affects the one profile, so re-read that one rather
+            // than walking everything.
             connect(profile, &NmConnection::needsReread, this, [this, path]() {
-                readProfile(path);
+                readProfile(path, Read::Detached);
             });
 
             m_byPath.insert(path, profile);
             m_profiles.append(profile);
-            m_listChanged = true;
+            setListChanged();
         }
 
         profile->update(reply.value());

--- a/plugin/src/Caelestia/Services/networkprofiles.cpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.cpp
@@ -61,10 +61,10 @@ QStringList packedDnsToStrings(const QVariant& value) {
     dns.reserve(packed.size());
     for (const auto address : std::as_const(packed)) {
         dns.append(QStringLiteral("%1.%2.%3.%4")
-                .arg(address & 0xff)
-                .arg((address >> 8) & 0xff)
-                .arg((address >> 16) & 0xff)
-                .arg((address >> 24) & 0xff));
+                       .arg(address & 0xff)
+                       .arg((address >> 8) & 0xff)
+                       .arg((address >> 16) & 0xff)
+                       .arg((address >> 24) & 0xff));
     }
     return dns;
 }
@@ -157,8 +157,8 @@ void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
     // dns-data is what NetworkManager publishes now; dns is the deprecated
     // packed form, still sent by older daemons.
     const auto dnsData = ipv4.find(QStringLiteral("dns-data"));
-    const auto ipv4Dns =
-        dnsData == ipv4.end() ? packedDnsToStrings(ipv4.value(QStringLiteral("dns"))) : dnsData.value().toStringList();
+    const auto ipv4Dns = dnsData == ipv4.end() ? packedDnsToStrings(ipv4.value(QStringLiteral("dns")))
+                                               : dnsData.value().toStringList();
 
     if (id == m_id && uuid == m_uuid && type == m_type && ssid == m_ssid && keyMgmt == m_keyMgmt &&
         autoconnect == m_autoconnect && ipv4Method == m_ipv4Method && ipv4Address == m_ipv4Address &&
@@ -187,8 +187,13 @@ void NmConnection::watch() {
         return;
     }
 
-    bus.connect(QString::fromUtf8(kService), m_path, QString::fromUtf8(kConnectionIface), QStringLiteral("Updated"),
-        this, SLOT(handleUpdated()));
+    bus.connect(
+        QString::fromUtf8(kService),
+        m_path,
+        QString::fromUtf8(kConnectionIface),
+        QStringLiteral("Updated"),
+        this,
+        SLOT(handleUpdated()));
 }
 
 void NmConnection::handleUpdated() {
@@ -207,8 +212,13 @@ NetworkProfiles::NetworkProfiles(QObject* parent)
     }
 
     // NetworkManager may not be up yet, or may restart under us.
-    bus->connect(QStringLiteral("org.freedesktop.DBus"), QStringLiteral("/org/freedesktop/DBus"),
-        QStringLiteral("org.freedesktop.DBus"), QStringLiteral("NameOwnerChanged"), QStringLiteral("sss"), this,
+    bus->connect(
+        QStringLiteral("org.freedesktop.DBus"),
+        QStringLiteral("/org/freedesktop/DBus"),
+        QStringLiteral("org.freedesktop.DBus"),
+        QStringLiteral("NameOwnerChanged"),
+        QStringLiteral("sss"),
+        this,
         SLOT(handleNameOwnerChanged(QString, QString, QString)));
 
     watchObject(QString::fromUtf8(kSettingsPath));
@@ -242,8 +252,12 @@ void NetworkProfiles::watchObject(const QString& path) {
         return;
     }
 
-    if (bus->connect(QString::fromUtf8(kService), path, QString::fromUtf8(kPropsIface),
-            QStringLiteral("PropertiesChanged"), this,
+    if (bus->connect(
+            QString::fromUtf8(kService),
+            path,
+            QString::fromUtf8(kPropsIface),
+            QStringLiteral("PropertiesChanged"),
+            this,
             SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
         m_watched.insert(path);
     }
@@ -359,8 +373,11 @@ void NetworkProfiles::readSettings() {
         return;
     }
 
-    auto msg = QDBusMessage::createMethodCall(QString::fromUtf8(kService), QString::fromUtf8(kSettingsPath),
-        QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
+    auto msg = QDBusMessage::createMethodCall(
+        QString::fromUtf8(kService),
+        QString::fromUtf8(kSettingsPath),
+        QString::fromUtf8(kPropsIface),
+        QStringLiteral("GetAll"));
     msg << QString::fromUtf8(kSettingsIface);
 
     step(1);

--- a/plugin/src/Caelestia/Services/networkprofiles.cpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.cpp
@@ -61,10 +61,10 @@ QStringList packedDnsToStrings(const QVariant& value) {
     dns.reserve(packed.size());
     for (const auto address : std::as_const(packed)) {
         dns.append(QStringLiteral("%1.%2.%3.%4")
-                       .arg(address & 0xff)
-                       .arg((address >> 8) & 0xff)
-                       .arg((address >> 16) & 0xff)
-                       .arg((address >> 24) & 0xff));
+                .arg(address & 0xff)
+                .arg((address >> 8) & 0xff)
+                .arg((address >> 16) & 0xff)
+                .arg((address >> 24) & 0xff));
     }
     return dns;
 }
@@ -157,8 +157,8 @@ void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
     // dns-data is what NetworkManager publishes now; dns is the deprecated
     // packed form, still sent by older daemons.
     const auto dnsData = ipv4.find(QStringLiteral("dns-data"));
-    const auto ipv4Dns = dnsData == ipv4.end() ? packedDnsToStrings(ipv4.value(QStringLiteral("dns")))
-                                               : dnsData.value().toStringList();
+    const auto ipv4Dns =
+        dnsData == ipv4.end() ? packedDnsToStrings(ipv4.value(QStringLiteral("dns"))) : dnsData.value().toStringList();
 
     if (id == m_id && uuid == m_uuid && type == m_type && ssid == m_ssid && keyMgmt == m_keyMgmt &&
         autoconnect == m_autoconnect && ipv4Method == m_ipv4Method && ipv4Address == m_ipv4Address &&
@@ -187,13 +187,8 @@ void NmConnection::watch() {
         return;
     }
 
-    bus.connect(
-        QString::fromUtf8(kService),
-        m_path,
-        QString::fromUtf8(kConnectionIface),
-        QStringLiteral("Updated"),
-        this,
-        SLOT(handleUpdated()));
+    bus.connect(QString::fromUtf8(kService), m_path, QString::fromUtf8(kConnectionIface), QStringLiteral("Updated"),
+        this, SLOT(handleUpdated()));
 }
 
 void NmConnection::handleUpdated() {
@@ -212,13 +207,8 @@ NetworkProfiles::NetworkProfiles(QObject* parent)
     }
 
     // NetworkManager may not be up yet, or may restart under us.
-    bus->connect(
-        QStringLiteral("org.freedesktop.DBus"),
-        QStringLiteral("/org/freedesktop/DBus"),
-        QStringLiteral("org.freedesktop.DBus"),
-        QStringLiteral("NameOwnerChanged"),
-        QStringLiteral("sss"),
-        this,
+    bus->connect(QStringLiteral("org.freedesktop.DBus"), QStringLiteral("/org/freedesktop/DBus"),
+        QStringLiteral("org.freedesktop.DBus"), QStringLiteral("NameOwnerChanged"), QStringLiteral("sss"), this,
         SLOT(handleNameOwnerChanged(QString, QString, QString)));
 
     watchObject(QString::fromUtf8(kSettingsPath));
@@ -252,12 +242,8 @@ void NetworkProfiles::watchObject(const QString& path) {
         return;
     }
 
-    if (bus->connect(
-            QString::fromUtf8(kService),
-            path,
-            QString::fromUtf8(kPropsIface),
-            QStringLiteral("PropertiesChanged"),
-            this,
+    if (bus->connect(QString::fromUtf8(kService), path, QString::fromUtf8(kPropsIface),
+            QStringLiteral("PropertiesChanged"), this,
             SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
         m_watched.insert(path);
     }
@@ -373,11 +359,8 @@ void NetworkProfiles::readSettings() {
         return;
     }
 
-    auto msg = QDBusMessage::createMethodCall(
-        QString::fromUtf8(kService),
-        QString::fromUtf8(kSettingsPath),
-        QString::fromUtf8(kPropsIface),
-        QStringLiteral("GetAll"));
+    auto msg = QDBusMessage::createMethodCall(QString::fromUtf8(kService), QString::fromUtf8(kSettingsPath),
+        QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
     msg << QString::fromUtf8(kSettingsIface);
 
     step(1);

--- a/plugin/src/Caelestia/Services/networkprofiles.cpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.cpp
@@ -1,0 +1,380 @@
+#include "networkprofiles.hpp"
+
+#include <qdbusargument.h>
+#include <qdbusextratypes.h>
+#include <qdbusmessage.h>
+#include <qdbusmetatype.h>
+#include <qdbuspendingcall.h>
+#include <qdbuspendingreply.h>
+#include <qloggingcategory.h>
+#include <qtimer.h>
+
+#include <utility>
+
+namespace caelestia::services {
+
+namespace {
+
+Q_LOGGING_CATEGORY(logNetworkProfiles, "caelestia.services.networkprofiles", QtWarningMsg);
+
+constexpr const char* kService = "org.freedesktop.NetworkManager";
+constexpr const char* kSettingsPath = "/org/freedesktop/NetworkManager/Settings";
+constexpr const char* kSettingsIface = "org.freedesktop.NetworkManager.Settings";
+constexpr const char* kConnectionIface = "org.freedesktop.NetworkManager.Settings.Connection";
+constexpr const char* kPropsIface = "org.freedesktop.DBus.Properties";
+
+// Setting group names, as NetworkManager keys them in GetSettings.
+constexpr const char* kGroupConnection = "connection";
+constexpr const char* kGroupWireless = "802-11-wireless";
+constexpr const char* kGroupWirelessSecurity = "802-11-wireless-security";
+
+// An `ay` inside a variant arrives as a byte array on most paths, but as a
+// nested argument on some, so both are worth handling.
+QString byteArrayToString(const QVariant& value) {
+    if (value.metaType().id() == QMetaType::QByteArray) {
+        return QString::fromUtf8(value.toByteArray());
+    }
+
+    if (value.canConvert<QDBusArgument>()) {
+        QByteArray bytes;
+        value.value<QDBusArgument>() >> bytes;
+        return QString::fromUtf8(bytes);
+    }
+
+    return {};
+}
+
+} // namespace
+
+NmConnection::NmConnection(QString path, QObject* parent)
+    : QObject(parent)
+    , m_path(std::move(path)) {}
+
+QString NmConnection::path() const {
+    return m_path;
+}
+
+QString NmConnection::id() const {
+    return m_id;
+}
+
+QString NmConnection::uuid() const {
+    return m_uuid;
+}
+
+QString NmConnection::type() const {
+    return m_type;
+}
+
+QString NmConnection::ssid() const {
+    return m_ssid;
+}
+
+QString NmConnection::keyMgmt() const {
+    return m_keyMgmt;
+}
+
+bool NmConnection::autoconnect() const {
+    return m_autoconnect;
+}
+
+void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
+    const auto connection = settings.value(QString::fromUtf8(kGroupConnection));
+    const auto wireless = settings.value(QString::fromUtf8(kGroupWireless));
+    const auto security = settings.value(QString::fromUtf8(kGroupWirelessSecurity));
+
+    const auto id = connection.value(QStringLiteral("id")).toString();
+    const auto uuid = connection.value(QStringLiteral("uuid")).toString();
+    const auto type = connection.value(QStringLiteral("type")).toString();
+    const auto ssid = byteArrayToString(wireless.value(QStringLiteral("ssid")));
+    const auto keyMgmt = security.value(QStringLiteral("key-mgmt")).toString();
+
+    // NetworkManager leaves autoconnect out when it's at its default, which is
+    // on, so a missing key is not false.
+    const auto autoconnectValue = connection.find(QStringLiteral("autoconnect"));
+    const auto autoconnect = autoconnectValue == connection.end() ? true : autoconnectValue.value().toBool();
+
+    if (id == m_id && uuid == m_uuid && type == m_type && ssid == m_ssid && keyMgmt == m_keyMgmt &&
+        autoconnect == m_autoconnect) {
+        return;
+    }
+
+    m_id = id;
+    m_uuid = uuid;
+    m_type = type;
+    m_ssid = ssid;
+    m_keyMgmt = keyMgmt;
+    m_autoconnect = autoconnect;
+
+    emit changed();
+}
+
+void NmConnection::watch() {
+    auto bus = QDBusConnection::systemBus();
+    if (!bus.isConnected()) {
+        return;
+    }
+
+    bus.connect(
+        QString::fromUtf8(kService),
+        m_path,
+        QString::fromUtf8(kConnectionIface),
+        QStringLiteral("Updated"),
+        this,
+        SLOT(handleUpdated()));
+}
+
+void NmConnection::handleUpdated() {
+    emit needsReread();
+}
+
+NetworkProfiles::NetworkProfiles(QObject* parent)
+    : QObject(parent) {
+    // GetSettings returns a{sa{sv}}, which needs registering before QtDBus will
+    // demarshal it into a nested map.
+    qDBusRegisterMetaType<QMap<QString, QVariantMap>>();
+
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    // NetworkManager may not be up yet, or may restart under us.
+    bus->connect(
+        QStringLiteral("org.freedesktop.DBus"),
+        QStringLiteral("/org/freedesktop/DBus"),
+        QStringLiteral("org.freedesktop.DBus"),
+        QStringLiteral("NameOwnerChanged"),
+        QStringLiteral("sss"),
+        this,
+        SLOT(handleNameOwnerChanged(QString, QString, QString)));
+
+    watchObject(QString::fromUtf8(kSettingsPath));
+    scheduleRefresh();
+}
+
+bool NetworkProfiles::ready() const {
+    return m_ready;
+}
+
+QQmlListProperty<NmConnection> NetworkProfiles::profiles() {
+    return { this, &m_profiles };
+}
+
+std::optional<QDBusConnection> NetworkProfiles::systemBus() {
+    auto bus = QDBusConnection::systemBus();
+    if (!bus.isConnected()) {
+        qCWarning(logNetworkProfiles) << "System bus unavailable";
+        return std::nullopt;
+    }
+    return bus;
+}
+
+void NetworkProfiles::watchObject(const QString& path) {
+    if (path.isEmpty() || path == QStringLiteral("/") || m_watched.contains(path)) {
+        return;
+    }
+
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    if (bus->connect(
+            QString::fromUtf8(kService),
+            path,
+            QString::fromUtf8(kPropsIface),
+            QStringLiteral("PropertiesChanged"),
+            this,
+            SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
+        m_watched.insert(path);
+    }
+}
+
+void NetworkProfiles::handlePropertiesChanged(
+    const QString& iface, const QVariantMap& properties, const QStringList& invalidated) {
+    Q_UNUSED(properties);
+    Q_UNUSED(invalidated);
+
+    // Profiles re-read themselves when edited, so this only needs to catch
+    // profiles being added or removed.
+    if (iface == QString::fromUtf8(kSettingsIface)) {
+        scheduleRefresh();
+    }
+}
+
+void NetworkProfiles::handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner) {
+    Q_UNUSED(oldOwner);
+
+    if (name != QString::fromUtf8(kService)) {
+        return;
+    }
+
+    m_watched.clear();
+
+    if (newOwner.isEmpty()) {
+        // NetworkManager went away; report nothing rather than stale profiles.
+        clearProfiles();
+        m_ready = false;
+        emit profilesChanged();
+        emit changed();
+        return;
+    }
+
+    // Fresh objects on the new owner, so the old subscriptions are worthless.
+    watchObject(QString::fromUtf8(kSettingsPath));
+    scheduleRefresh();
+}
+
+void NetworkProfiles::clearProfiles() {
+    for (auto* profile : std::as_const(m_profiles)) {
+        profile->deleteLater();
+    }
+    m_profiles.clear();
+    m_byPath.clear();
+}
+
+void NetworkProfiles::scheduleRefresh() {
+    if (m_refreshing) {
+        m_refreshQueued = true;
+        return;
+    }
+
+    m_refreshing = true;
+    QTimer::singleShot(0, this, [this]() {
+        refresh();
+    });
+}
+
+void NetworkProfiles::refresh() {
+    m_seen.clear();
+    m_listChanged = false;
+    m_pending = 0;
+
+    readSettings();
+}
+
+// Each async read holds a reference; the result is published when the last one
+// lands, so a partial walk is never visible.
+void NetworkProfiles::step(int delta) {
+    m_pending += delta;
+    if (m_pending > 0) {
+        return;
+    }
+
+    finish();
+}
+
+void NetworkProfiles::finish() {
+    // Anything not seen by this walk is gone.
+    for (int i = m_profiles.size() - 1; i >= 0; i--) {
+        auto* profile = m_profiles.at(i);
+        if (!m_seen.contains(profile->path())) {
+            m_byPath.remove(profile->path());
+            m_profiles.removeAt(i);
+            profile->deleteLater();
+            m_listChanged = true;
+        }
+    }
+
+    const bool wasReady = m_ready;
+    m_ready = true;
+
+    if (m_listChanged) {
+        emit profilesChanged();
+    }
+    if (!wasReady || m_listChanged) {
+        emit changed();
+    }
+
+    m_refreshing = false;
+    if (m_refreshQueued) {
+        m_refreshQueued = false;
+        scheduleRefresh();
+    }
+}
+
+void NetworkProfiles::readSettings() {
+    auto bus = systemBus();
+    if (!bus) {
+        finish();
+        return;
+    }
+
+    auto msg = QDBusMessage::createMethodCall(
+        QString::fromUtf8(kService),
+        QString::fromUtf8(kSettingsPath),
+        QString::fromUtf8(kPropsIface),
+        QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(kSettingsIface);
+
+    step(1);
+    auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* call) {
+        call->deleteLater();
+
+        const QDBusPendingReply<QVariantMap> reply = *call;
+        if (reply.isError()) {
+            qCWarning(logNetworkProfiles) << "Failed to read settings properties:" << reply.error().message();
+            step(-1);
+            return;
+        }
+
+        const auto connections = reply.value().value(QStringLiteral("Connections")).value<QDBusArgument>();
+        QList<QDBusObjectPath> paths;
+        connections >> paths;
+
+        for (const auto& path : paths) {
+            readProfile(path.path());
+        }
+
+        step(-1);
+    });
+}
+
+void NetworkProfiles::readProfile(const QString& path) {
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    auto msg = QDBusMessage::createMethodCall(
+        QString::fromUtf8(kService), path, QString::fromUtf8(kConnectionIface), QStringLiteral("GetSettings"));
+
+    step(1);
+    auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, path](QDBusPendingCallWatcher* call) {
+        call->deleteLater();
+
+        const QDBusPendingReply<QMap<QString, QVariantMap>> reply = *call;
+        if (reply.isError()) {
+            // Profiles get deleted while a walk is in flight; that's expected.
+            qCDebug(logNetworkProfiles) << "Skipping profile" << path << ":" << reply.error().message();
+            step(-1);
+            return;
+        }
+
+        m_seen.insert(path);
+
+        auto* profile = m_byPath.value(path);
+        if (profile == nullptr) {
+            profile = new NmConnection(path, this);
+            profile->watch();
+            // An edit only affects the one profile, so re-read it rather than
+            // walking everything.
+            connect(profile, &NmConnection::needsReread, this, [this, path]() {
+                readProfile(path);
+            });
+
+            m_byPath.insert(path, profile);
+            m_profiles.append(profile);
+            m_listChanged = true;
+        }
+
+        profile->update(reply.value());
+
+        step(-1);
+    });
+}
+
+} // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkprofiles.cpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.cpp
@@ -103,10 +103,6 @@ bool NmConnection::autoconnect() const {
     return m_autoconnect;
 }
 
-bool NmConnection::hidden() const {
-    return m_hidden;
-}
-
 QString NmConnection::ipv4Method() const {
     return m_ipv4Method;
 }
@@ -138,7 +134,6 @@ void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
     const auto type = connection.value(QStringLiteral("type")).toString();
     const auto ssid = byteArrayToString(wireless.value(QStringLiteral("ssid")));
     const auto keyMgmt = security.value(QStringLiteral("key-mgmt")).toString();
-    const auto hidden = wireless.value(QStringLiteral("hidden")).toBool();
 
     // NetworkManager leaves autoconnect out when it's at its default, which is
     // on, so a missing key is not false.
@@ -166,9 +161,8 @@ void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
         dnsData == ipv4.end() ? packedDnsToStrings(ipv4.value(QStringLiteral("dns"))) : dnsData.value().toStringList();
 
     if (id == m_id && uuid == m_uuid && type == m_type && ssid == m_ssid && keyMgmt == m_keyMgmt &&
-        autoconnect == m_autoconnect && hidden == m_hidden && ipv4Method == m_ipv4Method &&
-        ipv4Address == m_ipv4Address && ipv4Gateway == m_ipv4Gateway && ipv4Dns == m_ipv4Dns &&
-        ipv4IgnoreAutoDns == m_ipv4IgnoreAutoDns) {
+        autoconnect == m_autoconnect && ipv4Method == m_ipv4Method && ipv4Address == m_ipv4Address &&
+        ipv4Gateway == m_ipv4Gateway && ipv4Dns == m_ipv4Dns && ipv4IgnoreAutoDns == m_ipv4IgnoreAutoDns) {
         return;
     }
 
@@ -178,7 +172,6 @@ void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
     m_ssid = ssid;
     m_keyMgmt = keyMgmt;
     m_autoconnect = autoconnect;
-    m_hidden = hidden;
     m_ipv4Method = ipv4Method;
     m_ipv4Address = ipv4Address;
     m_ipv4Gateway = ipv4Gateway;

--- a/plugin/src/Caelestia/Services/networkprofiles.cpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.cpp
@@ -211,7 +211,7 @@ void NetworkProfiles::clearItems() {
 }
 
 // Anything not seen by this walk is gone.
-void NetworkProfiles::pruneUnseen() {
+void NetworkProfiles::publish() {
     for (qsizetype i = m_profiles.size() - 1; i >= 0; i--) {
         auto* profile = m_profiles.at(i);
         if (!seen().contains(profile->path())) {

--- a/plugin/src/Caelestia/Services/networkprofiles.cpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.cpp
@@ -83,10 +83,6 @@ QString NmConnection::id() const {
     return m_id;
 }
 
-QString NmConnection::uuid() const {
-    return m_uuid;
-}
-
 QString NmConnection::type() const {
     return m_type;
 }
@@ -130,7 +126,6 @@ void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
     const auto ipv4 = settings.value(QString::fromUtf8(k_groupIpv4));
 
     const auto id = connection.value(QStringLiteral("id")).toString();
-    const auto uuid = connection.value(QStringLiteral("uuid")).toString();
     const auto type = connection.value(QStringLiteral("type")).toString();
     const auto ssid = byteArrayToString(wireless.value(QStringLiteral("ssid")));
     const auto keyMgmt = security.value(QStringLiteral("key-mgmt")).toString();
@@ -160,14 +155,13 @@ void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
     const auto ipv4Dns =
         dnsData == ipv4.end() ? packedDnsToStrings(ipv4.value(QStringLiteral("dns"))) : dnsData.value().toStringList();
 
-    if (id == m_id && uuid == m_uuid && type == m_type && ssid == m_ssid && keyMgmt == m_keyMgmt &&
-        autoconnect == m_autoconnect && ipv4Method == m_ipv4Method && ipv4Address == m_ipv4Address &&
-        ipv4Gateway == m_ipv4Gateway && ipv4Dns == m_ipv4Dns && ipv4IgnoreAutoDns == m_ipv4IgnoreAutoDns) {
+    if (id == m_id && type == m_type && ssid == m_ssid && keyMgmt == m_keyMgmt && autoconnect == m_autoconnect &&
+        ipv4Method == m_ipv4Method && ipv4Address == m_ipv4Address && ipv4Gateway == m_ipv4Gateway &&
+        ipv4Dns == m_ipv4Dns && ipv4IgnoreAutoDns == m_ipv4IgnoreAutoDns) {
         return;
     }
 
     m_id = id;
-    m_uuid = uuid;
     m_type = type;
     m_ssid = ssid;
     m_keyMgmt = keyMgmt;

--- a/plugin/src/Caelestia/Services/networkprofiles.cpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.cpp
@@ -103,6 +103,10 @@ bool NmConnection::autoconnect() const {
     return m_autoconnect;
 }
 
+bool NmConnection::hidden() const {
+    return m_hidden;
+}
+
 QString NmConnection::ipv4Method() const {
     return m_ipv4Method;
 }
@@ -134,6 +138,7 @@ void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
     const auto type = connection.value(QStringLiteral("type")).toString();
     const auto ssid = byteArrayToString(wireless.value(QStringLiteral("ssid")));
     const auto keyMgmt = security.value(QStringLiteral("key-mgmt")).toString();
+    const auto hidden = wireless.value(QStringLiteral("hidden")).toBool();
 
     // NetworkManager leaves autoconnect out when it's at its default, which is
     // on, so a missing key is not false.
@@ -161,8 +166,9 @@ void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
         dnsData == ipv4.end() ? packedDnsToStrings(ipv4.value(QStringLiteral("dns"))) : dnsData.value().toStringList();
 
     if (id == m_id && uuid == m_uuid && type == m_type && ssid == m_ssid && keyMgmt == m_keyMgmt &&
-        autoconnect == m_autoconnect && ipv4Method == m_ipv4Method && ipv4Address == m_ipv4Address &&
-        ipv4Gateway == m_ipv4Gateway && ipv4Dns == m_ipv4Dns && ipv4IgnoreAutoDns == m_ipv4IgnoreAutoDns) {
+        autoconnect == m_autoconnect && hidden == m_hidden && ipv4Method == m_ipv4Method &&
+        ipv4Address == m_ipv4Address && ipv4Gateway == m_ipv4Gateway && ipv4Dns == m_ipv4Dns &&
+        ipv4IgnoreAutoDns == m_ipv4IgnoreAutoDns) {
         return;
     }
 
@@ -172,6 +178,7 @@ void NmConnection::update(const QMap<QString, QVariantMap>& settings) {
     m_ssid = ssid;
     m_keyMgmt = keyMgmt;
     m_autoconnect = autoconnect;
+    m_hidden = hidden;
     m_ipv4Method = ipv4Method;
     m_ipv4Address = ipv4Address;
     m_ipv4Gateway = ipv4Gateway;

--- a/plugin/src/Caelestia/Services/networkprofiles.hpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "networkwalker.hpp"
-
 #include <qhash.h>
 #include <qobject.h>
 #include <qqmlintegration.h>
@@ -11,6 +9,8 @@
 #include <qvariant.h>
 
 #include <cstdint>
+
+#include "networkwalker.hpp"
 
 namespace caelestia::services {
 
@@ -107,7 +107,6 @@ public:
 
     [[nodiscard]] QQmlListProperty<NmConnection> profiles();
 
-
 protected:
     void readRoot() override;
     [[nodiscard]] bool triggersRefresh(const QString& iface) const override;
@@ -119,7 +118,10 @@ private:
     // not: it must stay out of the walk's pending count and seen set, or it
     // will drive the count to zero underneath a walk in progress and prune
     // profiles the walk hasn't reached yet.
-    enum class Read : std::uint8_t { Walk, Detached };
+    enum class Read : std::uint8_t {
+        Walk,
+        Detached
+    };
 
     void readProfile(const QString& path, Read read);
 

--- a/plugin/src/Caelestia/Services/networkprofiles.hpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.hpp
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <qdbusconnection.h>
+#include <qhash.h>
+#include <qobject.h>
+#include <qqmlintegration.h>
+#include <qqmllist.h>
+#include <qset.h>
+#include <qstring.h>
+#include <qstringlist.h>
+#include <qvariant.h>
+
+#include <optional>
+
+namespace caelestia::services {
+
+// A saved connection profile, as stored by NetworkManager.
+//
+// Each profile reads itself and subscribes to its own object, so editing one
+// doesn't cost a walk over all of them.
+class NmConnection : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("NmConnection instances are owned by NetworkProfiles")
+
+    // Profile name, i.e. what nmcli takes as a connection argument.
+    Q_PROPERTY(QString id READ id NOTIFY changed)
+    Q_PROPERTY(QString uuid READ uuid NOTIFY changed)
+    // NetworkManager's setting name, e.g. "802-11-wireless" or "802-3-ethernet".
+    Q_PROPERTY(QString type READ type NOTIFY changed)
+    // Wifi profiles only; empty for everything else.
+    Q_PROPERTY(QString ssid READ ssid NOTIFY changed)
+    // Raw key management, e.g. "wpa-psk" or "sae". Empty on an open network.
+    Q_PROPERTY(QString keyMgmt READ keyMgmt NOTIFY changed)
+    Q_PROPERTY(bool autoconnect READ autoconnect NOTIFY changed)
+
+public:
+    explicit NmConnection(QString path, QObject* parent = nullptr);
+
+    [[nodiscard]] QString path() const;
+    [[nodiscard]] QString id() const;
+    [[nodiscard]] QString uuid() const;
+    [[nodiscard]] QString type() const;
+    [[nodiscard]] QString ssid() const;
+    [[nodiscard]] QString keyMgmt() const;
+    [[nodiscard]] bool autoconnect() const;
+
+    // Applies the nested settings map GetSettings returns.
+    void update(const QMap<QString, QVariantMap>& settings);
+
+    // Subscribes to this profile's own object on the system bus.
+    void watch();
+
+signals:
+    void changed();
+    // Raised when NetworkManager reports the profile was edited, so the owner
+    // can read it again.
+    void needsReread();
+
+private slots:
+    void handleUpdated();
+
+private:
+    QString m_path;
+    QString m_id;
+    QString m_uuid;
+    QString m_type;
+    QString m_ssid;
+    QString m_keyMgmt;
+    bool m_autoconnect = true;
+};
+
+// NetworkManager's saved profiles, read over D-Bus.
+//
+// This replaces parsing `nmcli connection show` and then spawning a further
+// nmcli per wifi profile just to read its SSID: one GetSettings call per
+// profile returns everything at once, and they run in parallel. Actions -
+// adding, deleting, toggling autoconnect - stay on the CLI, where there's
+// nothing to parse and nothing to gain from moving them.
+class NetworkProfiles : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+    // False until a full snapshot has been read, so consumers can hold their
+    // previous behaviour rather than acting on an empty list.
+    Q_PROPERTY(bool ready READ ready NOTIFY changed)
+    Q_PROPERTY(QQmlListProperty<caelestia::services::NmConnection> profiles READ profiles NOTIFY profilesChanged)
+
+public:
+    explicit NetworkProfiles(QObject* parent = nullptr);
+
+    [[nodiscard]] bool ready() const;
+    [[nodiscard]] QQmlListProperty<NmConnection> profiles();
+
+signals:
+    void changed();
+    void profilesChanged();
+
+private slots:
+    void handlePropertiesChanged(const QString& iface, const QVariantMap& properties, const QStringList& invalidated);
+    void handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner);
+
+private:
+    // One walk at a time, with a flag to run again after. Bursts of signals
+    // would otherwise each start their own and land out of order.
+    void scheduleRefresh();
+    void refresh();
+    void readSettings();
+    void readProfile(const QString& path);
+    void step(int delta);
+    void finish();
+
+    void watchObject(const QString& path);
+    void clearProfiles();
+
+    [[nodiscard]] static std::optional<QDBusConnection> systemBus();
+
+    bool m_ready = false;
+
+    QList<NmConnection*> m_profiles;
+    QHash<QString, NmConnection*> m_byPath;
+    // Paths seen by the walk in progress; anything missing afterwards has gone.
+    QSet<QString> m_seen;
+
+    bool m_refreshing = false;
+    bool m_refreshQueued = false;
+    int m_pending = 0;
+    bool m_listChanged = false;
+
+    QSet<QString> m_watched;
+};
+
+} // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkprofiles.hpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.hpp
@@ -33,6 +33,14 @@ class NmConnection : public QObject {
     // Raw key management, e.g. "wpa-psk" or "sae". Empty on an open network.
     Q_PROPERTY(QString keyMgmt READ keyMgmt NOTIFY changed)
     Q_PROPERTY(bool autoconnect READ autoconnect NOTIFY changed)
+    // IPv4 configuration as saved on the profile, which is not the same thing
+    // as what the device ended up with; that lives on NmDevice.
+    Q_PROPERTY(QString ipv4Method READ ipv4Method NOTIFY changed)
+    // First manual address in CIDR form, e.g. "192.168.1.5/24". Empty on auto.
+    Q_PROPERTY(QString ipv4Address READ ipv4Address NOTIFY changed)
+    Q_PROPERTY(QString ipv4Gateway READ ipv4Gateway NOTIFY changed)
+    Q_PROPERTY(QStringList ipv4Dns READ ipv4Dns NOTIFY changed)
+    Q_PROPERTY(bool ipv4IgnoreAutoDns READ ipv4IgnoreAutoDns NOTIFY changed)
 
 public:
     explicit NmConnection(QString path, QObject* parent = nullptr);
@@ -44,6 +52,11 @@ public:
     [[nodiscard]] QString ssid() const;
     [[nodiscard]] QString keyMgmt() const;
     [[nodiscard]] bool autoconnect() const;
+    [[nodiscard]] QString ipv4Method() const;
+    [[nodiscard]] QString ipv4Address() const;
+    [[nodiscard]] QString ipv4Gateway() const;
+    [[nodiscard]] QStringList ipv4Dns() const;
+    [[nodiscard]] bool ipv4IgnoreAutoDns() const;
 
     // Applies the nested settings map GetSettings returns.
     void update(const QMap<QString, QVariantMap>& settings);
@@ -68,6 +81,11 @@ private:
     QString m_ssid;
     QString m_keyMgmt;
     bool m_autoconnect = true;
+    QString m_ipv4Method;
+    QString m_ipv4Address;
+    QString m_ipv4Gateway;
+    QStringList m_ipv4Dns;
+    bool m_ipv4IgnoreAutoDns = false;
 };
 
 // NetworkManager's saved profiles, read over D-Bus.

--- a/plugin/src/Caelestia/Services/networkprofiles.hpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <qdbusconnection.h>
+#include "networkwalker.hpp"
+
 #include <qhash.h>
 #include <qobject.h>
 #include <qqmlintegration.h>
 #include <qqmllist.h>
-#include <qset.h>
 #include <qstring.h>
 #include <qstringlist.h>
 #include <qvariant.h>
 
-#include <optional>
+#include <cstdint>
 
 namespace caelestia::services {
 
@@ -95,58 +95,36 @@ private:
 // profile returns everything at once, and they run in parallel. Actions -
 // adding, deleting, toggling autoconnect - stay on the CLI, where there's
 // nothing to parse and nothing to gain from moving them.
-class NetworkProfiles : public QObject {
+class NetworkProfiles : public NmWalker {
     Q_OBJECT
     QML_ELEMENT
     QML_SINGLETON
 
-    // False until a full snapshot has been read, so consumers can hold their
-    // previous behaviour rather than acting on an empty list.
-    Q_PROPERTY(bool ready READ ready NOTIFY changed)
-    Q_PROPERTY(QQmlListProperty<caelestia::services::NmConnection> profiles READ profiles NOTIFY profilesChanged)
+    Q_PROPERTY(QQmlListProperty<caelestia::services::NmConnection> profiles READ profiles NOTIFY itemsChanged)
 
 public:
     explicit NetworkProfiles(QObject* parent = nullptr);
 
-    [[nodiscard]] bool ready() const;
     [[nodiscard]] QQmlListProperty<NmConnection> profiles();
 
-signals:
-    void changed();
-    void profilesChanged();
 
-private slots:
-    void handlePropertiesChanged(const QString& iface, const QVariantMap& properties, const QStringList& invalidated);
-    void handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner);
+protected:
+    void readRoot() override;
+    [[nodiscard]] bool triggersRefresh(const QString& iface) const override;
+    void pruneUnseen() override;
+    void clearItems() override;
 
 private:
-    // One walk at a time, with a flag to run again after. Bursts of signals
-    // would otherwise each start their own and land out of order.
-    void scheduleRefresh();
-    void refresh();
-    void readSettings();
-    void readProfile(const QString& path);
-    void step(int delta);
-    void finish();
+    // Whether the read belongs to a walk. A reread triggered by an edit does
+    // not: it must stay out of the walk's pending count and seen set, or it
+    // will drive the count to zero underneath a walk in progress and prune
+    // profiles the walk hasn't reached yet.
+    enum class Read : std::uint8_t { Walk, Detached };
 
-    void watchObject(const QString& path);
-    void clearProfiles();
-
-    [[nodiscard]] static std::optional<QDBusConnection> systemBus();
-
-    bool m_ready = false;
+    void readProfile(const QString& path, Read read);
 
     QList<NmConnection*> m_profiles;
     QHash<QString, NmConnection*> m_byPath;
-    // Paths seen by the walk in progress; anything missing afterwards has gone.
-    QSet<QString> m_seen;
-
-    bool m_refreshing = false;
-    bool m_refreshQueued = false;
-    int m_pending = 0;
-    bool m_listChanged = false;
-
-    QSet<QString> m_watched;
 };
 
 } // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkprofiles.hpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.hpp
@@ -107,7 +107,7 @@ public:
 protected:
     void readRoot() override;
     [[nodiscard]] bool triggersRefresh(const QString& iface) const override;
-    void pruneUnseen() override;
+    void publish() override;
     void clearItems() override;
 
 private:

--- a/plugin/src/Caelestia/Services/networkprofiles.hpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.hpp
@@ -33,6 +33,10 @@ class NmConnection : public QObject {
     // Raw key management, e.g. "wpa-psk" or "sae". Empty on an open network.
     Q_PROPERTY(QString keyMgmt READ keyMgmt NOTIFY changed)
     Q_PROPERTY(bool autoconnect READ autoconnect NOTIFY changed)
+    // Whether the network doesn't broadcast its SSID. NetworkManager learns the
+    // SSID of a hidden access point while associated and keeps it on the access
+    // point afterwards, so this is the only way to tell one apart later.
+    Q_PROPERTY(bool hidden READ hidden NOTIFY changed)
     // IPv4 configuration as saved on the profile, which is not the same thing
     // as what the device ended up with; that lives on NmDevice.
     Q_PROPERTY(QString ipv4Method READ ipv4Method NOTIFY changed)
@@ -52,6 +56,7 @@ public:
     [[nodiscard]] QString ssid() const;
     [[nodiscard]] QString keyMgmt() const;
     [[nodiscard]] bool autoconnect() const;
+    [[nodiscard]] bool hidden() const;
     [[nodiscard]] QString ipv4Method() const;
     [[nodiscard]] QString ipv4Address() const;
     [[nodiscard]] QString ipv4Gateway() const;
@@ -81,6 +86,7 @@ private:
     QString m_ssid;
     QString m_keyMgmt;
     bool m_autoconnect = true;
+    bool m_hidden = false;
     QString m_ipv4Method;
     QString m_ipv4Address;
     QString m_ipv4Gateway;

--- a/plugin/src/Caelestia/Services/networkprofiles.hpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.hpp
@@ -25,7 +25,6 @@ class NmConnection : public QObject {
 
     // Profile name, i.e. what nmcli takes as a connection argument.
     Q_PROPERTY(QString id READ id NOTIFY changed)
-    Q_PROPERTY(QString uuid READ uuid NOTIFY changed)
     // NetworkManager's setting name, e.g. "802-11-wireless" or "802-3-ethernet".
     Q_PROPERTY(QString type READ type NOTIFY changed)
     // Wifi profiles only; empty for everything else.
@@ -47,7 +46,6 @@ public:
 
     [[nodiscard]] QString path() const;
     [[nodiscard]] QString id() const;
-    [[nodiscard]] QString uuid() const;
     [[nodiscard]] QString type() const;
     [[nodiscard]] QString ssid() const;
     [[nodiscard]] QString keyMgmt() const;
@@ -76,7 +74,6 @@ private slots:
 private:
     QString m_path;
     QString m_id;
-    QString m_uuid;
     QString m_type;
     QString m_ssid;
     QString m_keyMgmt;

--- a/plugin/src/Caelestia/Services/networkprofiles.hpp
+++ b/plugin/src/Caelestia/Services/networkprofiles.hpp
@@ -33,10 +33,6 @@ class NmConnection : public QObject {
     // Raw key management, e.g. "wpa-psk" or "sae". Empty on an open network.
     Q_PROPERTY(QString keyMgmt READ keyMgmt NOTIFY changed)
     Q_PROPERTY(bool autoconnect READ autoconnect NOTIFY changed)
-    // Whether the network doesn't broadcast its SSID. NetworkManager learns the
-    // SSID of a hidden access point while associated and keeps it on the access
-    // point afterwards, so this is the only way to tell one apart later.
-    Q_PROPERTY(bool hidden READ hidden NOTIFY changed)
     // IPv4 configuration as saved on the profile, which is not the same thing
     // as what the device ended up with; that lives on NmDevice.
     Q_PROPERTY(QString ipv4Method READ ipv4Method NOTIFY changed)
@@ -56,7 +52,6 @@ public:
     [[nodiscard]] QString ssid() const;
     [[nodiscard]] QString keyMgmt() const;
     [[nodiscard]] bool autoconnect() const;
-    [[nodiscard]] bool hidden() const;
     [[nodiscard]] QString ipv4Method() const;
     [[nodiscard]] QString ipv4Address() const;
     [[nodiscard]] QString ipv4Gateway() const;
@@ -86,7 +81,6 @@ private:
     QString m_ssid;
     QString m_keyMgmt;
     bool m_autoconnect = true;
-    bool m_hidden = false;
     QString m_ipv4Method;
     QString m_ipv4Address;
     QString m_ipv4Gateway;

--- a/plugin/src/Caelestia/Services/networkroute.cpp
+++ b/plugin/src/Caelestia/Services/networkroute.cpp
@@ -9,6 +9,8 @@
 #include <qloggingcategory.h>
 #include <qtimer.h>
 
+#include <utility>
+
 namespace caelestia::services {
 
 namespace {
@@ -247,12 +249,13 @@ void NetworkRoute::readManager() {
         QList<QDBusObjectPath> paths;
         actives >> paths;
 
-        for (const auto& path : paths) {
+        for (const auto& path : std::as_const(paths)) {
             readActiveConnection(path.path(), path.path() == m_primaryConnection);
         }
 
         step(-1);
     });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 void NetworkRoute::readActiveConnection(const QString& path, bool isPrimary) {
@@ -300,6 +303,7 @@ void NetworkRoute::readActiveConnection(const QString& path, bool isPrimary) {
 
         step(-1);
     });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 void NetworkRoute::readDevice(const QString& connPath, const QString& devicePath) {
@@ -332,6 +336,7 @@ void NetworkRoute::readDevice(const QString& connPath, const QString& devicePath
 
         step(-1);
     });
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
 } // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkroute.cpp
+++ b/plugin/src/Caelestia/Services/networkroute.cpp
@@ -15,16 +15,16 @@ namespace {
 
 Q_LOGGING_CATEGORY(logNetworkRoute, "caelestia.services.networkroute", QtWarningMsg);
 
-constexpr const char* kService = "org.freedesktop.NetworkManager";
-constexpr const char* kManagerPath = "/org/freedesktop/NetworkManager";
-constexpr const char* kManagerIface = "org.freedesktop.NetworkManager";
-constexpr const char* kActiveIface = "org.freedesktop.NetworkManager.Connection.Active";
-constexpr const char* kDeviceIface = "org.freedesktop.NetworkManager.Device";
-constexpr const char* kPropsIface = "org.freedesktop.DBus.Properties";
+constexpr const char* k_service = "org.freedesktop.NetworkManager";
+constexpr const char* k_managerPath = "/org/freedesktop/NetworkManager";
+constexpr const char* k_managerIface = "org.freedesktop.NetworkManager";
+constexpr const char* k_activeIface = "org.freedesktop.NetworkManager.Connection.Active";
+constexpr const char* k_deviceIface = "org.freedesktop.NetworkManager.Device";
+constexpr const char* k_propsIface = "org.freedesktop.DBus.Properties";
 
 // From NMDeviceType; only the two we classify are named.
-constexpr uint kDeviceTypeEthernet = 1;
-constexpr uint kDeviceTypeWifi = 2;
+constexpr uint k_deviceTypeEthernet = 1;
+constexpr uint k_deviceTypeWifi = 2;
 
 } // namespace
 
@@ -40,16 +40,11 @@ NetworkRoute::NetworkRoute(QObject* parent)
     }
 
     // NetworkManager may not be up yet, or may restart under us.
-    bus->connect(
-        QStringLiteral("org.freedesktop.DBus"),
-        QStringLiteral("/org/freedesktop/DBus"),
-        QStringLiteral("org.freedesktop.DBus"),
-        QStringLiteral("NameOwnerChanged"),
-        QStringLiteral("sss"),
-        this,
+    bus->connect(QStringLiteral("org.freedesktop.DBus"), QStringLiteral("/org/freedesktop/DBus"),
+        QStringLiteral("org.freedesktop.DBus"), QStringLiteral("NameOwnerChanged"), QStringLiteral("sss"), this,
         SLOT(handleNameOwnerChanged(QString, QString, QString)));
 
-    watchObject(QString::fromUtf8(kManagerPath));
+    watchObject(QString::fromUtf8(k_managerPath));
     scheduleRefresh();
 }
 
@@ -70,7 +65,8 @@ Transport NetworkRoute::ipv6Transport() const {
 }
 
 bool NetworkRoute::mixed() const {
-    return m_current.ipv4 != config::NetworkTransport::None && m_current.ipv6 != config::NetworkTransport::None && m_current.ipv4 != m_current.ipv6;
+    return m_current.ipv4 != config::NetworkTransport::None && m_current.ipv6 != config::NetworkTransport::None &&
+           m_current.ipv4 != m_current.ipv6;
 }
 
 QString NetworkRoute::primaryInterface() const {
@@ -88,9 +84,12 @@ std::optional<QDBusConnection> NetworkRoute::systemBus() {
 
 Transport NetworkRoute::transportForDeviceType(uint deviceType) {
     switch (deviceType) {
-    case kDeviceTypeEthernet: return config::NetworkTransport::Ethernet;
-    case kDeviceTypeWifi: return config::NetworkTransport::Wifi;
-    default: return config::NetworkTransport::Other;
+    case k_deviceTypeEthernet:
+        return config::NetworkTransport::Ethernet;
+    case k_deviceTypeWifi:
+        return config::NetworkTransport::Wifi;
+    default:
+        return config::NetworkTransport::Other;
     }
 }
 
@@ -107,12 +106,8 @@ void NetworkRoute::watchObject(const QString& path) {
         return;
     }
 
-    if (bus->connect(
-            QString::fromUtf8(kService),
-            path,
-            QString::fromUtf8(kPropsIface),
-            QStringLiteral("PropertiesChanged"),
-            this,
+    if (bus->connect(QString::fromUtf8(k_service), path, QString::fromUtf8(k_propsIface),
+            QStringLiteral("PropertiesChanged"), this,
             SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
         m_watched.insert(path);
     }
@@ -123,8 +118,8 @@ void NetworkRoute::handlePropertiesChanged(
     Q_UNUSED(properties);
     Q_UNUSED(invalidated);
 
-    if (iface == QString::fromUtf8(kManagerIface) || iface == QString::fromUtf8(kActiveIface)
-        || iface == QString::fromUtf8(kDeviceIface)) {
+    if (iface == QString::fromUtf8(k_managerIface) || iface == QString::fromUtf8(k_activeIface) ||
+        iface == QString::fromUtf8(k_deviceIface)) {
         scheduleRefresh();
     }
 }
@@ -132,7 +127,7 @@ void NetworkRoute::handlePropertiesChanged(
 void NetworkRoute::handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner) {
     Q_UNUSED(oldOwner);
 
-    if (name != QString::fromUtf8(kService)) {
+    if (name != QString::fromUtf8(k_service)) {
         return;
     }
 
@@ -147,7 +142,7 @@ void NetworkRoute::handleNameOwnerChanged(const QString& name, const QString& ol
 
     // Fresh objects on the new owner, so the old subscriptions are worthless.
     m_watched.clear();
-    watchObject(QString::fromUtf8(kManagerPath));
+    watchObject(QString::fromUtf8(k_managerPath));
     scheduleRefresh();
 }
 
@@ -229,12 +224,9 @@ void NetworkRoute::readManager() {
         return;
     }
 
-    auto msg = QDBusMessage::createMethodCall(
-        QString::fromUtf8(kService),
-        QString::fromUtf8(kManagerPath),
-        QString::fromUtf8(kPropsIface),
-        QStringLiteral("GetAll"));
-    msg << QString::fromUtf8(kManagerIface);
+    auto msg = QDBusMessage::createMethodCall(QString::fromUtf8(k_service), QString::fromUtf8(k_managerPath),
+        QString::fromUtf8(k_propsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(k_managerIface);
 
     step(1);
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
@@ -274,8 +266,8 @@ void NetworkRoute::readActiveConnection(const QString& path, bool isPrimary) {
     watchObject(path);
 
     auto msg = QDBusMessage::createMethodCall(
-        QString::fromUtf8(kService), path, QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
-    msg << QString::fromUtf8(kActiveIface);
+        QString::fromUtf8(k_service), path, QString::fromUtf8(k_propsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(k_activeIface);
 
     step(1);
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
@@ -319,8 +311,8 @@ void NetworkRoute::readDevice(const QString& connPath, const QString& devicePath
     watchObject(devicePath);
 
     auto msg = QDBusMessage::createMethodCall(
-        QString::fromUtf8(kService), devicePath, QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
-    msg << QString::fromUtf8(kDeviceIface);
+        QString::fromUtf8(k_service), devicePath, QString::fromUtf8(k_propsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(k_deviceIface);
 
     step(1);
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);

--- a/plugin/src/Caelestia/Services/networkroute.cpp
+++ b/plugin/src/Caelestia/Services/networkroute.cpp
@@ -1,0 +1,345 @@
+#include "networkroute.hpp"
+
+#include <qdbusargument.h>
+#include <qdbusextratypes.h>
+#include <qdbusmessage.h>
+#include <qdbuspendingcall.h>
+#include <qdbuspendingreply.h>
+#include <qdbusreply.h>
+#include <qloggingcategory.h>
+#include <qtimer.h>
+
+namespace caelestia::services {
+
+namespace {
+
+Q_LOGGING_CATEGORY(logNetworkRoute, "caelestia.services.networkroute", QtWarningMsg);
+
+constexpr const char* kService = "org.freedesktop.NetworkManager";
+constexpr const char* kManagerPath = "/org/freedesktop/NetworkManager";
+constexpr const char* kManagerIface = "org.freedesktop.NetworkManager";
+constexpr const char* kActiveIface = "org.freedesktop.NetworkManager.Connection.Active";
+constexpr const char* kDeviceIface = "org.freedesktop.NetworkManager.Device";
+constexpr const char* kPropsIface = "org.freedesktop.DBus.Properties";
+
+// From NMDeviceType; only the two we classify are named.
+constexpr uint kDeviceTypeEthernet = 1;
+constexpr uint kDeviceTypeWifi = 2;
+
+} // namespace
+
+bool NetworkRoute::Snapshot::operator==(const Snapshot& o) const noexcept {
+    return primary == o.primary && ipv4 == o.ipv4 && ipv6 == o.ipv6 && primaryInterface == o.primaryInterface;
+}
+
+NetworkRoute::NetworkRoute(QObject* parent)
+    : QObject(parent) {
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    // NetworkManager may not be up yet, or may restart under us.
+    bus->connect(
+        QStringLiteral("org.freedesktop.DBus"),
+        QStringLiteral("/org/freedesktop/DBus"),
+        QStringLiteral("org.freedesktop.DBus"),
+        QStringLiteral("NameOwnerChanged"),
+        QStringLiteral("sss"),
+        this,
+        SLOT(handleNameOwnerChanged(QString, QString, QString)));
+
+    watchObject(QString::fromUtf8(kManagerPath));
+    scheduleRefresh();
+}
+
+bool NetworkRoute::ready() const {
+    return m_ready;
+}
+
+Transport NetworkRoute::primaryTransport() const {
+    return m_current.primary;
+}
+
+Transport NetworkRoute::ipv4Transport() const {
+    return m_current.ipv4;
+}
+
+Transport NetworkRoute::ipv6Transport() const {
+    return m_current.ipv6;
+}
+
+bool NetworkRoute::mixed() const {
+    return m_current.ipv4 != config::NetworkTransport::None && m_current.ipv6 != config::NetworkTransport::None && m_current.ipv4 != m_current.ipv6;
+}
+
+QString NetworkRoute::primaryInterface() const {
+    return m_current.primaryInterface;
+}
+
+std::optional<QDBusConnection> NetworkRoute::systemBus() {
+    auto bus = QDBusConnection::systemBus();
+    if (!bus.isConnected()) {
+        qCWarning(logNetworkRoute) << "System bus unavailable";
+        return std::nullopt;
+    }
+    return bus;
+}
+
+Transport NetworkRoute::transportForDeviceType(uint deviceType) {
+    switch (deviceType) {
+    case kDeviceTypeEthernet: return config::NetworkTransport::Ethernet;
+    case kDeviceTypeWifi: return config::NetworkTransport::Wifi;
+    default: return config::NetworkTransport::Other;
+    }
+}
+
+// Subscribes to property changes on an object once. NetworkManager emits these
+// for the manager, every active connection and every device, which is what
+// tells us a walk is out of date.
+void NetworkRoute::watchObject(const QString& path) {
+    if (path.isEmpty() || path == QStringLiteral("/") || m_watched.contains(path)) {
+        return;
+    }
+
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    if (bus->connect(
+            QString::fromUtf8(kService),
+            path,
+            QString::fromUtf8(kPropsIface),
+            QStringLiteral("PropertiesChanged"),
+            this,
+            SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
+        m_watched.insert(path);
+    }
+}
+
+void NetworkRoute::handlePropertiesChanged(
+    const QString& iface, const QVariantMap& properties, const QStringList& invalidated) {
+    Q_UNUSED(properties);
+    Q_UNUSED(invalidated);
+
+    if (iface == QString::fromUtf8(kManagerIface) || iface == QString::fromUtf8(kActiveIface)
+        || iface == QString::fromUtf8(kDeviceIface)) {
+        scheduleRefresh();
+    }
+}
+
+void NetworkRoute::handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner) {
+    Q_UNUSED(oldOwner);
+
+    if (name != QString::fromUtf8(kService)) {
+        return;
+    }
+
+    if (newOwner.isEmpty()) {
+        // NetworkManager went away; report nothing rather than stale state.
+        m_watched.clear();
+        m_ready = false;
+        m_current = Snapshot();
+        emit changed();
+        return;
+    }
+
+    // Fresh objects on the new owner, so the old subscriptions are worthless.
+    m_watched.clear();
+    watchObject(QString::fromUtf8(kManagerPath));
+    scheduleRefresh();
+}
+
+// Signals arrive in bursts - a connection going up touches the manager, the
+// active connection and its device in quick succession. Coalescing them means
+// one walk per burst instead of several racing ones.
+void NetworkRoute::scheduleRefresh() {
+    if (m_refreshing) {
+        m_refreshQueued = true;
+        return;
+    }
+
+    m_refreshing = true;
+    QTimer::singleShot(0, this, [this]() {
+        refresh();
+    });
+}
+
+void NetworkRoute::refresh() {
+    m_building = Snapshot();
+    m_primaryConnection.clear();
+    m_connIsDefault4.clear();
+    m_connIsDefault6.clear();
+    m_connTransport.clear();
+    m_connInterface.clear();
+    m_pending = 0;
+
+    readManager();
+}
+
+// Each async read holds a reference; the snapshot is applied when the last one
+// lands, so a partial walk is never published.
+void NetworkRoute::step(int delta) {
+    m_pending += delta;
+    if (m_pending > 0) {
+        return;
+    }
+
+    Snapshot snapshot;
+    snapshot.primaryInterface = m_connInterface.value(m_primaryConnection);
+    snapshot.primary = m_connTransport.value(m_primaryConnection, config::NetworkTransport::None);
+
+    for (auto it = m_connIsDefault4.cbegin(); it != m_connIsDefault4.cend(); ++it) {
+        if (it.value()) {
+            snapshot.ipv4 = m_connTransport.value(it.key(), config::NetworkTransport::None);
+            break;
+        }
+    }
+    for (auto it = m_connIsDefault6.cbegin(); it != m_connIsDefault6.cend(); ++it) {
+        if (it.value()) {
+            snapshot.ipv6 = m_connTransport.value(it.key(), config::NetworkTransport::None);
+            break;
+        }
+    }
+
+    finishRefresh(snapshot);
+}
+
+void NetworkRoute::finishRefresh(const Snapshot& snapshot) {
+    const bool wasReady = m_ready;
+    m_ready = true;
+
+    if (!wasReady || !(snapshot == m_current)) {
+        m_current = snapshot;
+        emit changed();
+    }
+
+    m_refreshing = false;
+    if (m_refreshQueued) {
+        m_refreshQueued = false;
+        scheduleRefresh();
+    }
+}
+
+void NetworkRoute::readManager() {
+    const auto bus = systemBus();
+    if (!bus) {
+        finishRefresh(Snapshot());
+        return;
+    }
+
+    auto msg = QDBusMessage::createMethodCall(
+        QString::fromUtf8(kService),
+        QString::fromUtf8(kManagerPath),
+        QString::fromUtf8(kPropsIface),
+        QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(kManagerIface);
+
+    step(1);
+    auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* call) {
+        call->deleteLater();
+
+        const QDBusPendingReply<QVariantMap> reply = *call;
+        if (reply.isError()) {
+            qCWarning(logNetworkRoute) << "Failed to read NetworkManager properties:" << reply.error().message();
+            step(-1);
+            return;
+        }
+
+        const auto props = reply.value();
+        m_primaryConnection = props.value(QStringLiteral("PrimaryConnection")).value<QDBusObjectPath>().path();
+
+        const auto actives = props.value(QStringLiteral("ActiveConnections")).value<QDBusArgument>();
+        QList<QDBusObjectPath> paths;
+        actives >> paths;
+
+        for (const auto& path : paths) {
+            readActiveConnection(path.path(), path.path() == m_primaryConnection);
+        }
+
+        step(-1);
+    });
+}
+
+void NetworkRoute::readActiveConnection(const QString& path, bool isPrimary) {
+    Q_UNUSED(isPrimary);
+
+    const auto bus = systemBus();
+    if (!bus || path.isEmpty() || path == QStringLiteral("/")) {
+        return;
+    }
+
+    watchObject(path);
+
+    auto msg = QDBusMessage::createMethodCall(
+        QString::fromUtf8(kService), path, QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(kActiveIface);
+
+    step(1);
+    auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, path](QDBusPendingCallWatcher* call) {
+        call->deleteLater();
+
+        const QDBusPendingReply<QVariantMap> reply = *call;
+        if (reply.isError()) {
+            // Connections come and go while we're walking; that's expected.
+            qCDebug(logNetworkRoute) << "Skipping active connection" << path << ":" << reply.error().message();
+            step(-1);
+            return;
+        }
+
+        const auto props = reply.value();
+        m_connIsDefault4.insert(path, props.value(QStringLiteral("Default")).toBool());
+        m_connIsDefault6.insert(path, props.value(QStringLiteral("Default6")).toBool());
+
+        const auto devices = props.value(QStringLiteral("Devices")).value<QDBusArgument>();
+        QList<QDBusObjectPath> paths;
+        devices >> paths;
+
+        // A connection's devices are its stack bottom-up, so the first one is
+        // the link the traffic actually goes over. A VPN's active connection
+        // has no devices of its own beyond its tunnel, which classifies as
+        // Other and leaves the underlying connection to answer for the link.
+        if (!paths.isEmpty()) {
+            readDevice(path, paths.first().path());
+        }
+
+        step(-1);
+    });
+}
+
+void NetworkRoute::readDevice(const QString& connPath, const QString& devicePath) {
+    const auto bus = systemBus();
+    if (!bus || devicePath.isEmpty() || devicePath == QStringLiteral("/")) {
+        return;
+    }
+
+    watchObject(devicePath);
+
+    auto msg = QDBusMessage::createMethodCall(
+        QString::fromUtf8(kService), devicePath, QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
+    msg << QString::fromUtf8(kDeviceIface);
+
+    step(1);
+    auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, connPath](QDBusPendingCallWatcher* call) {
+        call->deleteLater();
+
+        const QDBusPendingReply<QVariantMap> reply = *call;
+        if (reply.isError()) {
+            qCDebug(logNetworkRoute) << "Skipping device for" << connPath << ":" << reply.error().message();
+            step(-1);
+            return;
+        }
+
+        const auto props = reply.value();
+        m_connTransport.insert(connPath, transportForDeviceType(props.value(QStringLiteral("DeviceType")).toUInt()));
+        m_connInterface.insert(connPath, props.value(QStringLiteral("Interface")).toString());
+
+        step(-1);
+    });
+}
+
+} // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkroute.cpp
+++ b/plugin/src/Caelestia/Services/networkroute.cpp
@@ -40,8 +40,13 @@ NetworkRoute::NetworkRoute(QObject* parent)
     }
 
     // NetworkManager may not be up yet, or may restart under us.
-    bus->connect(QStringLiteral("org.freedesktop.DBus"), QStringLiteral("/org/freedesktop/DBus"),
-        QStringLiteral("org.freedesktop.DBus"), QStringLiteral("NameOwnerChanged"), QStringLiteral("sss"), this,
+    bus->connect(
+        QStringLiteral("org.freedesktop.DBus"),
+        QStringLiteral("/org/freedesktop/DBus"),
+        QStringLiteral("org.freedesktop.DBus"),
+        QStringLiteral("NameOwnerChanged"),
+        QStringLiteral("sss"),
+        this,
         SLOT(handleNameOwnerChanged(QString, QString, QString)));
 
     watchObject(QString::fromUtf8(kManagerPath));
@@ -65,8 +70,7 @@ Transport NetworkRoute::ipv6Transport() const {
 }
 
 bool NetworkRoute::mixed() const {
-    return m_current.ipv4 != config::NetworkTransport::None && m_current.ipv6 != config::NetworkTransport::None &&
-           m_current.ipv4 != m_current.ipv6;
+    return m_current.ipv4 != config::NetworkTransport::None && m_current.ipv6 != config::NetworkTransport::None && m_current.ipv4 != m_current.ipv6;
 }
 
 QString NetworkRoute::primaryInterface() const {
@@ -84,12 +88,9 @@ std::optional<QDBusConnection> NetworkRoute::systemBus() {
 
 Transport NetworkRoute::transportForDeviceType(uint deviceType) {
     switch (deviceType) {
-    case kDeviceTypeEthernet:
-        return config::NetworkTransport::Ethernet;
-    case kDeviceTypeWifi:
-        return config::NetworkTransport::Wifi;
-    default:
-        return config::NetworkTransport::Other;
+    case kDeviceTypeEthernet: return config::NetworkTransport::Ethernet;
+    case kDeviceTypeWifi: return config::NetworkTransport::Wifi;
+    default: return config::NetworkTransport::Other;
     }
 }
 
@@ -106,8 +107,12 @@ void NetworkRoute::watchObject(const QString& path) {
         return;
     }
 
-    if (bus->connect(QString::fromUtf8(kService), path, QString::fromUtf8(kPropsIface),
-            QStringLiteral("PropertiesChanged"), this,
+    if (bus->connect(
+            QString::fromUtf8(kService),
+            path,
+            QString::fromUtf8(kPropsIface),
+            QStringLiteral("PropertiesChanged"),
+            this,
             SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
         m_watched.insert(path);
     }
@@ -118,8 +123,8 @@ void NetworkRoute::handlePropertiesChanged(
     Q_UNUSED(properties);
     Q_UNUSED(invalidated);
 
-    if (iface == QString::fromUtf8(kManagerIface) || iface == QString::fromUtf8(kActiveIface) ||
-        iface == QString::fromUtf8(kDeviceIface)) {
+    if (iface == QString::fromUtf8(kManagerIface) || iface == QString::fromUtf8(kActiveIface)
+        || iface == QString::fromUtf8(kDeviceIface)) {
         scheduleRefresh();
     }
 }
@@ -224,8 +229,11 @@ void NetworkRoute::readManager() {
         return;
     }
 
-    auto msg = QDBusMessage::createMethodCall(QString::fromUtf8(kService), QString::fromUtf8(kManagerPath),
-        QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
+    auto msg = QDBusMessage::createMethodCall(
+        QString::fromUtf8(kService),
+        QString::fromUtf8(kManagerPath),
+        QString::fromUtf8(kPropsIface),
+        QStringLiteral("GetAll"));
     msg << QString::fromUtf8(kManagerIface);
 
     step(1);

--- a/plugin/src/Caelestia/Services/networkroute.cpp
+++ b/plugin/src/Caelestia/Services/networkroute.cpp
@@ -40,13 +40,8 @@ NetworkRoute::NetworkRoute(QObject* parent)
     }
 
     // NetworkManager may not be up yet, or may restart under us.
-    bus->connect(
-        QStringLiteral("org.freedesktop.DBus"),
-        QStringLiteral("/org/freedesktop/DBus"),
-        QStringLiteral("org.freedesktop.DBus"),
-        QStringLiteral("NameOwnerChanged"),
-        QStringLiteral("sss"),
-        this,
+    bus->connect(QStringLiteral("org.freedesktop.DBus"), QStringLiteral("/org/freedesktop/DBus"),
+        QStringLiteral("org.freedesktop.DBus"), QStringLiteral("NameOwnerChanged"), QStringLiteral("sss"), this,
         SLOT(handleNameOwnerChanged(QString, QString, QString)));
 
     watchObject(QString::fromUtf8(kManagerPath));
@@ -70,7 +65,8 @@ Transport NetworkRoute::ipv6Transport() const {
 }
 
 bool NetworkRoute::mixed() const {
-    return m_current.ipv4 != config::NetworkTransport::None && m_current.ipv6 != config::NetworkTransport::None && m_current.ipv4 != m_current.ipv6;
+    return m_current.ipv4 != config::NetworkTransport::None && m_current.ipv6 != config::NetworkTransport::None &&
+           m_current.ipv4 != m_current.ipv6;
 }
 
 QString NetworkRoute::primaryInterface() const {
@@ -88,9 +84,12 @@ std::optional<QDBusConnection> NetworkRoute::systemBus() {
 
 Transport NetworkRoute::transportForDeviceType(uint deviceType) {
     switch (deviceType) {
-    case kDeviceTypeEthernet: return config::NetworkTransport::Ethernet;
-    case kDeviceTypeWifi: return config::NetworkTransport::Wifi;
-    default: return config::NetworkTransport::Other;
+    case kDeviceTypeEthernet:
+        return config::NetworkTransport::Ethernet;
+    case kDeviceTypeWifi:
+        return config::NetworkTransport::Wifi;
+    default:
+        return config::NetworkTransport::Other;
     }
 }
 
@@ -107,12 +106,8 @@ void NetworkRoute::watchObject(const QString& path) {
         return;
     }
 
-    if (bus->connect(
-            QString::fromUtf8(kService),
-            path,
-            QString::fromUtf8(kPropsIface),
-            QStringLiteral("PropertiesChanged"),
-            this,
+    if (bus->connect(QString::fromUtf8(kService), path, QString::fromUtf8(kPropsIface),
+            QStringLiteral("PropertiesChanged"), this,
             SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
         m_watched.insert(path);
     }
@@ -123,8 +118,8 @@ void NetworkRoute::handlePropertiesChanged(
     Q_UNUSED(properties);
     Q_UNUSED(invalidated);
 
-    if (iface == QString::fromUtf8(kManagerIface) || iface == QString::fromUtf8(kActiveIface)
-        || iface == QString::fromUtf8(kDeviceIface)) {
+    if (iface == QString::fromUtf8(kManagerIface) || iface == QString::fromUtf8(kActiveIface) ||
+        iface == QString::fromUtf8(kDeviceIface)) {
         scheduleRefresh();
     }
 }
@@ -229,11 +224,8 @@ void NetworkRoute::readManager() {
         return;
     }
 
-    auto msg = QDBusMessage::createMethodCall(
-        QString::fromUtf8(kService),
-        QString::fromUtf8(kManagerPath),
-        QString::fromUtf8(kPropsIface),
-        QStringLiteral("GetAll"));
+    auto msg = QDBusMessage::createMethodCall(QString::fromUtf8(kService), QString::fromUtf8(kManagerPath),
+        QString::fromUtf8(kPropsIface), QStringLiteral("GetAll"));
     msg << QString::fromUtf8(kManagerIface);
 
     step(1);

--- a/plugin/src/Caelestia/Services/networkroute.cpp
+++ b/plugin/src/Caelestia/Services/networkroute.cpp
@@ -7,8 +7,6 @@
 #include <qdbuspendingreply.h>
 #include <qloggingcategory.h>
 
-#include <utility>
-
 namespace caelestia::services {
 
 namespace {

--- a/plugin/src/Caelestia/Services/networkroute.cpp
+++ b/plugin/src/Caelestia/Services/networkroute.cpp
@@ -5,9 +5,7 @@
 #include <qdbusmessage.h>
 #include <qdbuspendingcall.h>
 #include <qdbuspendingreply.h>
-#include <qdbusreply.h>
 #include <qloggingcategory.h>
-#include <qtimer.h>
 
 #include <utility>
 
@@ -30,58 +28,11 @@ constexpr uint k_deviceTypeWifi = 2;
 
 } // namespace
 
-bool NetworkRoute::Snapshot::operator==(const Snapshot& o) const noexcept {
-    return primary == o.primary && ipv4 == o.ipv4 && ipv6 == o.ipv6 && primaryInterface == o.primaryInterface;
-}
-
 NetworkRoute::NetworkRoute(QObject* parent)
-    : QObject(parent) {
-    auto bus = systemBus();
-    if (!bus) {
-        return;
-    }
-
-    // NetworkManager may not be up yet, or may restart under us.
-    bus->connect(QStringLiteral("org.freedesktop.DBus"), QStringLiteral("/org/freedesktop/DBus"),
-        QStringLiteral("org.freedesktop.DBus"), QStringLiteral("NameOwnerChanged"), QStringLiteral("sss"), this,
-        SLOT(handleNameOwnerChanged(QString, QString, QString)));
-
-    watchObject(QString::fromUtf8(k_managerPath));
-    scheduleRefresh();
-}
-
-bool NetworkRoute::ready() const {
-    return m_ready;
-}
+    : NmWalker(QString::fromUtf8(k_managerPath), parent) {}
 
 Transport NetworkRoute::primaryTransport() const {
-    return m_current.primary;
-}
-
-Transport NetworkRoute::ipv4Transport() const {
-    return m_current.ipv4;
-}
-
-Transport NetworkRoute::ipv6Transport() const {
-    return m_current.ipv6;
-}
-
-bool NetworkRoute::mixed() const {
-    return m_current.ipv4 != config::NetworkTransport::None && m_current.ipv6 != config::NetworkTransport::None &&
-           m_current.ipv4 != m_current.ipv6;
-}
-
-QString NetworkRoute::primaryInterface() const {
-    return m_current.primaryInterface;
-}
-
-std::optional<QDBusConnection> NetworkRoute::systemBus() {
-    auto bus = QDBusConnection::systemBus();
-    if (!bus.isConnected()) {
-        qCWarning(logNetworkRoute) << "System bus unavailable";
-        return std::nullopt;
-    }
-    return bus;
+    return m_primary;
 }
 
 Transport NetworkRoute::transportForDeviceType(uint deviceType) {
@@ -95,134 +46,33 @@ Transport NetworkRoute::transportForDeviceType(uint deviceType) {
     }
 }
 
-// Subscribes to property changes on an object once. NetworkManager emits these
-// for the manager, every active connection and every device, which is what
-// tells us a walk is out of date.
-void NetworkRoute::watchObject(const QString& path) {
-    if (path.isEmpty() || path == QStringLiteral("/") || m_watched.contains(path)) {
+// The primary connection is a manager property, and its device's type is a
+// device property, so a change to either has to start a fresh walk. The active
+// connection is watched too, since its device list can change under it.
+bool NetworkRoute::triggersRefresh(const QString& iface) const {
+    return iface == QString::fromUtf8(k_managerIface) || iface == QString::fromUtf8(k_activeIface) ||
+           iface == QString::fromUtf8(k_deviceIface);
+}
+
+void NetworkRoute::publish() {
+    if (m_building == m_primary) {
         return;
     }
+
+    m_primary = m_building;
+    setListChanged();
+}
+
+void NetworkRoute::clearItems() {
+    m_primary = config::NetworkTransport::None;
+}
+
+void NetworkRoute::readRoot() {
+    m_building = config::NetworkTransport::None;
 
     auto bus = systemBus();
     if (!bus) {
-        return;
-    }
-
-    if (bus->connect(QString::fromUtf8(k_service), path, QString::fromUtf8(k_propsIface),
-            QStringLiteral("PropertiesChanged"), this,
-            SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
-        m_watched.insert(path);
-    }
-}
-
-void NetworkRoute::handlePropertiesChanged(
-    const QString& iface, const QVariantMap& properties, const QStringList& invalidated) {
-    Q_UNUSED(properties);
-    Q_UNUSED(invalidated);
-
-    if (iface == QString::fromUtf8(k_managerIface) || iface == QString::fromUtf8(k_activeIface) ||
-        iface == QString::fromUtf8(k_deviceIface)) {
-        scheduleRefresh();
-    }
-}
-
-void NetworkRoute::handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner) {
-    Q_UNUSED(oldOwner);
-
-    if (name != QString::fromUtf8(k_service)) {
-        return;
-    }
-
-    if (newOwner.isEmpty()) {
-        // NetworkManager went away; report nothing rather than stale state.
-        m_watched.clear();
-        m_ready = false;
-        m_current = Snapshot();
-        emit changed();
-        return;
-    }
-
-    // Fresh objects on the new owner, so the old subscriptions are worthless.
-    m_watched.clear();
-    watchObject(QString::fromUtf8(k_managerPath));
-    scheduleRefresh();
-}
-
-// Signals arrive in bursts - a connection going up touches the manager, the
-// active connection and its device in quick succession. Coalescing them means
-// one walk per burst instead of several racing ones.
-void NetworkRoute::scheduleRefresh() {
-    if (m_refreshing) {
-        m_refreshQueued = true;
-        return;
-    }
-
-    m_refreshing = true;
-    QTimer::singleShot(0, this, [this]() {
-        refresh();
-    });
-}
-
-void NetworkRoute::refresh() {
-    m_building = Snapshot();
-    m_primaryConnection.clear();
-    m_connIsDefault4.clear();
-    m_connIsDefault6.clear();
-    m_connTransport.clear();
-    m_connInterface.clear();
-    m_pending = 0;
-
-    readManager();
-}
-
-// Each async read holds a reference; the snapshot is applied when the last one
-// lands, so a partial walk is never published.
-void NetworkRoute::step(int delta) {
-    m_pending += delta;
-    if (m_pending > 0) {
-        return;
-    }
-
-    Snapshot snapshot;
-    snapshot.primaryInterface = m_connInterface.value(m_primaryConnection);
-    snapshot.primary = m_connTransport.value(m_primaryConnection, config::NetworkTransport::None);
-
-    for (auto it = m_connIsDefault4.cbegin(); it != m_connIsDefault4.cend(); ++it) {
-        if (it.value()) {
-            snapshot.ipv4 = m_connTransport.value(it.key(), config::NetworkTransport::None);
-            break;
-        }
-    }
-    for (auto it = m_connIsDefault6.cbegin(); it != m_connIsDefault6.cend(); ++it) {
-        if (it.value()) {
-            snapshot.ipv6 = m_connTransport.value(it.key(), config::NetworkTransport::None);
-            break;
-        }
-    }
-
-    finishRefresh(snapshot);
-}
-
-void NetworkRoute::finishRefresh(const Snapshot& snapshot) {
-    const bool wasReady = m_ready;
-    m_ready = true;
-
-    if (!wasReady || !(snapshot == m_current)) {
-        m_current = snapshot;
-        emit changed();
-    }
-
-    m_refreshing = false;
-    if (m_refreshQueued) {
-        m_refreshQueued = false;
-        scheduleRefresh();
-    }
-}
-
-void NetworkRoute::readManager() {
-    const auto bus = systemBus();
-    if (!bus) {
-        finishRefresh(Snapshot());
+        abandonWalk();
         return;
     }
 
@@ -242,26 +92,15 @@ void NetworkRoute::readManager() {
             return;
         }
 
-        const auto props = reply.value();
-        m_primaryConnection = props.value(QStringLiteral("PrimaryConnection")).value<QDBusObjectPath>().path();
-
-        const auto actives = props.value(QStringLiteral("ActiveConnections")).value<QDBusArgument>();
-        QList<QDBusObjectPath> paths;
-        actives >> paths;
-
-        for (const auto& path : std::as_const(paths)) {
-            readActiveConnection(path.path(), path.path() == m_primaryConnection);
-        }
+        readActiveConnection(reply.value().value(QStringLiteral("PrimaryConnection")).value<QDBusObjectPath>().path());
 
         step(-1);
     });
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
-void NetworkRoute::readActiveConnection(const QString& path, bool isPrimary) {
-    Q_UNUSED(isPrimary);
-
-    const auto bus = systemBus();
+void NetworkRoute::readActiveConnection(const QString& path) {
+    auto bus = systemBus();
     if (!bus || path.isEmpty() || path == QStringLiteral("/")) {
         return;
     }
@@ -285,20 +124,15 @@ void NetworkRoute::readActiveConnection(const QString& path, bool isPrimary) {
             return;
         }
 
-        const auto props = reply.value();
-        m_connIsDefault4.insert(path, props.value(QStringLiteral("Default")).toBool());
-        m_connIsDefault6.insert(path, props.value(QStringLiteral("Default6")).toBool());
-
-        const auto devices = props.value(QStringLiteral("Devices")).value<QDBusArgument>();
         QList<QDBusObjectPath> paths;
-        devices >> paths;
+        reply.value().value(QStringLiteral("Devices")).value<QDBusArgument>() >> paths;
 
         // A connection's devices are its stack bottom-up, so the first one is
         // the link the traffic actually goes over. A VPN's active connection
         // has no devices of its own beyond its tunnel, which classifies as
         // Other and leaves the underlying connection to answer for the link.
         if (!paths.isEmpty()) {
-            readDevice(path, paths.first().path());
+            readDevice(paths.first().path());
         }
 
         step(-1);
@@ -306,8 +140,8 @@ void NetworkRoute::readActiveConnection(const QString& path, bool isPrimary) {
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) watcher is parented and self-deletes
 }
 
-void NetworkRoute::readDevice(const QString& connPath, const QString& devicePath) {
-    const auto bus = systemBus();
+void NetworkRoute::readDevice(const QString& devicePath) {
+    auto bus = systemBus();
     if (!bus || devicePath.isEmpty() || devicePath == QStringLiteral("/")) {
         return;
     }
@@ -320,19 +154,17 @@ void NetworkRoute::readDevice(const QString& connPath, const QString& devicePath
 
     step(1);
     auto* watcher = new QDBusPendingCallWatcher(bus->asyncCall(msg), this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, connPath](QDBusPendingCallWatcher* call) {
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, devicePath](QDBusPendingCallWatcher* call) {
         call->deleteLater();
 
         const QDBusPendingReply<QVariantMap> reply = *call;
         if (reply.isError()) {
-            qCDebug(logNetworkRoute) << "Skipping device for" << connPath << ":" << reply.error().message();
+            qCDebug(logNetworkRoute) << "Skipping device" << devicePath << ":" << reply.error().message();
             step(-1);
             return;
         }
 
-        const auto props = reply.value();
-        m_connTransport.insert(connPath, transportForDeviceType(props.value(QStringLiteral("DeviceType")).toUInt()));
-        m_connInterface.insert(connPath, props.value(QStringLiteral("Interface")).toString());
+        m_building = transportForDeviceType(reply.value().value(QStringLiteral("DeviceType")).toUInt());
 
         step(-1);
     });

--- a/plugin/src/Caelestia/Services/networkroute.hpp
+++ b/plugin/src/Caelestia/Services/networkroute.hpp
@@ -9,9 +9,9 @@
 #include <qstringlist.h>
 #include <qvariant.h>
 
-#include "config/enums.hpp"
-
 #include <optional>
+
+#include "config/enums.hpp"
 
 namespace caelestia::services {
 

--- a/plugin/src/Caelestia/Services/networkroute.hpp
+++ b/plugin/src/Caelestia/Services/networkroute.hpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <qdbusconnection.h>
+#include <qhash.h>
+#include <qobject.h>
+#include <qqmlintegration.h>
+#include <qset.h>
+#include <qstring.h>
+#include <qstringlist.h>
+#include <qvariant.h>
+
+#include "config/enums.hpp"
+
+#include <optional>
+
+namespace caelestia::services {
+
+using Transport = config::NetworkTransport::Enum;
+
+// Which kind of link the system is actually routing through, read from
+// NetworkManager rather than reconstructed from the routing table.
+//
+// "Is a cable plugged in" and "is traffic going over it" are different
+// questions, and the routing table alone can't answer the second one either:
+// a VPN owns the default route while the traffic underneath it still leaves
+// over ethernet or wifi. NetworkManager already tracks this - the primary
+// connection, and which active connection holds the v4 and v6 defaults - so
+// this follows those to their devices and classifies them by device type.
+class NetworkRoute : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+    // False until a full snapshot has been read; consumers should keep their
+    // previous behaviour until then rather than acting on empty state.
+    Q_PROPERTY(bool ready READ ready NOTIFY changed)
+    Q_PROPERTY(caelestia::config::NetworkTransport::Enum primaryTransport READ primaryTransport NOTIFY changed)
+    Q_PROPERTY(caelestia::config::NetworkTransport::Enum ipv4Transport READ ipv4Transport NOTIFY changed)
+    Q_PROPERTY(caelestia::config::NetworkTransport::Enum ipv6Transport READ ipv6Transport NOTIFY changed)
+    // True when v4 and v6 both have a default and they're on different kinds
+    // of link, so a UI showing a single icon can tell it's simplifying.
+    Q_PROPERTY(bool mixed READ mixed NOTIFY changed)
+    Q_PROPERTY(QString primaryInterface READ primaryInterface NOTIFY changed)
+
+public:
+    explicit NetworkRoute(QObject* parent = nullptr);
+
+    [[nodiscard]] bool ready() const;
+    [[nodiscard]] Transport primaryTransport() const;
+    [[nodiscard]] Transport ipv4Transport() const;
+    [[nodiscard]] Transport ipv6Transport() const;
+    [[nodiscard]] bool mixed() const;
+    [[nodiscard]] QString primaryInterface() const;
+
+signals:
+    void changed();
+
+private slots:
+    void handlePropertiesChanged(const QString& iface, const QVariantMap& properties, const QStringList& invalidated);
+    void handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner);
+
+private:
+    struct Snapshot {
+        Transport primary = Transport::None;
+        Transport ipv4 = Transport::None;
+        Transport ipv6 = Transport::None;
+        QString primaryInterface;
+
+        bool operator==(const Snapshot& o) const noexcept;
+    };
+
+    // One refresh at a time, with a flag to run again afterwards. Bursts of
+    // NetworkManager signals would otherwise each start their own walk of the
+    // object tree and land out of order.
+    void scheduleRefresh();
+    void refresh();
+    void finishRefresh(const Snapshot& snapshot);
+
+    void readManager();
+    void readActiveConnection(const QString& path, bool isPrimary);
+    void readDevice(const QString& connPath, const QString& devicePath);
+    void step(int delta);
+
+    void watchObject(const QString& path);
+
+    [[nodiscard]] static std::optional<QDBusConnection> systemBus();
+    [[nodiscard]] static Transport transportForDeviceType(uint deviceType);
+
+    bool m_ready = false;
+    Snapshot m_current;
+
+    bool m_refreshing = false;
+    bool m_refreshQueued = false;
+    int m_pending = 0;
+
+    // State being assembled by the in-flight refresh.
+    Snapshot m_building;
+    QString m_primaryConnection;
+    QHash<QString, bool> m_connIsDefault4;
+    QHash<QString, bool> m_connIsDefault6;
+    QHash<QString, Transport> m_connTransport;
+    QHash<QString, QString> m_connInterface;
+    QSet<QString> m_watched;
+};
+
+} // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkroute.hpp
+++ b/plugin/src/Caelestia/Services/networkroute.hpp
@@ -9,9 +9,9 @@
 #include <qstringlist.h>
 #include <qvariant.h>
 
-#include <optional>
-
 #include "config/enums.hpp"
+
+#include <optional>
 
 namespace caelestia::services {
 

--- a/plugin/src/Caelestia/Services/networkroute.hpp
+++ b/plugin/src/Caelestia/Services/networkroute.hpp
@@ -1,17 +1,13 @@
 #pragma once
 
-#include <qdbusconnection.h>
-#include <qhash.h>
 #include <qobject.h>
 #include <qqmlintegration.h>
-#include <qset.h>
 #include <qstring.h>
 #include <qstringlist.h>
 #include <qvariant.h>
 
-#include <optional>
-
 #include "config/enums.hpp"
+#include "networkwalker.hpp"
 
 namespace caelestia::services {
 
@@ -23,84 +19,35 @@ using Transport = config::NetworkTransport::Enum;
 // "Is a cable plugged in" and "is traffic going over it" are different
 // questions, and the routing table alone can't answer the second one either:
 // a VPN owns the default route while the traffic underneath it still leaves
-// over ethernet or wifi. NetworkManager already tracks this - the primary
-// connection, and which active connection holds the v4 and v6 defaults - so
-// this follows those to their devices and classifies them by device type.
-class NetworkRoute : public QObject {
+// over ethernet or wifi. NetworkManager already tracks this as its primary
+// connection, so this follows that to its device and classifies it by type.
+class NetworkRoute : public NmWalker {
     Q_OBJECT
     QML_ELEMENT
     QML_SINGLETON
 
-    // False until a full snapshot has been read; consumers should keep their
-    // previous behaviour until then rather than acting on empty state.
-    Q_PROPERTY(bool ready READ ready NOTIFY changed)
     Q_PROPERTY(caelestia::config::NetworkTransport::Enum primaryTransport READ primaryTransport NOTIFY changed)
-    Q_PROPERTY(caelestia::config::NetworkTransport::Enum ipv4Transport READ ipv4Transport NOTIFY changed)
-    Q_PROPERTY(caelestia::config::NetworkTransport::Enum ipv6Transport READ ipv6Transport NOTIFY changed)
-    // True when v4 and v6 both have a default and they're on different kinds
-    // of link, so a UI showing a single icon can tell it's simplifying.
-    Q_PROPERTY(bool mixed READ mixed NOTIFY changed)
-    Q_PROPERTY(QString primaryInterface READ primaryInterface NOTIFY changed)
 
 public:
     explicit NetworkRoute(QObject* parent = nullptr);
 
-    [[nodiscard]] bool ready() const;
     [[nodiscard]] Transport primaryTransport() const;
-    [[nodiscard]] Transport ipv4Transport() const;
-    [[nodiscard]] Transport ipv6Transport() const;
-    [[nodiscard]] bool mixed() const;
-    [[nodiscard]] QString primaryInterface() const;
 
-signals:
-    void changed();
-
-private slots:
-    void handlePropertiesChanged(const QString& iface, const QVariantMap& properties, const QStringList& invalidated);
-    void handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner);
+protected:
+    void readRoot() override;
+    [[nodiscard]] bool triggersRefresh(const QString& iface) const override;
+    void publish() override;
+    void clearItems() override;
 
 private:
-    struct Snapshot {
-        Transport primary = Transport::None;
-        Transport ipv4 = Transport::None;
-        Transport ipv6 = Transport::None;
-        QString primaryInterface;
+    void readActiveConnection(const QString& path);
+    void readDevice(const QString& devicePath);
 
-        bool operator==(const Snapshot& o) const noexcept;
-    };
-
-    // One refresh at a time, with a flag to run again afterwards. Bursts of
-    // NetworkManager signals would otherwise each start their own walk of the
-    // object tree and land out of order.
-    void scheduleRefresh();
-    void refresh();
-    void finishRefresh(const Snapshot& snapshot);
-
-    void readManager();
-    void readActiveConnection(const QString& path, bool isPrimary);
-    void readDevice(const QString& connPath, const QString& devicePath);
-    void step(int delta);
-
-    void watchObject(const QString& path);
-
-    [[nodiscard]] static std::optional<QDBusConnection> systemBus();
     [[nodiscard]] static Transport transportForDeviceType(uint deviceType);
 
-    bool m_ready = false;
-    Snapshot m_current;
-
-    bool m_refreshing = false;
-    bool m_refreshQueued = false;
-    int m_pending = 0;
-
-    // State being assembled by the in-flight refresh.
-    Snapshot m_building;
-    QString m_primaryConnection;
-    QHash<QString, bool> m_connIsDefault4;
-    QHash<QString, bool> m_connIsDefault6;
-    QHash<QString, Transport> m_connTransport;
-    QHash<QString, QString> m_connInterface;
-    QSet<QString> m_watched;
+    Transport m_primary = config::NetworkTransport::None;
+    // What the walk in progress has worked out so far.
+    Transport m_building = config::NetworkTransport::None;
 };
 
 } // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkroute.hpp
+++ b/plugin/src/Caelestia/Services/networkroute.hpp
@@ -3,8 +3,6 @@
 #include <qobject.h>
 #include <qqmlintegration.h>
 #include <qstring.h>
-#include <qstringlist.h>
-#include <qvariant.h>
 
 #include "config/enums.hpp"
 #include "networkwalker.hpp"

--- a/plugin/src/Caelestia/Services/networkwalker.cpp
+++ b/plugin/src/Caelestia/Services/networkwalker.cpp
@@ -11,8 +11,8 @@ namespace {
 
 Q_LOGGING_CATEGORY(logNmWalker, "caelestia.services.nmwalker", QtWarningMsg);
 
-constexpr const char* kService = "org.freedesktop.NetworkManager";
-constexpr const char* kPropsIface = "org.freedesktop.DBus.Properties";
+constexpr const char* k_service = "org.freedesktop.NetworkManager";
+constexpr const char* k_propsIface = "org.freedesktop.DBus.Properties";
 
 } // namespace
 
@@ -25,13 +25,8 @@ NmWalker::NmWalker(QString rootPath, QObject* parent)
     }
 
     // NetworkManager may not be up yet, or may restart under us.
-    bus->connect(
-        QStringLiteral("org.freedesktop.DBus"),
-        QStringLiteral("/org/freedesktop/DBus"),
-        QStringLiteral("org.freedesktop.DBus"),
-        QStringLiteral("NameOwnerChanged"),
-        QStringLiteral("sss"),
-        this,
+    bus->connect(QStringLiteral("org.freedesktop.DBus"), QStringLiteral("/org/freedesktop/DBus"),
+        QStringLiteral("org.freedesktop.DBus"), QStringLiteral("NameOwnerChanged"), QStringLiteral("sss"), this,
         SLOT(handleNameOwnerChanged(QString, QString, QString)));
 
     watchObject(m_rootPath);
@@ -73,12 +68,8 @@ void NmWalker::watchObject(const QString& path) {
         return;
     }
 
-    if (bus->connect(
-            QString::fromUtf8(kService),
-            path,
-            QString::fromUtf8(kPropsIface),
-            QStringLiteral("PropertiesChanged"),
-            this,
+    if (bus->connect(QString::fromUtf8(k_service), path, QString::fromUtf8(k_propsIface),
+            QStringLiteral("PropertiesChanged"), this,
             SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
         m_watched.insert(path);
     }
@@ -97,7 +88,7 @@ void NmWalker::handlePropertiesChanged(
 void NmWalker::handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner) {
     Q_UNUSED(oldOwner);
 
-    if (name != QString::fromUtf8(kService)) {
+    if (name != QString::fromUtf8(k_service)) {
         return;
     }
 

--- a/plugin/src/Caelestia/Services/networkwalker.cpp
+++ b/plugin/src/Caelestia/Services/networkwalker.cpp
@@ -1,0 +1,173 @@
+#include "networkwalker.hpp"
+
+#include <qloggingcategory.h>
+#include <qtimer.h>
+
+#include <utility>
+
+namespace caelestia::services {
+
+namespace {
+
+Q_LOGGING_CATEGORY(logNmWalker, "caelestia.services.nmwalker", QtWarningMsg);
+
+constexpr const char* kService = "org.freedesktop.NetworkManager";
+constexpr const char* kPropsIface = "org.freedesktop.DBus.Properties";
+
+} // namespace
+
+NmWalker::NmWalker(QString rootPath, QObject* parent)
+    : QObject(parent)
+    , m_rootPath(std::move(rootPath)) {
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    // NetworkManager may not be up yet, or may restart under us.
+    bus->connect(
+        QStringLiteral("org.freedesktop.DBus"),
+        QStringLiteral("/org/freedesktop/DBus"),
+        QStringLiteral("org.freedesktop.DBus"),
+        QStringLiteral("NameOwnerChanged"),
+        QStringLiteral("sss"),
+        this,
+        SLOT(handleNameOwnerChanged(QString, QString, QString)));
+
+    watchObject(m_rootPath);
+    scheduleRefresh();
+}
+
+bool NmWalker::ready() const {
+    return m_ready;
+}
+
+bool NmWalker::walking() const {
+    return m_refreshing;
+}
+
+QSet<QString>& NmWalker::seen() {
+    return m_seen;
+}
+
+void NmWalker::setListChanged() {
+    m_listChanged = true;
+}
+
+std::optional<QDBusConnection> NmWalker::systemBus() {
+    auto bus = QDBusConnection::systemBus();
+    if (!bus.isConnected()) {
+        qCWarning(logNmWalker) << "System bus unavailable";
+        return std::nullopt;
+    }
+    return bus;
+}
+
+void NmWalker::watchObject(const QString& path) {
+    if (path.isEmpty() || path == QStringLiteral("/") || m_watched.contains(path)) {
+        return;
+    }
+
+    auto bus = systemBus();
+    if (!bus) {
+        return;
+    }
+
+    if (bus->connect(
+            QString::fromUtf8(kService),
+            path,
+            QString::fromUtf8(kPropsIface),
+            QStringLiteral("PropertiesChanged"),
+            this,
+            SLOT(handlePropertiesChanged(QString, QVariantMap, QStringList)))) {
+        m_watched.insert(path);
+    }
+}
+
+void NmWalker::handlePropertiesChanged(
+    const QString& iface, const QVariantMap& properties, const QStringList& invalidated) {
+    Q_UNUSED(properties);
+    Q_UNUSED(invalidated);
+
+    if (triggersRefresh(iface)) {
+        scheduleRefresh();
+    }
+}
+
+void NmWalker::handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner) {
+    Q_UNUSED(oldOwner);
+
+    if (name != QString::fromUtf8(kService)) {
+        return;
+    }
+
+    m_watched.clear();
+
+    if (newOwner.isEmpty()) {
+        clearItems();
+        m_ready = false;
+        emit itemsChanged();
+        emit changed();
+        return;
+    }
+
+    // Fresh objects on the new owner, so the old subscriptions are worthless.
+    watchObject(m_rootPath);
+    scheduleRefresh();
+}
+
+void NmWalker::scheduleRefresh() {
+    if (m_refreshing) {
+        m_refreshQueued = true;
+        return;
+    }
+
+    m_refreshing = true;
+    QTimer::singleShot(0, this, [this]() {
+        refresh();
+    });
+}
+
+void NmWalker::refresh() {
+    m_seen.clear();
+    m_listChanged = false;
+    m_pending = 0;
+
+    readRoot();
+}
+
+void NmWalker::step(int delta) {
+    m_pending += delta;
+    if (m_pending > 0) {
+        return;
+    }
+
+    finish();
+}
+
+void NmWalker::abandonWalk() {
+    m_pending = 0;
+    finish();
+}
+
+void NmWalker::finish() {
+    pruneUnseen();
+
+    const bool wasReady = m_ready;
+    m_ready = true;
+
+    if (m_listChanged) {
+        emit itemsChanged();
+    }
+    if (!wasReady || m_listChanged) {
+        emit changed();
+    }
+
+    m_refreshing = false;
+    if (m_refreshQueued) {
+        m_refreshQueued = false;
+        scheduleRefresh();
+    }
+}
+
+} // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkwalker.cpp
+++ b/plugin/src/Caelestia/Services/networkwalker.cpp
@@ -142,7 +142,7 @@ void NmWalker::abandonWalk() {
 }
 
 void NmWalker::finish() {
-    pruneUnseen();
+    publish();
 
     const bool wasReady = m_ready;
     m_ready = true;

--- a/plugin/src/Caelestia/Services/networkwalker.hpp
+++ b/plugin/src/Caelestia/Services/networkwalker.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <qdbusconnection.h>
+#include <qobject.h>
+#include <qset.h>
+#include <qstring.h>
+#include <qstringlist.h>
+#include <qvariant.h>
+
+#include <optional>
+
+namespace caelestia::services {
+
+// Shared plumbing for the singletons that mirror a NetworkManager object tree
+// over D-Bus.
+//
+// Both of them do the same thing: subscribe to a root object, walk it whenever
+// something changes, hold every async read open so a partial tree is never
+// published, and drop whatever the walk didn't see. Only the objects being
+// walked differ, so that part is left to subclasses.
+class NmWalker : public QObject {
+    Q_OBJECT
+
+    // False until a full snapshot has been read, so consumers can hold their
+    // previous behaviour rather than acting on an empty list.
+    Q_PROPERTY(bool ready READ ready NOTIFY changed)
+
+public:
+    [[nodiscard]] bool ready() const;
+
+signals:
+    void changed();
+    void itemsChanged();
+
+protected:
+    explicit NmWalker(QString rootPath, QObject* parent = nullptr);
+
+    // Reads the root object and issues a read per child. Called once per walk.
+    virtual void readRoot() = 0;
+    // Whether a PropertiesChanged on this interface means the tree moved.
+    // Interfaces whose objects track themselves should say no.
+    [[nodiscard]] virtual bool triggersRefresh(const QString& iface) const = 0;
+    // Drops anything whose path isn't in seen(). Should set listChanged() when
+    // it removes something.
+    virtual void pruneUnseen() = 0;
+    // NetworkManager went away; report nothing rather than a stale tree.
+    virtual void clearItems() = 0;
+
+    // One walk at a time, with a flag to run again after. Bursts of signals
+    // would otherwise each start their own and land out of order.
+    void scheduleRefresh();
+    // Each async read holds a reference; the result is published when the last
+    // one lands. Only for reads belonging to a walk: a read started outside one
+    // must not touch this, or it will drive the count to zero mid-walk.
+    void step(int delta);
+    // Ends a walk that can't start, so the ready flag isn't held back forever.
+    void abandonWalk();
+    void watchObject(const QString& path);
+
+    [[nodiscard]] bool walking() const;
+    [[nodiscard]] QSet<QString>& seen();
+    void setListChanged();
+
+    [[nodiscard]] static std::optional<QDBusConnection> systemBus();
+
+private slots:
+    void handlePropertiesChanged(const QString& iface, const QVariantMap& properties, const QStringList& invalidated);
+    void handleNameOwnerChanged(const QString& name, const QString& oldOwner, const QString& newOwner);
+
+private:
+    void refresh();
+    void finish();
+
+    QString m_rootPath;
+    bool m_ready = false;
+
+    // Paths seen by the walk in progress; anything missing afterwards has gone.
+    QSet<QString> m_seen;
+
+    bool m_refreshing = false;
+    bool m_refreshQueued = false;
+    int m_pending = 0;
+    bool m_listChanged = false;
+
+    QSet<QString> m_watched;
+};
+
+} // namespace caelestia::services

--- a/plugin/src/Caelestia/Services/networkwalker.hpp
+++ b/plugin/src/Caelestia/Services/networkwalker.hpp
@@ -40,9 +40,10 @@ protected:
     // Whether a PropertiesChanged on this interface means the tree moved.
     // Interfaces whose objects track themselves should say no.
     [[nodiscard]] virtual bool triggersRefresh(const QString& iface) const = 0;
-    // Drops anything whose path isn't in seen(). Should set listChanged() when
-    // it removes something.
-    virtual void pruneUnseen() = 0;
+    // Applies what the walk found, once every read has landed. Should call
+    // setListChanged() when the result differs from what consumers were last
+    // told, which is what makes the change signal fire.
+    virtual void publish() = 0;
     // NetworkManager went away; report nothing rather than a stale tree.
     virtual void clearItems() = 0;
 

--- a/services/NmAction.qml
+++ b/services/NmAction.qml
@@ -30,6 +30,7 @@ Singleton {
             property var callback: null
             property string error: ""
 
+            // qmllint disable incompatible-type
             environment: ({
                     LANG: "C.UTF-8",
                     LC_ALL: "C.UTF-8"

--- a/services/NmAction.qml
+++ b/services/NmAction.qml
@@ -1,0 +1,50 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// One-shot nmcli calls for the network services.
+//
+// Only the exit code and, for the handful of callers that have to tell one
+// failure from another, stderr matter: there's no output to parse and no shared
+// state to race, since state comes from NetworkManager over dbus.
+Singleton {
+    id: root
+
+    // Runs nmcli with `args`. The callback takes (success, error).
+    function run(args: list<string>, callback: var): void {
+        const proc = actionProc.createObject(root, {
+            command: ["nmcli", ...args],
+            callback: callback ?? null
+        });
+        proc.running = true;
+    }
+
+    Component {
+        id: actionProc
+
+        Process {
+            id: proc
+
+            property var callback: null
+            property string error: ""
+
+            environment: ({
+                    LANG: "C.UTF-8",
+                    LC_ALL: "C.UTF-8"
+                })
+
+            stderr: StdioCollector {
+                onStreamFinished: proc.error = text
+            }
+
+            onExited: code => { // qmllint disable signal-handler-parameters
+                const callback = proc.callback;
+                const error = proc.error;
+                proc.destroy();
+                callback?.(code === 0, error);
+            }
+        }
+    }
+}

--- a/services/NmAction.qml
+++ b/services/NmAction.qml
@@ -6,13 +6,12 @@ import Quickshell.Io
 
 // One-shot nmcli calls for the network services.
 //
-// Only the exit code and, for the handful of callers that have to tell one
-// failure from another, stderr matter: there's no output to parse and no shared
-// state to race, since state comes from NetworkManager over dbus.
+// Only the exit code matters: there's no output to parse and no shared state to
+// race, since state comes from NetworkManager over dbus.
 Singleton {
     id: root
 
-    // Runs nmcli with `args`. The callback takes (success, error).
+    // Runs nmcli with `args`. The callback takes (success).
     function run(args: list<string>, callback: var): void {
         const proc = actionProc.createObject(root, {
             command: ["nmcli", ...args],
@@ -28,7 +27,6 @@ Singleton {
             id: proc
 
             property var callback: null
-            property string error: ""
 
             // qmllint disable incompatible-type
             environment: ({
@@ -36,15 +34,10 @@ Singleton {
                     LC_ALL: "C.UTF-8"
                 })
 
-            stderr: StdioCollector {
-                onStreamFinished: proc.error = text
-            }
-
             onExited: code => { // qmllint disable signal-handler-parameters
                 const callback = proc.callback;
-                const error = proc.error;
                 proc.destroy();
-                callback?.(code === 0, error);
+                callback?.(code === 0);
             }
         }
     }

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -4,6 +4,8 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import Quickshell
 import Quickshell.Io
+import Caelestia.Config
+import Caelestia.Services
 
 Singleton {
     id: root
@@ -34,19 +36,19 @@ Singleton {
     property string ethernetSpeed: ""
     readonly property list<EthernetDevice> ethernetDevices: []
     readonly property EthernetDevice activeEthernet: ethernetDevices.find(d => d.connected) ?? null
+    // Whether traffic is actually leaving over a wired link, which isn't the
+    // same question as whether a cable is plugged in - with both a cable and
+    // wifi up, either can be carrying it. NetworkManager already tracks which
+    // connection is primary, so this follows that rather than guessing.
+    //
+    // Falls back to activeEthernet until a full snapshot has been read, so the
+    // icon doesn't flicker through a wrong state on startup or if
+    // NetworkManager isn't reachable.
+    readonly property bool onEthernet: NetworkRoute.ready ? NetworkRoute.primaryTransport === NetworkTransport.Ethernet : !!activeEthernet
     // True when at least one wired device has a carrier (cable plugged in).
     // nmcli reports "unavailable" for ethernet NICs with no link, so we treat
     // anything other than that as a usable connection.
     readonly property bool hasAvailableEthernet: ethernetDevices.some(d => d.state !== "unavailable")
-    // Interface carrying the default route, i.e. the one traffic actually
-    // leaves through. Not the same question as whether a device is connected:
-    // with both a cable and Wi-Fi up, either can hold the route depending on
-    // the metrics, and it changes without any device changing state.
-    property string defaultRouteInterface: ""
-    // Whether traffic is leaving over a wired link. Falls back to "a cable is
-    // connected" until the routing table has been read, so nothing flickers on
-    // startup.
-    readonly property bool onEthernet: !!activeEthernet && (!defaultRouteInterface || ethernetDevices.some(d => d.iface === defaultRouteInterface))
     property list<var> activeProcesses: []
 
     readonly property alias connectionCheckTimer: connectionCheckTimer
@@ -1407,15 +1409,7 @@ Singleton {
         return details;
     }
 
-    // NetworkManager doesn't report which connection owns the default route -
-    // `connection show --active` has no field for it - so read it from the
-    // routing table. Lowest metric wins, which is what the kernel picks.
-    function refreshDefaultRoute(): void {
-        defaultRouteProc.running = true;
-    }
-
     function refreshOnConnectionChange(): void {
-        refreshDefaultRoute();
         getNetworks(networks => {
             const newActive = root.active;
 
@@ -1456,7 +1450,6 @@ Singleton {
     }
 
     Component.onCompleted: {
-        refreshDefaultRoute();
         getWifiStatus(() => {});
         getNetworks(() => {});
         loadSavedConnections(() => {});
@@ -1724,30 +1717,6 @@ Singleton {
 
         command: ["nmcli", "dev", root.nmcliCommandWifi, "list", "--rescan", "yes"]
         onExited: root.getNetworks() // qmllint disable signal-handler-parameters
-    }
-
-    Process {
-        id: defaultRouteProc
-
-        command: ["ip", "-j", "route", "show", "default"]
-        environment: ({
-                LANG: "C.UTF-8",
-                LC_ALL: "C.UTF-8"
-            })
-        stdout: StdioCollector {
-            onStreamFinished: {
-                let best = null;
-                try {
-                    for (const route of JSON.parse(text || "[]"))
-                        if (route.dev && (best === null || (route.metric ?? 0) < (best.metric ?? 0)))
-                            best = route;
-                } catch (error) {
-                    console.warn(lc, `Unable to parse routing table: ${error}`);
-                    return;
-                }
-                root.defaultRouteInterface = best?.dev ?? "";
-            }
-        }
     }
 
     Process {

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -38,6 +38,15 @@ Singleton {
     // nmcli reports "unavailable" for ethernet NICs with no link, so we treat
     // anything other than that as a usable connection.
     readonly property bool hasAvailableEthernet: ethernetDevices.some(d => d.state !== "unavailable")
+    // Interface carrying the default route, i.e. the one traffic actually
+    // leaves through. Not the same question as whether a device is connected:
+    // with both a cable and Wi-Fi up, either can hold the route depending on
+    // the metrics, and it changes without any device changing state.
+    property string defaultRouteInterface: ""
+    // Whether traffic is leaving over a wired link. Falls back to "a cable is
+    // connected" until the routing table has been read, so nothing flickers on
+    // startup.
+    readonly property bool onEthernet: !!activeEthernet && (!defaultRouteInterface || ethernetDevices.some(d => d.iface === defaultRouteInterface))
     property list<var> activeProcesses: []
 
     readonly property alias connectionCheckTimer: connectionCheckTimer
@@ -1398,7 +1407,15 @@ Singleton {
         return details;
     }
 
+    // NetworkManager doesn't report which connection owns the default route -
+    // `connection show --active` has no field for it - so read it from the
+    // routing table. Lowest metric wins, which is what the kernel picks.
+    function refreshDefaultRoute(): void {
+        defaultRouteProc.running = true;
+    }
+
     function refreshOnConnectionChange(): void {
+        refreshDefaultRoute();
         getNetworks(networks => {
             const newActive = root.active;
 
@@ -1439,6 +1456,7 @@ Singleton {
     }
 
     Component.onCompleted: {
+        refreshDefaultRoute();
         getWifiStatus(() => {});
         getNetworks(() => {});
         loadSavedConnections(() => {});
@@ -1706,6 +1724,30 @@ Singleton {
 
         command: ["nmcli", "dev", root.nmcliCommandWifi, "list", "--rescan", "yes"]
         onExited: root.getNetworks() // qmllint disable signal-handler-parameters
+    }
+
+    Process {
+        id: defaultRouteProc
+
+        command: ["ip", "-j", "route", "show", "default"]
+        environment: ({
+                LANG: "C.UTF-8",
+                LC_ALL: "C.UTF-8"
+            })
+        stdout: StdioCollector {
+            onStreamFinished: {
+                let best = null;
+                try {
+                    for (const route of JSON.parse(text || "[]"))
+                        if (route.dev && (best === null || (route.metric ?? 0) < (best.metric ?? 0)))
+                            best = route;
+                } catch (error) {
+                    console.warn(lc, `Unable to parse routing table: ${error}`);
+                    return;
+                }
+                root.defaultRouteInterface = best?.dev ?? "";
+            }
+        }
     }
 
     Process {

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -6,13 +6,13 @@ import Quickshell
 import Quickshell.Io
 import Caelestia.Config
 import Caelestia.Services
+import qs.services
 
 Singleton {
     id: root
 
     property var deviceStatus: null
     property var wirelessInterfaces: []
-    property var ethernetInterfaces: []
     property bool isConnected: false
     readonly property bool connecting: wirelessInterfaces.some(i => isConnectingState(i.state))
     property string activeInterface: ""
@@ -31,11 +31,12 @@ Singleton {
     property var pendingConnection: null
     property var wirelessDeviceDetails: null
     property var ethernetDeviceDetails: null
-    property string ethernetDataUsage: ""
-    // Link speed of the active ethernet interface (from sysfs), e.g. "1 Gbps".
-    property string ethernetSpeed: ""
-    readonly property list<EthernetDevice> ethernetDevices: []
-    readonly property EthernetDevice activeEthernet: ethernetDevices.find(d => d.connected) ?? null
+    // Wired state lives in Wired now, read from NetworkManager over dbus.
+    // These forward it so existing consumers keep working unchanged.
+    readonly property string ethernetDataUsage: Wired.dataUsage
+    readonly property string ethernetSpeed: Wired.speed
+    readonly property list<var> ethernetDevices: Wired.devices
+    readonly property var activeEthernet: Wired.active
     // Whether traffic is actually leaving over a wired link, which isn't the
     // same question as whether a cable is plugged in - with both a cable and
     // wifi up, either can be carrying it. NetworkManager already tracks which
@@ -45,10 +46,7 @@ Singleton {
     // icon doesn't flicker through a wrong state on startup or if
     // NetworkManager isn't reachable.
     readonly property bool onEthernet: NetworkRoute.ready ? NetworkRoute.primaryTransport === NetworkTransport.Ethernet : !!activeEthernet
-    // True when at least one wired device has a carrier (cable plugged in).
-    // nmcli reports "unavailable" for ethernet NICs with no link, so we treat
-    // anything other than that as a usable connection.
-    readonly property bool hasAvailableEthernet: ethernetDevices.some(d => d.state !== "unavailable")
+    readonly property bool hasAvailableEthernet: Wired.available
     property list<var> activeProcesses: []
 
     readonly property alias connectionCheckTimer: connectionCheckTimer
@@ -232,149 +230,30 @@ Singleton {
         });
     }
 
+    // Kept so existing callers still get their callback; the device list is
+    // a live binding on Wired now, so there is nothing to fetch.
     function getEthernetInterfaces(callback: var): void {
-        executeCommand(["-t", "-f", root.deviceStatusFields, root.nmcliCommandDevice, "status"], result => {
-            const interfaces = parseDeviceStatusOutput(result.output, root.deviceTypeEthernet);
-            const applyInterfaces = filtered => {
-                const devices = filtered.map(iface => ({
-                            interface: iface.device,
-                            type: iface.type,
-                            state: iface.state,
-                            connection: iface.connection,
-                            connected: isConnectedState(iface.state),
-                            ipAddress: "",
-                            gateway: "",
-                            dns: [],
-                            subnet: "",
-                            macAddress: "",
-                            speed: ""
-                        }));
-
-                root.ethernetInterfaces = filtered;
-                syncEthernetDevices(devices);
-                if (callback)
-                    callback(filtered);
-            };
-
-            if (interfaces.length === 0) {
-                applyInterfaces([]);
-                return;
-            }
-
-            // NetworkManager reports container/VM veth pairs (Docker, Podman,
-            // etc.) as type "ethernet" too, so they'd show up here like real
-            // connections. A physical NIC always has
-            // /sys/class/net/<iface>/device; veth/bridge/tun interfaces
-            // never do, so that's how we tell them apart.
-            const proc = physicalCheckProc.createObject(root);
-            proc.callback = result => {
-                if (!result.success) {
-                    console.warn(lc, `Failed to classify ethernet interfaces (exited: ${result.exitCode}); keeping the unfiltered list.`);
-                    applyInterfaces(interfaces);
-                    return;
-                }
-
-                const physicalSet = result.output.trim().split("\n").filter(l => l.length > 0);
-                const filtered = interfaces.filter(iface => physicalSet.includes(iface.device));
-
-                applyInterfaces(filtered);
-            };
-
-            proc.exec(["sh", "-c", 'test -d /sys/class/net || exit 1; for i do [ -e "/sys/class/net/$i/device" ] && printf "%s\\n" "$i"; done; exit 0', "sh", ...interfaces.map(iface => iface.device)]);
-        });
-    }
-
-    // Sync a list of ethernet devices to the existing device list. Same logic as getNetworks
-    function syncEthernetDevices(devices: list<var>): void {
-        const rDevices = root.ethernetDevices;
-
-        const newMap = new Map();
-        for (const d of devices)
-            newMap.set(d.interface, d);
-
-        for (let i = rDevices.length - 1; i >= 0; i--) {
-            if (!newMap.has(rDevices[i].iface)) {
-                const removed = rDevices.splice(i, 1)[0];
-                removed.destroy();
-            }
-        }
-
-        const existingMap = new Map();
-        for (const rd of rDevices)
-            existingMap.set(rd.iface, rd);
-
-        for (const [iface, data] of newMap) {
-            const match = existingMap.get(iface);
-            if (match)
-                match.lastIpcObject = data;
-            else
-                rDevices.push(ethComp.createObject(root, {
-                    lastIpcObject: data
-                }));
-        }
+        if (callback)
+            callback(root.ethernetDevices);
     }
 
     function connectEthernet(connectionName: string, interfaceName: string, callback: var): void {
-        if (connectionName && connectionName.length > 0) {
-            executeCommand([root.nmcliCommandConnection, "up", connectionName], result => {
-                if (result.success) {
-                    Qt.callLater(() => {
-                        getEthernetInterfaces(() => {});
-                        if (interfaceName && interfaceName.length > 0) {
-                            Qt.callLater(() => {
-                                getEthernetDeviceDetails(interfaceName, () => {});
-                            }, 1000);
-                        }
-                    }, 500);
-                }
-                if (callback)
-                    callback(result);
-            });
-        } else if (interfaceName && interfaceName.length > 0) {
-            executeCommand([root.nmcliCommandDevice, "connect", interfaceName], result => {
-                if (result.success) {
-                    Qt.callLater(() => {
-                        getEthernetInterfaces(() => {});
-                        Qt.callLater(() => {
-                            getEthernetDeviceDetails(interfaceName, () => {});
-                        }, 1000);
-                    }, 500);
-                }
-                if (callback)
-                    callback(result);
-            });
-        } else {
+        Wired.connect(connectionName, interfaceName, success => {
+            // The device list updates itself; details still come from nmcli, and
+            // NM needs a moment after activation before they are worth reading.
+            if (success && interfaceName)
+                Qt.callLater(() => getEthernetDeviceDetails(interfaceName, () => {}), 1000);
             if (callback)
-                callback({
-                    success: false,
-                    output: "",
-                    error: "No connection name or interface specified",
-                    exitCode: -1
-                });
-        }
+                callback(success);
+        });
     }
 
     function disconnectEthernet(connectionName: string, callback: var): void {
-        if (!connectionName || connectionName.length === 0) {
-            if (callback)
-                callback({
-                    success: false,
-                    output: "",
-                    error: "No connection name specified",
-                    exitCode: -1
-                });
-            return;
-        }
-
-        executeCommand([root.nmcliCommandConnection, "down", connectionName], result => {
-            if (result.success) {
+        Wired.disconnect(connectionName, success => {
+            if (success)
                 root.ethernetDeviceDetails = null;
-                Qt.callLater(() => {
-                    getEthernetInterfaces(() => {});
-                }, 500);
-            }
             if (callback)
-                callback(result);
+                callback(success);
         });
     }
 
@@ -1291,30 +1170,12 @@ Singleton {
         });
     }
 
-    // Reads cumulative since-boot byte counters from sysfs for an interface and
-    // returns a human-readable total via the callback.
-    // Reads the negotiated link speed (Mbit/s) from sysfs and stores a
-    // human-readable form in ethernetSpeed. nmcli `device show` doesn't expose
-    // link speed, so sysfs is the root-free source.
     function getEthernetSpeed(interfaceName: string): void {
-        if (!interfaceName || interfaceName.length === 0) {
-            root.ethernetSpeed = "";
-            return;
-        }
-        speedProc.command = ["sh", "-c", `cat /sys/class/net/${interfaceName}/speed 2>/dev/null`];
-        speedProc.running = true;
+        Wired.refreshSpeed(interfaceName);
     }
 
-    function getEthernetDataUsage(interfaceName: string, callback: var): void {
-        if (!interfaceName || interfaceName.length === 0) {
-            if (callback)
-                callback("");
-            return;
-        }
-        dataUsageProc.iface = interfaceName;
-        dataUsageProc.cb = callback;
-        dataUsageProc.command = ["sh", "-c", `cat /sys/class/net/${interfaceName}/statistics/rx_bytes /sys/class/net/${interfaceName}/statistics/tx_bytes 2>/dev/null`];
-        dataUsageProc.running = true;
+    function getEthernetDataUsage(interfaceName: string): void {
+        Wired.refreshDataUsage(interfaceName);
     }
 
     function formatBytes(bytes: var): string {
@@ -1332,16 +1193,12 @@ Singleton {
 
     function getEthernetDeviceDetails(interfaceName: string, callback: var): void {
         if (!interfaceName || interfaceName.length === 0) {
-            const activeInterface = root.ethernetInterfaces.find(iface => {
-                return isConnectedState(iface.state);
-            });
-            if (activeInterface && activeInterface.device) {
-                interfaceName = activeInterface.device;
-            } else {
+            if (!root.activeEthernet) {
                 if (callback)
                     callback(null);
                 return;
             }
+            interfaceName = root.activeEthernet.iface;
         }
 
         executeCommand(["device", "show", interfaceName], result => {
@@ -1424,13 +1281,8 @@ Singleton {
                         }
                     }
 
-                    if (root.ethernetInterfaces.length > 0) {
-                        const activeEthernet = root.ethernetInterfaces.find(iface => {
-                            return isConnectedState(iface.state);
-                        });
-                        if (activeEthernet && activeEthernet.device) {
-                            getEthernetDeviceDetails(activeEthernet.device, () => {});
-                        }
+                    if (root.activeEthernet) {
+                        getEthernetDeviceDetails(root.activeEthernet.iface, () => {});
                     }
                 }, 500);
             } else {
@@ -1439,13 +1291,11 @@ Singleton {
             }
 
             getWirelessInterfaces(() => {});
-            getEthernetInterfaces(() => {
-                if (root.activeEthernet && root.activeEthernet.connected) {
-                    Qt.callLater(() => {
-                        getEthernetDeviceDetails(root.activeEthernet.iface, () => {});
-                    }, 500);
-                }
-            });
+            if (root.activeEthernet) {
+                Qt.callLater(() => {
+                    getEthernetDeviceDetails(root.activeEthernet.iface, () => {});
+                }, 500);
+            }
         });
     }
 
@@ -1453,7 +1303,6 @@ Singleton {
         getWifiStatus(() => {});
         getNetworks(() => {});
         loadSavedConnections(() => {});
-        getEthernetInterfaces(() => {});
 
         Qt.callLater(() => {
             if (root.wirelessInterfaces.length > 0) {
@@ -1465,13 +1314,8 @@ Singleton {
                 }
             }
 
-            if (root.ethernetInterfaces.length > 0) {
-                const activeEthernet = root.ethernetInterfaces.find(iface => {
-                    return isConnectedState(iface.state);
-                });
-                if (activeEthernet && activeEthernet.device) {
-                    getEthernetDeviceDetails(activeEthernet.device, () => {});
-                }
+            if (root.activeEthernet) {
+                getEthernetDeviceDetails(root.activeEthernet.iface, () => {});
             }
         }, 2000);
     }
@@ -1486,45 +1330,6 @@ Singleton {
         id: apComp
 
         AccessPoint {}
-    }
-
-    Component {
-        id: ethComp
-
-        EthernetDevice {}
-    }
-
-    Component {
-        id: physicalCheckProc
-
-        Process {
-            id: proc
-
-            property var callback: null
-
-            stdout: StdioCollector {
-                id: stdoutCollector
-            }
-
-            stderr: StdioCollector {
-                id: stderrCollector
-            }
-
-            onExited: code => { // qmllint disable signal-handler-parameters
-                Qt.callLater(() => {
-                    const callback = proc.callback;
-                    const result = {
-                        success: code === 0,
-                        output: stdoutCollector.text ?? "",
-                        error: stderrCollector.text ?? "",
-                        exitCode: code
-                    };
-
-                    proc.destroy();
-                    callback?.(result);
-                });
-            }
-        }
     }
 
     Timer {
@@ -1672,47 +1477,6 @@ Singleton {
     }
 
     Process {
-        id: dataUsageProc
-
-        property string iface
-        property var cb
-
-        stdout: StdioCollector {
-            onStreamFinished: {
-                const nums = text.trim().split("\n").map(n => parseInt(n.trim(), 10)).filter(n => !isNaN(n));
-                if (nums.length < 2) {
-                    if (dataUsageProc.cb)
-                        dataUsageProc.cb("");
-                    return;
-                }
-                const human = root.formatBytes(nums[0] + nums[1]);
-                root.ethernetDataUsage = human;
-                if (dataUsageProc.cb)
-                    dataUsageProc.cb(human);
-            }
-        }
-    }
-
-    Process {
-        id: speedProc
-
-        stdout: StdioCollector {
-            onStreamFinished: {
-                const mbit = parseInt(text.trim(), 10);
-                // Disconnected/virtual interfaces report -1 or nothing.
-                if (isNaN(mbit) || mbit <= 0) {
-                    root.ethernetSpeed = "";
-                } else if (mbit >= 1000) {
-                    const gbps = mbit / 1000;
-                    root.ethernetSpeed = `${Number.isInteger(gbps) ? gbps : gbps.toFixed(1)} Gbps`;
-                } else {
-                    root.ethernetSpeed = `${mbit} Mbps`;
-                }
-            }
-        }
-    }
-
-    Process {
         id: rescanProc
 
         command: ["nmcli", "dev", root.nmcliCommandWifi, "list", "--rescan", "yes"]
@@ -1833,20 +1597,5 @@ Singleton {
         readonly property bool active: lastIpcObject.active
         readonly property string security: lastIpcObject.security
         readonly property bool isSecure: security.length > 0
-    }
-
-    component EthernetDevice: QtObject {
-        required property var lastIpcObject
-        readonly property string iface: lastIpcObject.interface
-        readonly property string type: lastIpcObject.type
-        readonly property string state: lastIpcObject.state
-        readonly property string connection: lastIpcObject.connection
-        readonly property bool connected: lastIpcObject.connected
-        readonly property string ipAddress: lastIpcObject.ipAddress ?? ""
-        readonly property string gateway: lastIpcObject.gateway ?? ""
-        readonly property var dns: lastIpcObject.dns ?? []
-        readonly property string subnet: lastIpcObject.subnet ?? ""
-        readonly property string macAddress: lastIpcObject.macAddress ?? ""
-        readonly property string speed: lastIpcObject.speed ?? ""
     }
 }

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -31,8 +31,10 @@ Singleton {
     readonly property var savedConnectionSecurity: Profiles.securityBySsid
 
     property var pendingConnection: null
-    property var wirelessDeviceDetails: null
-    property var ethernetDeviceDetails: null
+    // Device details come from NetworkManager's IP4Config over dbus now.
+    // These forward them so existing consumers keep working unchanged.
+    readonly property var wirelessDeviceDetails: Wifi.details
+    readonly property var ethernetDeviceDetails: Wired.details
     // Wired state lives in Wired now, read from NetworkManager over dbus.
     // These forward it so existing consumers keep working unchanged.
     readonly property string ethernetDataUsage: Wired.dataUsage
@@ -188,23 +190,11 @@ Singleton {
     }
 
     function connectEthernet(connectionName: string, interfaceName: string, callback: var): void {
-        Wired.connect(connectionName, interfaceName, success => {
-            // The device list updates itself; details still come from nmcli, and
-            // NM needs a moment after activation before they are worth reading.
-            if (success && interfaceName)
-                Qt.callLater(() => getEthernetDeviceDetails(interfaceName, () => {}), 1000);
-            if (callback)
-                callback(success);
-        });
+        Wired.connect(connectionName, interfaceName, callback);
     }
 
     function disconnectEthernet(connectionName: string, callback: var): void {
-        Wired.disconnect(connectionName, success => {
-            if (success)
-                root.ethernetDeviceDetails = null;
-            if (callback)
-                callback(success);
-        });
+        Wired.disconnect(connectionName, callback);
     }
 
     function getAllInterfaces(callback: var): void {
@@ -466,13 +456,6 @@ Singleton {
         Wifi.disconnect(null);
     }
 
-    function getDeviceDetails(interfaceName: string, callback: var): void {
-        executeCommand([root.nmcliCommandDevice, "show", interfaceName], result => {
-            if (callback)
-                callback(result.output);
-        });
-    }
-
     function refreshStatus(callback: var): void {
         getDeviceStatus(output => {
             const lines = output.trim().split("\n");
@@ -689,48 +672,9 @@ Singleton {
         }
     }
 
-    function cidrToSubnetMask(cidr: string): string {
-        const cidrNum = parseInt(cidr, 10);
-        if (isNaN(cidrNum) || cidrNum < 0 || cidrNum > 32) {
-            return "";
-        }
-
-        const mask = (0xffffffff << (32 - cidrNum)) >>> 0;
-        const octet1 = (mask >>> 24) & 0xff;
-        const octet2 = (mask >>> 16) & 0xff;
-        const octet3 = (mask >>> 8) & 0xff;
-        const octet4 = mask & 0xff;
-
-        return `${octet1}.${octet2}.${octet3}.${octet4}`;
-    }
-
     function getWirelessDeviceDetails(interfaceName: string, callback: var): void {
-        if (!interfaceName || interfaceName.length === 0) {
-            const activeInterface = root.wirelessInterfaces.find(iface => {
-                return isConnectedState(iface.state);
-            });
-            if (activeInterface && activeInterface.device) {
-                interfaceName = activeInterface.device;
-            } else {
-                if (callback)
-                    callback(null);
-                return;
-            }
-        }
-
-        executeCommand(["device", "show", interfaceName], result => {
-            if (!result.success || !result.output) {
-                root.wirelessDeviceDetails = null;
-                if (callback)
-                    callback(null);
-                return;
-            }
-
-            const details = parseDeviceDetails(result.output, false);
-            root.wirelessDeviceDetails = details;
-            if (callback)
-                callback(details);
-        });
+        if (callback)
+            callback(root.wirelessDeviceDetails);
     }
 
     // Reads the IPv4 configuration (method, address, gateway, DNS, autoconnect)
@@ -870,130 +814,20 @@ Singleton {
         return `${v.toFixed(v < 10 && i > 0 ? 1 : 0)} ${units[i]}`;
     }
 
+    // Kept so existing callers still get their callback; the details are a
+    // live binding on Wired now, so there is nothing to fetch.
     function getEthernetDeviceDetails(interfaceName: string, callback: var): void {
-        if (!interfaceName || interfaceName.length === 0) {
-            if (!root.activeEthernet) {
-                if (callback)
-                    callback(null);
-                return;
-            }
-            interfaceName = root.activeEthernet.iface;
-        }
-
-        executeCommand(["device", "show", interfaceName], result => {
-            if (!result.success || !result.output) {
-                // Transient failure (e.g. nmcli busy during a toggle). Keep the
-                // previous details so dependent UI (gateway, IP/DNS) doesn't
-                // blink out and back.
-                if (callback)
-                    callback(root.ethernetDeviceDetails);
-                return;
-            }
-
-            const details = parseDeviceDetails(result.output, true);
-            root.ethernetDeviceDetails = details;
-            if (callback)
-                callback(details);
-        });
-    }
-
-    function parseDeviceDetails(output: string, isEthernet: bool): var {
-        const details = {
-            ipAddress: "",
-            gateway: "",
-            dns: [],
-            subnet: "",
-            macAddress: "",
-            speed: ""
-        };
-
-        if (!output || output.length === 0) {
-            return details;
-        }
-
-        const lines = output.trim().split("\n");
-
-        for (let i = 0; i < lines.length; i++) {
-            const line = lines[i];
-            const parts = line.split(":");
-            if (parts.length >= 2) {
-                const key = parts[0].trim();
-                const value = parts.slice(1).join(":").trim();
-
-                if (key.startsWith("IP4.ADDRESS")) {
-                    const ipParts = value.split("/");
-                    details.ipAddress = ipParts[0] || "";
-                    if (ipParts[1]) {
-                        details.subnet = cidrToSubnetMask(ipParts[1]);
-                    } else {
-                        details.subnet = "";
-                    }
-                } else if (key === "IP4.GATEWAY") {
-                    if (value !== "--") {
-                        details.gateway = value;
-                    }
-                } else if (key.startsWith("IP4.DNS")) {
-                    if (value !== "--" && value.length > 0) {
-                        details.dns.push(value);
-                    }
-                } else if (key === "GENERAL.HWADDR") {
-                    details.macAddress = value;
-                }
-            }
-        }
-
-        return details;
+        if (callback)
+            callback(root.ethernetDeviceDetails);
     }
 
     function refreshOnConnectionChange(): void {
-        if (root.active) {
-            Qt.callLater(() => {
-                if (root.wirelessInterfaces.length > 0) {
-                    const activeWireless = root.wirelessInterfaces.find(iface => {
-                        return isConnectedState(iface.state);
-                    });
-                    if (activeWireless && activeWireless.device) {
-                        getWirelessDeviceDetails(activeWireless.device, () => {});
-                    }
-                }
-
-                if (root.activeEthernet) {
-                    getEthernetDeviceDetails(root.activeEthernet.iface, () => {});
-                }
-            }, 500);
-        } else {
-            root.wirelessDeviceDetails = null;
-            root.ethernetDeviceDetails = null;
-        }
-
         getWirelessInterfaces(() => {});
-        if (root.activeEthernet) {
-            Qt.callLater(() => {
-                getEthernetDeviceDetails(root.activeEthernet.iface, () => {});
-            }, 500);
-        }
     }
 
     // Association is reported over dbus now, so a pending connect resolves the
     // moment NetworkManager says so rather than on the next poll.
     onActiveChanged: checkPendingConnection()
-
-    Component.onCompleted: {
-        Qt.callLater(() => {
-            if (root.wirelessInterfaces.length > 0) {
-                const activeWireless = root.wirelessInterfaces.find(iface => {
-                    return isConnectedState(iface.state);
-                });
-                if (activeWireless && activeWireless.device) {
-                    getWirelessDeviceDetails(activeWireless.device, () => {});
-                }
-            }
-
-            if (root.activeEthernet) {
-                getEthernetDeviceDetails(root.activeEthernet.iface, () => {});
-            }
-        }, 2000);
-    }
 
     Component {
         id: commandProc

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -17,10 +17,12 @@ Singleton {
     readonly property bool connecting: wirelessInterfaces.some(i => isConnectingState(i.state))
     property string activeInterface: ""
     property string activeConnection: ""
-    property bool wifiEnabled: true
-    readonly property bool scanning: rescanProc.running
-    readonly property list<AccessPoint> networks: []
-    readonly property AccessPoint active: networks.find(n => n.active) ?? null
+    // Wifi state lives in Wifi now, read from NetworkManager over dbus.
+    // These forward it so existing consumers keep working unchanged.
+    readonly property bool wifiEnabled: Wifi.enabled
+    readonly property bool scanning: Wifi.scanning
+    readonly property list<var> networks: Wifi.networks
+    readonly property var active: Wifi.active
     property list<string> savedConnections: []
     property list<string> savedConnectionSsids: []
     // Map of saved Wi-Fi SSID (lowercased) -> security type
@@ -59,12 +61,10 @@ Singleton {
     readonly property string nmcliCommandDevice: "device"
     readonly property string nmcliCommandConnection: "connection"
     readonly property string nmcliCommandWifi: "wifi"
-    readonly property string nmcliCommandRadio: "radio"
     readonly property string deviceStatusFields: "DEVICE,TYPE,STATE,CONNECTION"
     readonly property string connectionListFields: "NAME,TYPE"
     readonly property string wirelessSsidField: "802-11-wireless.ssid"
     readonly property string networkListFields: "SSID,SIGNAL,SECURITY"
-    readonly property string networkDetailFields: "ACTIVE,SIGNAL,FREQ,SSID,BSSID,SECURITY"
     readonly property string securityKeyMgmt: "802-11-wireless-security.key-mgmt"
     readonly property string securityPsk: "802-11-wireless-security.psk"
     readonly property string keyMgmtWpaPsk: "wpa-psk"
@@ -84,54 +84,6 @@ Singleton {
         }
 
         return (error.includes("Secrets were required") || error.includes("Secrets were required, but not provided") || error.includes("No secrets provided") || error.includes("802-11-wireless-security.psk") || error.includes("password for") || (error.includes("password") && !error.includes("Connection activated") && !error.includes("successfully")) || (error.includes("Secrets") && !error.includes("Connection activated") && !error.includes("successfully")) || (error.includes("802.11") && !error.includes("Connection activated") && !error.includes("successfully"))) && !error.includes("Connection activated") && !error.includes("successfully");
-    }
-
-    function parseNetworkOutput(output: string): list<var> {
-        if (!output || output.length === 0) {
-            return [];
-        }
-
-        const PLACEHOLDER = "STRINGWHICHHOPEFULLYWONTBEUSED";
-        const rep = new RegExp("\\\\:", "g");
-        const rep2 = new RegExp(PLACEHOLDER, "g");
-
-        const allNetworks = output.trim().split("\n").filter(line => line && line.length > 0).map(n => {
-            const net = n.replace(rep, PLACEHOLDER).split(":");
-            return {
-                active: net[0] === "yes",
-                strength: parseInt(net[1] || "0", 10) || 0,
-                frequency: parseInt(net[2] || "0", 10) || 0,
-                ssid: (net[3]?.replace(rep2, ":") ?? "").trim(),
-                bssid: (net[4]?.replace(rep2, ":") ?? "").trim(),
-                security: (net[5] ?? "").trim()
-            };
-        }).filter(n => n.ssid && n.ssid.length > 0);
-
-        return allNetworks;
-    }
-
-    function deduplicateNetworks(networks: list<var>): list<var> {
-        if (!networks || networks.length === 0) {
-            return [];
-        }
-
-        const networkMap = new Map();
-        for (const network of networks) {
-            const existing = networkMap.get(network.ssid);
-            if (!existing) {
-                networkMap.set(network.ssid, network);
-            } else {
-                if (network.active && !existing.active) {
-                    networkMap.set(network.ssid, network);
-                } else if (!network.active && !existing.active) {
-                    if (network.strength > existing.strength) {
-                        networkMap.set(network.ssid, network);
-                    }
-                }
-            }
-        }
-
-        return Array.from(networkMap.values());
     }
 
     function isConnectionCommand(command: list<string>): bool {
@@ -708,19 +660,11 @@ Singleton {
     }
 
     function disconnectFromNetwork(): void {
-        if (active && active.ssid) {
-            executeCommand([root.nmcliCommandConnection, "down", active.ssid], result => {
-                if (result.success) {
-                    getNetworks(() => {});
-                }
-            });
-        } else {
-            executeCommand([root.nmcliCommandDevice, "disconnect", root.deviceTypeWifi], result => {
-                if (result.success) {
-                    getNetworks(() => {});
-                }
-            });
-        }
+        // No refresh afterwards: the active access point is a live binding.
+        if (root.active?.ssid)
+            Wifi.run([root.nmcliCommandConnection, "down", root.active.ssid], null);
+        else
+            Wifi.disconnect(null);
     }
 
     function getDeviceDetails(interfaceName: string, callback: var): void {
@@ -800,104 +744,40 @@ Singleton {
     }
 
     function scanWirelessNetworks(interfaceName: string, callback: var): void {
-        let cmd = [root.nmcliCommandDevice, root.nmcliCommandWifi, "rescan"];
-        if (interfaceName && interfaceName.length > 0) {
-            cmd.push(root.connectionParamIfname, interfaceName);
-        }
-        executeCommand(cmd, result => {
-            if (callback) {
-                callback(result);
-            }
-        });
+        Wifi.scan();
+        if (callback)
+            callback(true);
     }
 
     function rescanWifi(): void {
-        rescanProc.running = true;
+        Wifi.scan();
     }
 
     function enableWifi(enabled: bool, callback: var): void {
-        const cmd = enabled ? "on" : "off";
-        executeCommand([root.nmcliCommandRadio, root.nmcliCommandWifi, cmd], result => {
-            if (result.success) {
-                getWifiStatus(status => {
-                    root.wifiEnabled = status;
-                    if (callback)
-                        callback(result);
-                });
-            } else {
-                if (callback)
-                    callback(result);
-            }
-        });
+        Wifi.setEnabled(enabled, callback);
     }
 
     function toggleWifi(callback: var): void {
-        const newState = !root.wifiEnabled;
-        enableWifi(newState, callback);
+        Wifi.toggle(callback);
     }
 
+    // Kept for existing callers; wifiEnabled is a live binding now, so there is
+    // nothing to fetch.
     function getWifiStatus(callback: var): void {
-        executeCommand([root.nmcliCommandRadio, root.nmcliCommandWifi], result => {
-            if (result.success) {
-                const enabled = result.output.trim() === "enabled";
-                root.wifiEnabled = enabled;
-                if (callback)
-                    callback(enabled);
-            } else {
-                if (callback)
-                    callback(root.wifiEnabled);
-            }
-        });
+        if (callback)
+            callback(root.wifiEnabled);
     }
 
     function findNetwork(ssid: string): var {
-        return networks.find(n => n.ssid === ssid) ?? null;
+        return Wifi.findNetwork(ssid);
     }
 
+    // Kept so existing callers still get their callback; the network list is
+    // a live binding on Wifi now, so there is nothing to fetch.
     function getNetworks(callback: var): void {
-        executeCommand(["-g", root.networkDetailFields, "d", "w"], result => {
-            if (!result.success) {
-                if (callback)
-                    callback([]);
-                return;
-            }
-
-            const allNetworks = parseNetworkOutput(result.output);
-            const networks = deduplicateNetworks(allNetworks);
-            const rNetworks = root.networks;
-
-            const newMap = new Map();
-            for (const n of networks)
-                newMap.set(`${n.frequency}:${n.ssid}:${n.bssid}`, n);
-
-            for (let i = rNetworks.length - 1; i >= 0; i--) {
-                const rn = rNetworks[i];
-                const key = `${rn.frequency}:${rn.ssid}:${rn.bssid}`;
-                if (!newMap.has(key)) {
-                    rNetworks.splice(i, 1);
-                    rn.destroy();
-                }
-            }
-
-            const existingMap = new Map();
-            for (const rn of rNetworks)
-                existingMap.set(`${rn.frequency}:${rn.ssid}:${rn.bssid}`, rn);
-
-            for (const [key, network] of newMap) {
-                const match = existingMap.get(key);
-                if (match) {
-                    match.lastIpcObject = network;
-                } else {
-                    rNetworks.push(apComp.createObject(root, {
-                        lastIpcObject: network
-                    }));
-                }
-            }
-
-            if (callback)
-                callback(root.networks);
-            checkPendingConnection();
-        });
+        if (callback)
+            callback(root.networks);
+        checkPendingConnection();
     }
 
     function getWirelessSSIDs(interfaceName: string, callback: var): void {
@@ -1267,41 +1147,39 @@ Singleton {
     }
 
     function refreshOnConnectionChange(): void {
-        getNetworks(networks => {
-            const newActive = root.active;
-
-            if (newActive && newActive.active) {
-                Qt.callLater(() => {
-                    if (root.wirelessInterfaces.length > 0) {
-                        const activeWireless = root.wirelessInterfaces.find(iface => {
-                            return isConnectedState(iface.state);
-                        });
-                        if (activeWireless && activeWireless.device) {
-                            getWirelessDeviceDetails(activeWireless.device, () => {});
-                        }
+        if (root.active) {
+            Qt.callLater(() => {
+                if (root.wirelessInterfaces.length > 0) {
+                    const activeWireless = root.wirelessInterfaces.find(iface => {
+                        return isConnectedState(iface.state);
+                    });
+                    if (activeWireless && activeWireless.device) {
+                        getWirelessDeviceDetails(activeWireless.device, () => {});
                     }
+                }
 
-                    if (root.activeEthernet) {
-                        getEthernetDeviceDetails(root.activeEthernet.iface, () => {});
-                    }
-                }, 500);
-            } else {
-                root.wirelessDeviceDetails = null;
-                root.ethernetDeviceDetails = null;
-            }
-
-            getWirelessInterfaces(() => {});
-            if (root.activeEthernet) {
-                Qt.callLater(() => {
+                if (root.activeEthernet) {
                     getEthernetDeviceDetails(root.activeEthernet.iface, () => {});
-                }, 500);
-            }
-        });
+                }
+            }, 500);
+        } else {
+            root.wirelessDeviceDetails = null;
+            root.ethernetDeviceDetails = null;
+        }
+
+        getWirelessInterfaces(() => {});
+        if (root.activeEthernet) {
+            Qt.callLater(() => {
+                getEthernetDeviceDetails(root.activeEthernet.iface, () => {});
+            }, 500);
+        }
     }
 
+    // Association is reported over dbus now, so a pending connect resolves the
+    // moment NetworkManager says so rather than on the next poll.
+    onActiveChanged: checkPendingConnection()
+
     Component.onCompleted: {
-        getWifiStatus(() => {});
-        getNetworks(() => {});
         loadSavedConnections(() => {});
 
         Qt.callLater(() => {
@@ -1324,12 +1202,6 @@ Singleton {
         id: commandProc
 
         CommandProcess {}
-    }
-
-    Component {
-        id: apComp
-
-        AccessPoint {}
     }
 
     Timer {
@@ -1477,13 +1349,6 @@ Singleton {
     }
 
     Process {
-        id: rescanProc
-
-        command: ["nmcli", "dev", root.nmcliCommandWifi, "list", "--rescan", "yes"]
-        onExited: root.getNetworks() // qmllint disable signal-handler-parameters
-    }
-
-    Process {
         id: monitorProc
 
         running: true
@@ -1586,16 +1451,5 @@ Singleton {
                 }
             });
         }
-    }
-
-    component AccessPoint: QtObject {
-        required property var lastIpcObject
-        readonly property string ssid: lastIpcObject.ssid
-        readonly property string bssid: lastIpcObject.bssid
-        readonly property int strength: lastIpcObject.strength
-        readonly property int frequency: lastIpcObject.frequency
-        readonly property bool active: lastIpcObject.active
-        readonly property string security: lastIpcObject.security
-        readonly property bool isSecure: security.length > 0
     }
 }

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -660,11 +660,7 @@ Singleton {
     }
 
     function disconnectFromNetwork(): void {
-        // No refresh afterwards: the active access point is a live binding.
-        if (root.active?.ssid)
-            Wifi.run([root.nmcliCommandConnection, "down", root.active.ssid], null);
-        else
-            Wifi.disconnect(null);
+        Wifi.disconnect(null);
     }
 
     function getDeviceDetails(interfaceName: string, callback: var): void {

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -668,62 +668,11 @@ Singleton {
 
     // Reads the IPv4 configuration (method, address, gateway, DNS, autoconnect)
     // of a connection profile for the ethernet detail page.
+    // Kept for existing callers; the saved configuration is a live binding on
+    // Profiles now, so there is nothing to fetch.
     function getIpv4Config(connectionName: string, callback: var): void {
-        if (!connectionName || connectionName.length === 0) {
-            if (callback)
-                callback(null);
-            return;
-        }
-
-        executeCommand(["-t", "-f", "ipv4.method,ipv4.addresses,ipv4.gateway,ipv4.dns,ipv4.ignore-auto-dns,connection.autoconnect", root.nmcliCommandConnection, "show", connectionName], result => {
-            if (!result.success) {
-                if (callback)
-                    callback(null);
-                return;
-            }
-
-            const cfg = {
-                method: "auto",
-                address: "",
-                gateway: "",
-                dns: "",
-                ignoreAutoDns: false,
-                autoconnect: true
-            };
-
-            const lines = result.output.trim().split("\n");
-            for (const line of lines) {
-                const idx = line.indexOf(":");
-                if (idx < 0)
-                    continue;
-                const key = line.slice(0, idx).trim();
-                const value = line.slice(idx + 1).trim();
-
-                if (key === "ipv4.ignore-auto-dns")
-                    cfg.ignoreAutoDns = value === "yes";
-                else if (key === "connection.autoconnect")
-                    cfg.autoconnect = value !== "no";
-
-                if (value === "" || value === "--")
-                    continue;
-
-                if (key === "ipv4.method")
-                    cfg.method = value;
-                else if (key === "ipv4.addresses")
-                    cfg.address = value.split(",")[0].trim();
-                else if (key === "ipv4.gateway")
-                    cfg.gateway = value;
-                else if (key === "ipv4.dns")
-                    cfg.dns = value.replace(/;\s*$/, "").split(/[;,]/).map(d => d.trim()).filter(d => d.length > 0).join(", ");
-            }
-
-            // Distinguish "automatic + custom DNS only" from plain DHCP.
-            if (cfg.method === "auto" && cfg.ignoreAutoDns)
-                cfg.method = "auto-dns";
-
-            if (callback)
-                callback(cfg);
-        });
+        if (callback)
+            callback(Profiles.ipv4ConfigFor(connectionName));
     }
 
     // Writes an IPv4 configuration to a connection profile and reactivates it so

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -54,7 +54,6 @@ Singleton {
     property list<var> activeProcesses: []
 
     readonly property alias connectionCheckTimer: connectionCheckTimer
-    readonly property alias immediateCheckTimer: immediateCheckTimer
 
     // Constants
     readonly property string deviceTypeWifi: "wifi"
@@ -271,8 +270,6 @@ Singleton {
                 retryCount: retries
             };
             connectionCheckTimer.start();
-            immediateCheckTimer.checkCount = 0;
-            immediateCheckTimer.start();
         }
 
         if (password && password.length > 0 && hasBssid) {
@@ -622,8 +619,6 @@ Singleton {
 
         if (needsPassword && !proc.callbackCalled && root.pendingConnection) {
             connectionCheckTimer.stop();
-            immediateCheckTimer.stop();
-            immediateCheckTimer.checkCount = 0;
             const pending = root.pendingConnection;
             root.pendingConnection = null;
             proc.callbackCalled = true;
@@ -652,8 +647,6 @@ Singleton {
                 const connected = root.active && root.active.ssid === root.pendingConnection.ssid;
                 if (connected) {
                     connectionCheckTimer.stop();
-                    immediateCheckTimer.stop();
-                    immediateCheckTimer.checkCount = 0;
                     if (root.pendingConnection.callback) {
                         root.pendingConnection.callback({
                             success: true,
@@ -663,10 +656,6 @@ Singleton {
                         });
                     }
                     root.pendingConnection = null;
-                } else {
-                    if (!immediateCheckTimer.running) {
-                        immediateCheckTimer.start();
-                    }
                 }
             });
         }
@@ -835,147 +824,31 @@ Singleton {
         CommandProcess {}
     }
 
+    // Nothing reports a connect that simply never happens, so this stays as the
+    // backstop. Success arrives on onActiveChanged and a rejected password on
+    // the process's own stderr, both immediately, so neither needs polling.
     Timer {
         id: connectionCheckTimer
 
         interval: 4000
         onTriggered: {
-            if (root.pendingConnection) {
-                const connected = root.active && root.active.ssid === root.pendingConnection.ssid;
+            if (!root.pendingConnection)
+                return;
 
-                if (!connected && root.pendingConnection.callback) {
-                    let foundPasswordError = false;
-                    for (let i = 0; i < root.activeProcesses.length; i++) {
-                        const proc = root.activeProcesses[i];
-                        if (proc && proc.stderr && proc.stderr.text) {
-                            const error = proc.stderr.text.trim();
-                            if (error && error.length > 0) {
-                                if (root.isConnectionCommand(proc.cmdArgs)) {
-                                    const needsPassword = root.detectPasswordRequired(error);
+            const pending = root.pendingConnection;
+            root.pendingConnection = null;
 
-                                    if (needsPassword && !proc.callbackCalled && root.pendingConnection) {
-                                        const pending = root.pendingConnection;
-                                        root.pendingConnection = null;
-                                        immediateCheckTimer.stop();
-                                        immediateCheckTimer.checkCount = 0;
-                                        proc.callbackCalled = true;
-                                        const result = {
-                                            success: false,
-                                            output: (proc.stdout && proc.stdout.text) ? proc.stdout.text : "",
-                                            error: error,
-                                            exitCode: -1,
-                                            needsPassword: true
-                                        };
-                                        if (pending.callback) {
-                                            pending.callback(result);
-                                        }
-                                        if (proc.callback && proc.callback !== pending.callback) {
-                                            proc.callback(result);
-                                        }
-                                        foundPasswordError = true;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                    }
+            if (root.active?.ssid === pending.ssid)
+                return;
 
-                    if (!foundPasswordError) {
-                        const pending = root.pendingConnection;
-                        const failedSsid = pending.ssid;
-                        root.pendingConnection = null;
-                        immediateCheckTimer.stop();
-                        immediateCheckTimer.checkCount = 0;
-                        root.connectionFailed(failedSsid);
-                        pending.callback({
-                            success: false,
-                            output: "",
-                            error: "Connection timeout",
-                            exitCode: -1,
-                            needsPassword: false
-                        });
-                    }
-                } else if (connected) {
-                    root.pendingConnection = null;
-                    immediateCheckTimer.stop();
-                    immediateCheckTimer.checkCount = 0;
-                }
-            }
-        }
-    }
-
-    Timer {
-        id: immediateCheckTimer
-
-        property int checkCount: 0
-
-        interval: 500
-        repeat: true
-        triggeredOnStart: false
-
-        onTriggered: {
-            if (root.pendingConnection) {
-                checkCount++;
-                const connected = root.active && root.active.ssid === root.pendingConnection.ssid;
-
-                if (connected) {
-                    connectionCheckTimer.stop();
-                    immediateCheckTimer.stop();
-                    immediateCheckTimer.checkCount = 0;
-                    if (root.pendingConnection.callback) {
-                        root.pendingConnection.callback({
-                            success: true,
-                            output: "Connected",
-                            error: "",
-                            exitCode: 0
-                        });
-                    }
-                    root.pendingConnection = null;
-                } else {
-                    for (let i = 0; i < root.activeProcesses.length; i++) {
-                        const proc = root.activeProcesses[i];
-                        if (proc && proc.stderr && proc.stderr.text) {
-                            const error = proc.stderr.text.trim();
-                            if (error && error.length > 0) {
-                                if (root.isConnectionCommand(proc.cmdArgs)) {
-                                    const needsPassword = root.detectPasswordRequired(error);
-
-                                    if (needsPassword && !proc.callbackCalled && root.pendingConnection && root.pendingConnection.callback) {
-                                        connectionCheckTimer.stop();
-                                        immediateCheckTimer.stop();
-                                        immediateCheckTimer.checkCount = 0;
-                                        const pending = root.pendingConnection;
-                                        root.pendingConnection = null;
-                                        proc.callbackCalled = true;
-                                        const result = {
-                                            success: false,
-                                            output: (proc.stdout && proc.stdout.text) ? proc.stdout.text : "",
-                                            error: error,
-                                            exitCode: -1,
-                                            needsPassword: true
-                                        };
-                                        if (pending.callback) {
-                                            pending.callback(result);
-                                        }
-                                        if (proc.callback && proc.callback !== pending.callback) {
-                                            proc.callback(result);
-                                        }
-                                        return;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    if (checkCount >= 6) {
-                        immediateCheckTimer.stop();
-                        immediateCheckTimer.checkCount = 0;
-                    }
-                }
-            } else {
-                immediateCheckTimer.stop();
-                immediateCheckTimer.checkCount = 0;
-            }
+            root.connectionFailed(pending.ssid);
+            pending.callback?.({
+                success: false,
+                output: "",
+                error: "Connection timeout",
+                exitCode: -1,
+                needsPassword: false
+            });
         }
     }
 

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -23,13 +23,13 @@ Singleton {
     readonly property bool scanning: Wifi.scanning
     readonly property list<var> networks: Wifi.networks
     readonly property var active: Wifi.active
-    property list<string> savedConnections: []
-    property list<string> savedConnectionSsids: []
+    // Saved profiles live in Profiles now, read from NetworkManager's Settings
+    // interface. These forward them so existing consumers keep working.
+    readonly property list<string> savedConnections: Profiles.names
+    readonly property list<string> savedConnectionSsids: Profiles.ssids
     // Map of saved Wi-Fi SSID (lowercased) -> security type
-    property var savedConnectionSecurity: ({})
+    readonly property var savedConnectionSecurity: Profiles.securityBySsid
 
-    property var wifiConnectionQueue: []
-    property int currentSsidQueryIndex: 0
     property var pendingConnection: null
     property var wirelessDeviceDetails: null
     property var ethernetDeviceDetails: null
@@ -62,8 +62,6 @@ Singleton {
     readonly property string nmcliCommandConnection: "connection"
     readonly property string nmcliCommandWifi: "wifi"
     readonly property string deviceStatusFields: "DEVICE,TYPE,STATE,CONNECTION"
-    readonly property string connectionListFields: "NAME,TYPE"
-    readonly property string wirelessSsidField: "802-11-wireless.ssid"
     readonly property string networkListFields: "SSID,SIGNAL,SECURITY"
     readonly property string securityKeyMgmt: "802-11-wireless-security.key-mgmt"
     readonly property string securityPsk: "802-11-wireless-security.psk"
@@ -322,13 +320,11 @@ Singleton {
 
             executeCommand(cmd, result => {
                 if (result.success) {
-                    loadSavedConnections(() => {});
                     activateConnection(ssid, callback);
                 } else {
                     const hasDuplicateWarning = result.error && (result.error.includes("another connection with the name") || result.error.includes("Reference the connection by its uuid"));
 
                     if (hasDuplicateWarning || (result.exitCode > 0 && result.exitCode < 10)) {
-                        loadSavedConnections(() => {});
                         activateConnection(ssid, callback);
                     } else {
                         console.warn(lc, "Connection profile creation failed, trying fallback...");
@@ -366,155 +362,28 @@ Singleton {
         });
     }
 
+    // Kept so existing callers still get their callback; the saved profiles
+    // are a live binding on Profiles now, so there is nothing to fetch.
     function loadSavedConnections(callback: var): void {
-        executeCommand(["-t", "-f", root.connectionListFields, root.nmcliCommandConnection, "show"], result => {
-            if (!result.success) {
-                root.savedConnections = [];
-                root.savedConnectionSsids = [];
-                root.savedConnectionSecurity = {};
-                if (callback)
-                    callback([]);
-                return;
-            }
-
-            parseConnectionList(result.output, callback);
-        });
-    }
-
-    function parseConnectionList(output: string, callback: var): void {
-        const lines = output.trim().split("\n").filter(line => line.length > 0);
-        const wifiConnections = [];
-        const connections = [];
-
-        for (const line of lines) {
-            const parts = line.split(":");
-            if (parts.length >= 2) {
-                const name = parts[0];
-                const type = parts[1];
-                connections.push(name);
-
-                if (type === root.connectionTypeWireless) {
-                    wifiConnections.push(name);
-                }
-            }
-        }
-
-        root.savedConnections = connections;
-
-        root.savedConnectionSecurity = {};
-
-        if (wifiConnections.length > 0) {
-            root.wifiConnectionQueue = wifiConnections;
-            root.currentSsidQueryIndex = 0;
-            root.savedConnectionSsids = [];
-            queryNextSsid(callback);
-        } else {
-            root.savedConnectionSsids = [];
-            root.wifiConnectionQueue = [];
-            if (callback)
-                callback(root.savedConnectionSsids);
-        }
-    }
-
-    function queryNextSsid(callback: var): void {
-        if (root.currentSsidQueryIndex < root.wifiConnectionQueue.length) {
-            const connectionName = root.wifiConnectionQueue[root.currentSsidQueryIndex];
-            root.currentSsidQueryIndex++;
-
-            executeCommand(["-t", "-f", `${root.wirelessSsidField},${root.securityKeyMgmt}`, root.nmcliCommandConnection, "show", connectionName], result => {
-                if (result.success) {
-                    processSsidOutput(result.output);
-                }
-                queryNextSsid(callback);
-            });
-        } else {
-            root.wifiConnectionQueue = [];
-            root.currentSsidQueryIndex = 0;
-            if (callback)
-                callback(root.savedConnectionSsids);
-        }
-    }
-
-    function processSsidOutput(output: string): void {
-        const ssidPrefix = "802-11-wireless.ssid:";
-        const keyMgmtPrefix = `${root.securityKeyMgmt}:`;
-
-        let ssid = "";
-        let keyMgmt = "";
-        for (const line of output.trim().split("\n")) {
-            if (line.startsWith(ssidPrefix))
-                ssid = line.substring(ssidPrefix.length).trim();
-            else if (line.startsWith(keyMgmtPrefix))
-                keyMgmt = line.substring(keyMgmtPrefix.length).trim();
-        }
-
-        if (!ssid || ssid.length === 0)
-            return;
-
-        const ssidLower = ssid.toLowerCase();
-
-        const exists = root.savedConnectionSsids.some(s => s && s.toLowerCase() === ssidLower);
-        if (!exists) {
-            const newList = root.savedConnectionSsids.slice();
-            newList.push(ssid);
-            root.savedConnectionSsids = newList;
-        }
-
-        const security = Object.assign({}, root.savedConnectionSecurity);
-        security[ssidLower] = keyMgmt;
-        root.savedConnectionSecurity = security;
+        if (callback)
+            callback(root.savedConnectionSsids);
     }
 
     function securityLabel(keyMgmt: string): string {
-        switch ((keyMgmt || "").trim().toLowerCase()) {
-        case "":
-        case "none":
-            return qsTr("Open");
-        case "sae":
-            return "WPA3";
-        case "wpa-psk":
-            return "WPA2";
-        case "wpa-eap":
-        case "wpa-eap-suite-b-192":
-            return qsTr("Enterprise");
-        case "owe":
-            return qsTr("Enhanced Open");
-        case "ieee8021x":
-            return "802.1X";
-        default:
-            return keyMgmt.trim();
-        }
+        return Profiles.securityLabel(keyMgmt);
     }
 
-    // Cached security label for a saved SSID, or "" if unknown (e.g. not loaded).
+    // Raw key management for a saved SSID, or "" if there is no profile.
     function savedSecurityFor(ssid: string): string {
-        if (!ssid || ssid.length === 0)
-            return "";
-        return root.savedConnectionSecurity[ssid.toLowerCase().trim()] || "";
+        return Profiles.keyMgmtFor(ssid);
     }
 
     function hasSavedProfile(ssid: string): bool {
-        if (!ssid || ssid.length === 0) {
-            return false;
-        }
-        const ssidLower = ssid.toLowerCase().trim();
-
-        if (root.active && root.active.ssid) {
-            const activeSsidLower = root.active.ssid.toLowerCase().trim();
-            if (activeSsidLower === ssidLower) {
-                return true;
-            }
-        }
-
-        const hasSsid = root.savedConnectionSsids.some(savedSsid => savedSsid && savedSsid.toLowerCase().trim() === ssidLower);
-
-        if (hasSsid) {
+        // An active network counts as saved even before the profile lands.
+        if (ssid && root.active?.ssid && root.active.ssid.toLowerCase().trim() === ssid.toLowerCase().trim())
             return true;
-        }
 
-        const hasConnectionName = root.savedConnections.some(connName => connName && connName.toLowerCase().trim() === ssidLower);
-
-        return hasConnectionName;
+        return Profiles.hasName(ssid);
     }
 
     // Adds and connects to an SSID by name. When hidden is true the profile is
@@ -544,13 +413,11 @@ Singleton {
 
             executeCommand(cmd, result => {
                 if (result.success) {
-                    loadSavedConnections(() => {});
                     activateConnection(ssid, callback);
                 } else {
                     const hasDuplicateWarning = result.error && (result.error.includes("another connection with the name") || result.error.includes("Reference the connection by its uuid"));
 
                     if (hasDuplicateWarning) {
-                        loadSavedConnections(() => {});
                         activateConnection(ssid, callback);
                     } else if (callback) {
                         callback(result);
@@ -561,88 +428,24 @@ Singleton {
     }
 
     // Reads whether a saved connection auto-connects.
+    // Kept for existing callers; autoconnect is a live binding on Profiles now.
     function getAutoconnect(connectionName: string, callback: var): void {
-        if (!connectionName || connectionName.length === 0) {
-            if (callback)
-                callback(true);
-            return;
-        }
-        executeCommand(["-t", "-f", "connection.autoconnect", root.nmcliCommandConnection, "show", connectionName], result => {
-            let auto = true;
-            if (result.success) {
-                const line = result.output.trim();
-                const idx = line.indexOf(":");
-                if (idx >= 0)
-                    auto = line.slice(idx + 1).trim() !== "no";
-            }
-            if (callback)
-                callback(auto);
-        });
+        if (callback)
+            callback(Profiles.autoconnectFor(connectionName));
     }
 
-    // Toggles auto-connect for a saved connection. When turned OFF, also makes
-    // NetworkManager ask for the password on the next manual connect instead of
-    // silently reusing the stored one (psk-flags 2 = "not saved, always ask");
-    // turning it back ON restores psk-flags 0 so the next password is saved.
     function setAutoconnect(connectionName: string, enabled: bool, callback: var): void {
-        if (!connectionName || connectionName.length === 0) {
-            if (callback)
-                callback({
-                    success: false,
-                    output: "",
-                    error: "No connection specified",
-                    exitCode: -1
-                });
-            return;
-        }
-
-        let cmd = [root.nmcliCommandConnection, "modify", connectionName, "connection.autoconnect", enabled ? "yes" : "no"];
-
-        if (enabled) {
-            cmd.push("802-11-wireless-security.psk-flags", "0");
-        } else {
-            cmd.push("802-11-wireless-security.psk-flags", "2");
-            cmd.push("802-11-wireless-security.psk", "");
-        }
-
-        executeCommand(cmd, result => {
-            // For open networks the security fields don't exist; nmcli then
-            // errors. Retry with just the autoconnect change so it still works.
-            if (!result.success && result.error && (result.error.includes("802-11-wireless-security") || result.error.includes("is not a valid property") || result.error.includes("Error: invalid"))) {
-                executeCommand([root.nmcliCommandConnection, "modify", connectionName, "connection.autoconnect", enabled ? "yes" : "no"], retryResult => {
-                    if (callback)
-                        callback(retryResult);
-                });
-                return;
-            }
-            if (callback)
-                callback(result);
-        });
+        Profiles.setAutoconnect(Profiles.nameFor(connectionName), enabled, callback);
     }
 
     function forgetNetwork(ssid: string, callback: var): void {
-        if (!ssid || ssid.length === 0) {
+        if (!ssid) {
             if (callback)
-                callback({
-                    success: false,
-                    output: "",
-                    error: "No SSID specified",
-                    exitCode: -1
-                });
+                callback(false);
             return;
         }
 
-        const connectionName = root.savedConnections.find(conn => conn && conn.toLowerCase().trim() === ssid.toLowerCase().trim()) || ssid;
-
-        executeCommand([root.nmcliCommandConnection, "delete", connectionName], result => {
-            if (result.success) {
-                Qt.callLater(() => {
-                    loadSavedConnections(() => {});
-                }, 500);
-            }
-            if (callback)
-                callback(result);
-        });
+        Profiles.forget(Profiles.nameFor(ssid), callback);
     }
 
     function disconnect(interfaceName: string, callback: var): void {
@@ -1176,8 +979,6 @@ Singleton {
     onActiveChanged: checkPendingConnection()
 
     Component.onCompleted: {
-        loadSavedConnections(() => {});
-
         Qt.callLater(() => {
             if (root.wirelessInterfaces.length > 0) {
                 const activeWireless = root.wirelessInterfaces.find(iface => {

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -25,10 +25,8 @@ Singleton {
     readonly property var active: Wifi.active
     // Saved profiles live in Profiles now, read from NetworkManager's Settings
     // interface. These forward them so existing consumers keep working.
-    readonly property list<string> savedConnections: Profiles.names
     readonly property list<string> savedConnectionSsids: Profiles.ssids
     // Map of saved Wi-Fi SSID (lowercased) -> security type
-    readonly property var savedConnectionSecurity: Profiles.securityBySsid
 
     property var pendingConnection: null
     // Device details come from NetworkManager's IP4Config over dbus now.
@@ -58,7 +56,6 @@ Singleton {
     // Constants
     readonly property string deviceTypeWifi: "wifi"
     readonly property string deviceTypeEthernet: "ethernet"
-    readonly property string connectionTypeWireless: "802-11-wireless"
     readonly property string nmcliCommandDevice: "device"
     readonly property string nmcliCommandConnection: "connection"
     readonly property string nmcliCommandWifi: "wifi"
@@ -165,13 +162,6 @@ Singleton {
         });
     }
 
-    function getDeviceStatus(callback: var): void {
-        executeCommand(["-t", "-f", root.deviceStatusFields, root.nmcliCommandDevice, "status"], result => {
-            if (callback)
-                callback(result.output);
-        });
-    }
-
     function getWirelessInterfaces(callback: var): void {
         executeCommand(["-t", "-f", root.deviceStatusFields, root.nmcliCommandDevice, "status"], result => {
             const interfaces = parseDeviceStatusOutput(result.output, root.deviceTypeWifi);
@@ -181,27 +171,12 @@ Singleton {
         });
     }
 
-    // Kept so existing callers still get their callback; the device list is
-    // a live binding on Wired now, so there is nothing to fetch.
-    function getEthernetInterfaces(callback: var): void {
-        if (callback)
-            callback(root.ethernetDevices);
-    }
-
     function connectEthernet(connectionName: string, interfaceName: string, callback: var): void {
         Wired.connect(connectionName, interfaceName, callback);
     }
 
     function disconnectEthernet(connectionName: string, callback: var): void {
         Wired.disconnect(connectionName, callback);
-    }
-
-    function getAllInterfaces(callback: var): void {
-        executeCommand(["-t", "-f", root.deviceStatusFields, root.nmcliCommandDevice, "status"], result => {
-            const interfaces = parseDeviceStatusOutput(result.output, "both");
-            if (callback)
-                callback(interfaces);
-        });
     }
 
     function isInterfaceConnected(interfaceName: string, callback: var): void {
@@ -414,13 +389,6 @@ Singleton {
         });
     }
 
-    // Reads whether a saved connection auto-connects.
-    // Kept for existing callers; autoconnect is a live binding on Profiles now.
-    function getAutoconnect(connectionName: string, callback: var): void {
-        if (callback)
-            callback(Profiles.autoconnectFor(connectionName));
-    }
-
     function setAutoconnect(connectionName: string, enabled: bool, callback: var): void {
         Profiles.setAutoconnect(Profiles.nameFor(connectionName), enabled, callback);
     }
@@ -451,39 +419,6 @@ Singleton {
 
     function disconnectFromNetwork(): void {
         Wifi.disconnect(null);
-    }
-
-    function refreshStatus(callback: var): void {
-        getDeviceStatus(output => {
-            const lines = output.trim().split("\n");
-            let connected = false;
-            let activeIf = "";
-            let activeConn = "";
-
-            for (const line of lines) {
-                const parts = line.split(":");
-                if (parts.length >= 4) {
-                    const state = parts[2] || "";
-                    if (isConnectedState(state)) {
-                        connected = true;
-                        activeIf = parts[0] || "";
-                        activeConn = parts[3] || "";
-                        break;
-                    }
-                }
-            }
-
-            root.isConnected = connected;
-            root.activeInterface = activeIf;
-            root.activeConnection = activeConn;
-
-            if (callback)
-                callback({
-                    connected,
-                    interface: activeIf,
-                    connection: activeConn
-                });
-        });
     }
 
     function bringInterfaceUp(interfaceName: string, callback: var): void {
@@ -522,12 +457,6 @@ Singleton {
         }
     }
 
-    function scanWirelessNetworks(interfaceName: string, callback: var): void {
-        Wifi.scan();
-        if (callback)
-            callback(true);
-    }
-
     function rescanWifi(): void {
         Wifi.scan();
     }
@@ -557,53 +486,6 @@ Singleton {
         if (callback)
             callback(root.networks);
         checkPendingConnection();
-    }
-
-    function getWirelessSSIDs(interfaceName: string, callback: var): void {
-        let cmd = ["-t", "-f", root.networkListFields, root.nmcliCommandDevice, root.nmcliCommandWifi, "list"];
-        if (interfaceName && interfaceName.length > 0) {
-            cmd.push(root.connectionParamIfname, interfaceName);
-        }
-        executeCommand(cmd, result => {
-            if (!result.success) {
-                if (callback)
-                    callback([]);
-                return;
-            }
-
-            const ssids = [];
-            const lines = result.output.trim().split("\n");
-            const seenSSIDs = new Set();
-
-            for (const line of lines) {
-                if (!line || line.length === 0)
-                    continue;
-
-                const parts = line.split(":");
-                if (parts.length >= 1) {
-                    const ssid = parts[0].trim();
-                    if (ssid && ssid.length > 0 && !seenSSIDs.has(ssid)) {
-                        seenSSIDs.add(ssid);
-                        const signalStr = parts.length >= 2 ? parts[1].trim() : "";
-                        const signal = signalStr ? parseInt(signalStr, 10) : 0;
-                        const security = parts.length >= 3 ? parts[2].trim() : "";
-                        ssids.push({
-                            ssid: ssid,
-                            signal: signalStr,
-                            signalValue: isNaN(signal) ? 0 : signal,
-                            security: security
-                        });
-                    }
-                }
-            }
-
-            ssids.sort((a, b) => {
-                return b.signalValue - a.signalValue;
-            });
-
-            if (callback)
-                callback(ssids);
-        });
     }
 
     function handlePasswordRequired(proc: var, error: string, output: string, exitCode: int): bool {
@@ -659,11 +541,6 @@ Singleton {
                 }
             });
         }
-    }
-
-    function getWirelessDeviceDetails(interfaceName: string, callback: var): void {
-        if (callback)
-            callback(root.wirelessDeviceDetails);
     }
 
     // Reads the IPv4 configuration (method, address, gateway, DNS, autoconnect)
@@ -731,32 +608,8 @@ Singleton {
         });
     }
 
-    function getEthernetSpeed(interfaceName: string): void {
-        Wired.refreshSpeed(interfaceName);
-    }
-
     function getEthernetDataUsage(interfaceName: string): void {
         Wired.refreshDataUsage(interfaceName);
-    }
-
-    function formatBytes(bytes: var): string {
-        if (!bytes || bytes <= 0)
-            return "0 B";
-        const units = ["B", "KB", "MB", "GB", "TB"];
-        let i = 0;
-        let v = bytes;
-        while (v >= 1024 && i < units.length - 1) {
-            v /= 1024;
-            i++;
-        }
-        return `${v.toFixed(v < 10 && i > 0 ? 1 : 0)} ${units[i]}`;
-    }
-
-    // Kept so existing callers still get their callback; the details are a
-    // live binding on Wired now, so there is nothing to fetch.
-    function getEthernetDeviceDetails(interfaceName: string, callback: var): void {
-        if (callback)
-            callback(root.ethernetDeviceDetails);
     }
 
     function refreshOnConnectionChange(): void {

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -11,12 +11,7 @@ import qs.services
 Singleton {
     id: root
 
-    property var deviceStatus: null
-    property var wirelessInterfaces: []
-    property bool isConnected: false
-    readonly property bool connecting: wirelessInterfaces.some(i => isConnectingState(i.state))
-    property string activeInterface: ""
-    property string activeConnection: ""
+    readonly property bool connecting: Wifi.connecting
     // Wifi state lives in Wifi now, read from NetworkManager over dbus.
     // These forward it so existing consumers keep working unchanged.
     readonly property bool wifiEnabled: Wifi.enabled
@@ -55,12 +50,9 @@ Singleton {
 
     // Constants
     readonly property string deviceTypeWifi: "wifi"
-    readonly property string deviceTypeEthernet: "ethernet"
     readonly property string nmcliCommandDevice: "device"
     readonly property string nmcliCommandConnection: "connection"
     readonly property string nmcliCommandWifi: "wifi"
-    readonly property string deviceStatusFields: "DEVICE,TYPE,STATE,CONNECTION"
-    readonly property string networkListFields: "SSID,SIGNAL,SECURITY"
     readonly property string securityKeyMgmt: "802-11-wireless-security.key-mgmt"
     readonly property string securityPsk: "802-11-wireless-security.psk"
     readonly property string keyMgmtWpaPsk: "wpa-psk"
@@ -90,57 +82,8 @@ Singleton {
         return command.includes(root.nmcliCommandWifi) || command.includes(root.nmcliCommandConnection);
     }
 
-    function parseDeviceStatusOutput(output: string, filterType: string): list<var> {
-        if (!output || output.length === 0) {
-            return [];
-        }
-
-        const interfaces = [];
-        const lines = output.trim().split("\n");
-
-        for (const line of lines) {
-            const parts = line.split(":");
-            if (parts.length >= 2) {
-                const deviceType = parts[1];
-                let shouldInclude = false;
-
-                if (filterType === root.deviceTypeWifi && deviceType === root.deviceTypeWifi) {
-                    shouldInclude = true;
-                } else if (filterType === root.deviceTypeEthernet && deviceType === root.deviceTypeEthernet) {
-                    shouldInclude = true;
-                } else if (filterType === "both" && (deviceType === root.deviceTypeWifi || deviceType === root.deviceTypeEthernet)) {
-                    shouldInclude = true;
-                }
-
-                if (shouldInclude) {
-                    interfaces.push({
-                        device: parts[0] || "",
-                        type: parts[1] || "",
-                        state: parts[2] || "",
-                        connection: parts[3] || ""
-                    });
-                }
-            }
-        }
-
-        return interfaces;
-    }
-
-    function isConnectedState(state: string): bool {
-        if (!state || state.length === 0) {
-            return false;
-        }
-
-        return state === "100 (connected)" || state === "connected" || state.startsWith("connected");
-    }
-
-    function isConnectingState(state: string): bool {
-        return !!state && state.startsWith("connecting");
-    }
-
     function connectingSsid(): string {
-        const iface = root.wirelessInterfaces.find(i => isConnectingState(i.state));
-        return iface ? iface.connection : "";
+        return Wifi.connectingSsid;
     }
 
     function executeCommand(args: list<string>, callback: var): void {
@@ -162,38 +105,12 @@ Singleton {
         });
     }
 
-    function getWirelessInterfaces(callback: var): void {
-        executeCommand(["-t", "-f", root.deviceStatusFields, root.nmcliCommandDevice, "status"], result => {
-            const interfaces = parseDeviceStatusOutput(result.output, root.deviceTypeWifi);
-            root.wirelessInterfaces = interfaces;
-            if (callback)
-                callback(interfaces);
-        });
-    }
-
     function connectEthernet(connectionName: string, interfaceName: string, callback: var): void {
         Wired.connect(connectionName, interfaceName, callback);
     }
 
     function disconnectEthernet(connectionName: string, callback: var): void {
         Wired.disconnect(connectionName, callback);
-    }
-
-    function isInterfaceConnected(interfaceName: string, callback: var): void {
-        executeCommand([root.nmcliCommandDevice, "status"], result => {
-            const lines = result.output.trim().split("\n");
-            for (const line of lines) {
-                const parts = line.split(/\s+/);
-                if (parts.length >= 3 && parts[0] === interfaceName) {
-                    const connected = isConnectedState(parts[2]);
-                    if (callback)
-                        callback(connected);
-                    return;
-                }
-            }
-            if (callback)
-                callback(false);
-        });
     }
 
     function connectToNetworkWithPasswordCheck(ssid: string, isSecure: bool, callback: var, bssid: string): void {
@@ -403,20 +320,6 @@ Singleton {
         Profiles.forget(Profiles.nameFor(ssid), callback);
     }
 
-    function disconnect(interfaceName: string, callback: var): void {
-        if (interfaceName && interfaceName.length > 0) {
-            executeCommand([root.nmcliCommandDevice, "disconnect", interfaceName], result => {
-                if (callback)
-                    callback(result.success ? result.output : "");
-            });
-        } else {
-            executeCommand([root.nmcliCommandDevice, "disconnect", root.deviceTypeWifi], result => {
-                if (callback)
-                    callback(result.success ? result.output : "");
-            });
-        }
-    }
-
     function disconnectFromNetwork(): void {
         Wifi.disconnect(null);
     }
@@ -597,11 +500,9 @@ Singleton {
                     callback(result);
                 return;
             }
-            // Reactivate so changes take effect immediately.
+            // Reactivate so changes take effect immediately. Nothing to
+            // refresh afterwards; the new addresses arrive over dbus.
             executeCommand([root.nmcliCommandConnection, "up", connectionName], upResult => {
-                Qt.callLater(() => {
-                    refreshOnConnectionChange();
-                });
                 if (callback)
                     callback(upResult);
             });
@@ -610,10 +511,6 @@ Singleton {
 
     function getEthernetDataUsage(interfaceName: string): void {
         Wired.refreshDataUsage(interfaceName);
-    }
-
-    function refreshOnConnectionChange(): void {
-        getWirelessInterfaces(() => {});
     }
 
     // Association is reported over dbus now, so a pending connect resolves the
@@ -651,30 +548,6 @@ Singleton {
                 exitCode: -1,
                 needsPassword: false
             });
-        }
-    }
-
-    Process {
-        id: monitorProc
-
-        running: true
-        command: ["nmcli", "monitor"]
-        environment: ({
-                LANG: "C.UTF-8",
-                LC_ALL: "C.UTF-8"
-            })
-        stdout: SplitParser {
-            onRead: root.refreshOnConnectionChange()
-        }
-        onExited: monitorRestartTimer.start() // qmllint disable signal-handler-parameters
-    }
-
-    Timer {
-        id: monitorRestartTimer
-
-        interval: 2000
-        onTriggered: {
-            monitorProc.running = true;
         }
     }
 

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -113,22 +113,6 @@ Singleton {
     }
 
     function connectToNetworkWithPasswordCheck(ssid: string, isSecure: bool, callback: var): void {
-        // A secure network with no profile always needs a password. Asking
-        // nmcli to connect without one has NetworkManager create the profile
-        // and only then fail for the missing secret, which leaves it behind
-        // looking saved even if the prompt is cancelled.
-        if (isSecure && !Profiles.has(ssid)) {
-            if (callback)
-                callback({
-                    success: false,
-                    needsPassword: true,
-                    output: "",
-                    error: "",
-                    exitCode: -1
-                });
-            return;
-        }
-
         if (isSecure) {
             connectWireless(ssid, "", result => {
                 if (result.success) {
@@ -327,9 +311,6 @@ Singleton {
             return;
         }
 
-        // Ask before the profile goes: afterwards there's nothing left to say
-        // whether the network broadcasts.
-        Wifi.noteForgotten(ssid);
         Profiles.forget(Profiles.nameFor(ssid), callback);
     }
 

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -113,6 +113,22 @@ Singleton {
     }
 
     function connectToNetworkWithPasswordCheck(ssid: string, isSecure: bool, callback: var): void {
+        // A secure network with no profile always needs a password. Asking
+        // nmcli to connect without one has NetworkManager create the profile
+        // and only then fail for the missing secret, which leaves it behind
+        // looking saved even if the prompt is cancelled.
+        if (isSecure && !Profiles.has(ssid)) {
+            if (callback)
+                callback({
+                    success: false,
+                    needsPassword: true,
+                    output: "",
+                    error: "",
+                    exitCode: -1
+                });
+            return;
+        }
+
         if (isSecure) {
             connectWireless(ssid, "", result => {
                 if (result.success) {
@@ -311,6 +327,9 @@ Singleton {
             return;
         }
 
+        // Ask before the profile goes: afterwards there's nothing left to say
+        // whether the network broadcasts.
+        Wifi.noteForgotten(ssid);
         Profiles.forget(Profiles.nameFor(ssid), callback);
     }
 

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -11,7 +11,6 @@ import qs.services
 Singleton {
     id: root
 
-    readonly property bool connecting: Wifi.connecting
     // Wifi state lives in Wifi now, read from NetworkManager over dbus.
     // These forward it so existing consumers keep working unchanged.
     readonly property bool wifiEnabled: Wifi.enabled
@@ -336,42 +335,6 @@ Singleton {
         Wifi.disconnect(null);
     }
 
-    function bringInterfaceUp(interfaceName: string, callback: var): void {
-        if (interfaceName && interfaceName.length > 0) {
-            executeCommand([root.nmcliCommandDevice, "connect", interfaceName], result => {
-                if (callback) {
-                    callback(result);
-                }
-            });
-        } else {
-            if (callback)
-                callback({
-                    success: false,
-                    output: "",
-                    error: "No interface specified",
-                    exitCode: -1
-                });
-        }
-    }
-
-    function bringInterfaceDown(interfaceName: string, callback: var): void {
-        if (interfaceName && interfaceName.length > 0) {
-            executeCommand([root.nmcliCommandDevice, "disconnect", interfaceName], result => {
-                if (callback) {
-                    callback(result);
-                }
-            });
-        } else {
-            if (callback)
-                callback({
-                    success: false,
-                    output: "",
-                    error: "No interface specified",
-                    exitCode: -1
-                });
-        }
-    }
-
     function rescanWifi(): void {
         Wifi.scan();
     }
@@ -384,23 +347,8 @@ Singleton {
         Wifi.toggle(callback);
     }
 
-    // Kept for existing callers; wifiEnabled is a live binding now, so there is
-    // nothing to fetch.
-    function getWifiStatus(callback: var): void {
-        if (callback)
-            callback(root.wifiEnabled);
-    }
-
     function findNetwork(ssid: string): var {
         return Wifi.findNetwork(ssid);
-    }
-
-    // Kept so existing callers still get their callback; the network list is
-    // a live binding on Wifi now, so there is nothing to fetch.
-    function getNetworks(callback: var): void {
-        if (callback)
-            callback(root.networks);
-        checkPendingConnection();
     }
 
     function handlePasswordRequired(proc: var, error: string, output: string, exitCode: int): bool {
@@ -538,11 +486,9 @@ Singleton {
         CommandProcess {}
     }
 
-    // Nothing reports a connect that simply never happens, so this stays as the
-    // backstop. Success arrives on onActiveChanged and a rejected password on
-    // the process's own stderr, both immediately, so neither needs polling.
-    // Qt.callLater takes arguments to pass on, not a delay, so the retry used
-    // to fire straight away and put three attempts back to back.
+    // A Timer rather than Qt.callLater, whose second argument is passed to the
+    // function rather than used as a delay, so the retry used to fire straight
+    // away and put three attempts back to back.
     Timer {
         id: connectRetryTimer
 
@@ -577,6 +523,9 @@ Singleton {
         }
     }
 
+    // Nothing reports a connect that simply never happens, so this is the
+    // backstop. Success arrives on onActiveChanged and a rejected password on
+    // the process's own stderr, both immediately, so neither needs polling.
     Timer {
         id: connectionCheckTimer
 

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -405,6 +405,17 @@ Singleton {
 
     // Writes an IPv4 configuration to a connection profile and reactivates it so
     // the change takes effect immediately.
+    // Whether a profile is the one currently up, on either transport.
+    function isActiveProfile(connectionName: string): bool {
+        if (!connectionName)
+            return false;
+
+        if (Wired.active?.connection === connectionName)
+            return true;
+
+        return !!root.active && Profiles.nameFor(root.active.ssid) === connectionName;
+    }
+
     function setIpv4Config(connectionName: string, config: var, callback: var): void {
         if (!connectionName || connectionName.length === 0) {
             if (callback)
@@ -448,8 +459,16 @@ Singleton {
                     callback(result);
                 return;
             }
-            // Reactivate so changes take effect immediately. Nothing to
-            // refresh afterwards; the new addresses arrive over dbus.
+            // Addressing only takes effect on activation, so the profile has
+            // to come back up - but only if it was up to begin with. Saving
+            // the addresses of a network you aren't on shouldn't connect you
+            // to it, which is what an unconditional `connection up` did.
+            if (!root.isActiveProfile(connectionName)) {
+                if (callback)
+                    callback(result);
+                return;
+            }
+
             executeCommand([root.nmcliCommandConnection, "up", connectionName], upResult => {
                 if (callback)
                     callback(upResult);

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -29,7 +29,6 @@ Singleton {
     readonly property list<string> savedConnectionSsids: Profiles.ssids
 
     property var pendingConnection: null
-    property list<var> activeProcesses: []
     // Whether traffic is actually leaving over a wired link, which isn't the
     // same question as whether a cable is plugged in - with both a cable and
     // wifi up, either can be carrying it. NetworkManager already tracks which
@@ -83,15 +82,6 @@ Singleton {
         const proc = commandProc.createObject(root);
         proc.cmdArgs = ["nmcli", ...args];
         proc.callback = callback;
-
-        activeProcesses.push(proc);
-
-        proc.processFinished.connect(() => {
-            const index = activeProcesses.indexOf(proc);
-            if (index >= 0) {
-                activeProcesses.splice(index, 1);
-            }
-        });
 
         Qt.callLater(() => {
             proc.exec(proc.cmdArgs);

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -11,28 +11,25 @@ import qs.services
 Singleton {
     id: root
 
-    // Wifi state lives in Wifi now, read from NetworkManager over dbus.
-    // These forward it so existing consumers keep working unchanged.
+    // State lives in Wired, Wifi and Profiles now, read from NetworkManager
+    // over dbus. These forward it so existing consumers keep working unchanged.
     readonly property bool wifiEnabled: Wifi.enabled
     readonly property bool scanning: Wifi.scanning
     readonly property list<var> networks: Wifi.networks
     readonly property var active: Wifi.active
-    // Saved profiles live in Profiles now, read from NetworkManager's Settings
-    // interface. These forward them so existing consumers keep working.
-    readonly property list<string> savedConnectionSsids: Profiles.ssids
-    // Map of saved Wi-Fi SSID (lowercased) -> security type
-
-    property var pendingConnection: null
-    // Device details come from NetworkManager's IP4Config over dbus now.
-    // These forward them so existing consumers keep working unchanged.
     readonly property var wirelessDeviceDetails: Wifi.details
-    readonly property var ethernetDeviceDetails: Wired.details
-    // Wired state lives in Wired now, read from NetworkManager over dbus.
-    // These forward it so existing consumers keep working unchanged.
-    readonly property string ethernetDataUsage: Wired.dataUsage
-    readonly property string ethernetSpeed: Wired.speed
+
     readonly property list<var> ethernetDevices: Wired.devices
     readonly property var activeEthernet: Wired.active
+    readonly property bool hasAvailableEthernet: Wired.available
+    readonly property string ethernetSpeed: Wired.speed
+    readonly property string ethernetDataUsage: Wired.dataUsage
+    readonly property var ethernetDeviceDetails: Wired.details
+
+    readonly property list<string> savedConnectionSsids: Profiles.ssids
+
+    property var pendingConnection: null
+    property list<var> activeProcesses: []
     // Whether traffic is actually leaving over a wired link, which isn't the
     // same question as whether a cable is plugged in - with both a cable and
     // wifi up, either can be carrying it. NetworkManager already tracks which
@@ -42,8 +39,6 @@ Singleton {
     // icon doesn't flicker through a wrong state on startup or if
     // NetworkManager isn't reachable.
     readonly property bool onEthernet: NetworkRoute.ready ? NetworkRoute.primaryTransport === NetworkTransport.Ethernet : !!activeEthernet
-    readonly property bool hasAvailableEthernet: Wired.available
-    property list<var> activeProcesses: []
 
     readonly property alias connectionCheckTimer: connectionCheckTimer
 

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -61,7 +61,6 @@ Singleton {
     readonly property string connectionParamIfname: "ifname"
     readonly property string connectionParamSsid: "ssid"
     readonly property string connectionParamPassword: "password"
-    readonly property string connectionParamBssid: "802-11-wireless.bssid"
     readonly property string connectionParamHidden: "802-11-wireless.hidden"
 
     signal connectionFailed(string ssid)
@@ -113,10 +112,9 @@ Singleton {
         Wired.disconnect(connectionName, callback);
     }
 
-    function connectToNetworkWithPasswordCheck(ssid: string, isSecure: bool, callback: var, bssid: string): void {
+    function connectToNetworkWithPasswordCheck(ssid: string, isSecure: bool, callback: var): void {
         if (isSecure) {
-            const hasBssid = bssid !== undefined && bssid !== null && bssid.length > 0;
-            connectWireless(ssid, "", bssid, result => {
+            connectWireless(ssid, "", result => {
                 if (result.success) {
                     if (callback)
                         callback({
@@ -141,96 +139,92 @@ Singleton {
                 }
             });
         } else {
-            connectWireless(ssid, "", bssid, callback);
+            connectWireless(ssid, "", callback);
         }
     }
 
-    function connectToNetwork(ssid: string, password: string, bssid: string, callback: var): void {
-        connectWireless(ssid, password, bssid, callback);
+    function connectToNetwork(ssid: string, password: string, callback: var): void {
+        connectWireless(ssid, password, callback);
     }
 
-    function connectWireless(ssid: string, password: string, bssid: string, callback: var, retryCount: int): void {
-        const hasBssid = bssid !== undefined && bssid !== null && bssid.length > 0;
+    // Connecting is left to nmcli, which reuses a saved profile when one
+    // matches the access point and updates it in place, and picks WEP, WPA-PSK
+    // or SAE from the access point's own security flags.
+    //
+    // What it must not be given is a BSSID. That pins the profile to one access
+    // point, which breaks roaming on a mesh and stops the profile matching the
+    // other access points, so the next connection through a different one
+    // leaves a second profile behind.
+    function connectWireless(ssid: string, password: string, callback: var, retryCount: int): void {
         const retries = retryCount !== undefined ? retryCount : 0;
         const maxRetries = 2;
 
         if (callback) {
             root.pendingConnection = {
                 ssid: ssid,
-                bssid: hasBssid ? bssid : "",
                 callback: callback,
                 retryCount: retries
             };
             connectionCheckTimer.start();
         }
 
-        if (password && password.length > 0 && hasBssid) {
-            const bssidUpper = bssid.toUpperCase();
-            createConnectionWithPassword(ssid, bssidUpper, password, callback);
-            return;
+        // A saved profile with no new password is brought up as it stands, so
+        // nothing the user set on it - a static address, a custom name, an
+        // autoconnect preference - is touched. If the profile list hasn't been
+        // read yet this falls through to the command below, which reuses the
+        // profile anyway.
+        const saved = Profiles.find(ssid);
+        let cmd;
+        if (saved && !password) {
+            cmd = [root.nmcliCommandConnection, "up", saved.id];
+        } else {
+            cmd = [root.nmcliCommandDevice, root.nmcliCommandWifi, "connect", ssid];
+            if (password && password.length > 0)
+                cmd.push(root.connectionParamPassword, password);
         }
 
-        let cmd = [root.nmcliCommandDevice, root.nmcliCommandWifi, "connect", ssid];
-        if (password && password.length > 0) {
-            cmd.push(root.connectionParamPassword, password);
-        }
         executeCommand(cmd, result => {
-            if (result.needsPassword && callback) {
+            if (result.needsPassword) {
                 if (callback)
                     callback(result);
                 return;
             }
 
             if (!result.success && root.pendingConnection && retries < maxRetries) {
-                console.warn(lc, "Connection failed, retrying... (attempt " + (retries + 1) + "/" + maxRetries + ")");
-                Qt.callLater(() => {
-                    connectWireless(ssid, password, bssid, callback, retries + 1);
-                }, 1000);
-            } else if (!result.success && root.pendingConnection) {} else if (result.success && callback) {} else if (!result.success && !root.pendingConnection) {
-                if (callback)
-                    callback(result);
+                console.warn(lc, `Connection failed, retrying (attempt ${retries + 1}/${maxRetries})`);
+                connectRetryTimer.ssid = ssid;
+                connectRetryTimer.password = password;
+                connectRetryTimer.callback = callback;
+                connectRetryTimer.retries = retries + 1;
+                connectRetryTimer.restart();
+                return;
             }
+
+            // A pending connect is reported by whichever of onActiveChanged
+            // or connectionCheckTimer resolves it, and a success always goes
+            // through one of those, so this only has to cover a failure that
+            // nothing else will pick up. Reporting here as well would call the
+            // callback twice.
+            if (!result.success && !root.pendingConnection && callback)
+                callback(result);
         });
     }
 
-    function createConnectionWithPassword(ssid: string, bssidUpper: string, password: string, callback: var): void {
-        checkAndDeleteConnection(ssid, () => {
-            const cmd = [root.nmcliCommandConnection, "add", root.connectionParamType, root.deviceTypeWifi, root.connectionParamConName, ssid, root.connectionParamIfname, "*", root.connectionParamSsid, ssid, root.connectionParamBssid, bssidUpper, root.securityKeyMgmt, root.keyMgmtWpaPsk, root.securityPsk, password];
-
-            executeCommand(cmd, result => {
-                if (result.success) {
-                    activateConnection(ssid, callback);
-                } else {
-                    const hasDuplicateWarning = result.error && (result.error.includes("another connection with the name") || result.error.includes("Reference the connection by its uuid"));
-
-                    if (hasDuplicateWarning || (result.exitCode > 0 && result.exitCode < 10)) {
-                        activateConnection(ssid, callback);
-                    } else {
-                        console.warn(lc, "Connection profile creation failed, trying fallback...");
-                        let fallbackCmd = [root.nmcliCommandDevice, root.nmcliCommandWifi, "connect", ssid, root.connectionParamPassword, password];
-                        executeCommand(fallbackCmd, fallbackResult => {
-                            if (callback)
-                                callback(fallbackResult);
-                        });
-                    }
-                }
-            });
-        });
-    }
-
+    // Replaces a profile for the same SSID, for the add-network form, which is
+    // an explicit request to redefine it. Resolved through Profiles so a
+    // profile saved under a name other than its SSID is replaced rather than
+    // duplicated.
     function checkAndDeleteConnection(ssid: string, callback: var): void {
-        executeCommand([root.nmcliCommandConnection, "show", ssid], result => {
-            if (result.success) {
-                executeCommand([root.nmcliCommandConnection, "delete", ssid], deleteResult => {
-                    Qt.callLater(() => {
-                        if (callback)
-                            callback();
-                    }, 300);
-                });
-            } else {
-                if (callback)
-                    callback();
-            }
+        const saved = Profiles.find(ssid);
+        if (!saved) {
+            if (callback)
+                callback();
+            return;
+        }
+
+        executeCommand([root.nmcliCommandConnection, "delete", saved.id], () => {
+            if (callback)
+                callback();
         });
     }
 
@@ -526,6 +520,20 @@ Singleton {
     // Nothing reports a connect that simply never happens, so this stays as the
     // backstop. Success arrives on onActiveChanged and a rejected password on
     // the process's own stderr, both immediately, so neither needs polling.
+    // Qt.callLater takes arguments to pass on, not a delay, so the retry used
+    // to fire straight away and put three attempts back to back.
+    Timer {
+        id: connectRetryTimer
+
+        property var callback: null
+        property string password: ""
+        property int retries: 0
+        property string ssid: ""
+
+        interval: 1000
+        onTriggered: root.connectWireless(connectRetryTimer.ssid, connectRetryTimer.password, connectRetryTimer.callback, connectRetryTimer.retries)
+    }
+
     Timer {
         id: connectionCheckTimer
 

--- a/services/Nmcli.qml
+++ b/services/Nmcli.qml
@@ -174,6 +174,16 @@ Singleton {
         // read yet this falls through to the command below, which reuses the
         // profile anyway.
         const saved = Profiles.find(ssid);
+
+        // `nmcli device wifi connect` goes through AddAndActivateConnection:
+        // NetworkManager writes the profile and only then asks the secret agent
+        // for the password. Cancel that prompt, or get the password wrong, and
+        // the profile stays behind as a saved network that never connected.
+        // Until the profile list has been read, a saved network looks unsaved,
+        // and cleaning up after a failure would delete the user's own profile.
+        // Assume there was one when we can't tell.
+        const existed = !Profiles.ready || !!saved;
+
         let cmd;
         if (saved && !password) {
             cmd = [root.nmcliCommandConnection, "up", saved.id];
@@ -184,6 +194,14 @@ Singleton {
         }
 
         executeCommand(cmd, result => {
+            // Before the early returns below: cancelling the password prompt
+            // comes back as needsPassword, and that is exactly the case that
+            // leaves a profile behind.
+            if (!result.success && !existed) {
+                strayProfileTimer.ssid = ssid;
+                strayProfileTimer.restart();
+            }
+
             if (result.needsPassword) {
                 if (callback)
                     callback(result);
@@ -421,23 +439,26 @@ Singleton {
     }
 
     function checkPendingConnection(): void {
-        if (root.pendingConnection) {
-            Qt.callLater(() => {
-                const connected = root.active && root.active.ssid === root.pendingConnection.ssid;
-                if (connected) {
-                    connectionCheckTimer.stop();
-                    if (root.pendingConnection.callback) {
-                        root.pendingConnection.callback({
-                            success: true,
-                            output: "Connected",
-                            error: "",
-                            exitCode: 0
-                        });
-                    }
-                    root.pendingConnection = null;
-                }
+        if (!root.pendingConnection)
+            return;
+
+        Qt.callLater(() => {
+            // Read again rather than captured: this runs a turn later, and the
+            // password prompt or the timeout may have resolved the pending
+            // connect in between.
+            const pending = root.pendingConnection;
+            if (!pending || root.active?.ssid !== pending.ssid)
+                return;
+
+            connectionCheckTimer.stop();
+            root.pendingConnection = null;
+            pending.callback?.({
+                success: true,
+                output: "Connected",
+                error: "",
+                exitCode: 0
             });
-        }
+        });
     }
 
     // Reads the IPv4 configuration (method, address, gateway, DNS, autoconnect)
@@ -532,6 +553,28 @@ Singleton {
 
         interval: 1000
         onTriggered: root.connectWireless(connectRetryTimer.ssid, connectRetryTimer.password, connectRetryTimer.callback, connectRetryTimer.retries)
+    }
+
+    Timer {
+        id: strayProfileTimer
+
+        property string ssid: ""
+
+        // Long enough to see whether the connection came up on a second
+        // attempt, short enough that the network doesn't linger under saved
+        // networks while the user is looking at it.
+        interval: 1000
+        onTriggered: {
+            const ssid = strayProfileTimer.ssid;
+            strayProfileTimer.ssid = "";
+
+            // Connected after all, or another attempt is still running: the
+            // profile is in use, leave it alone.
+            if (!ssid || root.active?.ssid === ssid || root.pendingConnection)
+                return;
+
+            Profiles.forget(Profiles.nameFor(ssid), null);
+        }
     }
 
     Timer {

--- a/services/Profiles.qml
+++ b/services/Profiles.qml
@@ -3,6 +3,7 @@ pragma Singleton
 import QtQuick
 import Quickshell
 import Caelestia.Services
+import qs.services
 
 // Saved connection profiles, split out of Nmcli along their own boundary.
 //

--- a/services/Profiles.qml
+++ b/services/Profiles.qml
@@ -1,0 +1,140 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import Caelestia.Services
+
+// Saved connection profiles, split out of Nmcli along their own boundary.
+//
+// State comes from NetworkManager's Settings interface over dbus. This replaces
+// parsing `nmcli connection show` and then spawning a further nmcli per wifi
+// profile just to read its SSID, one at a time through a queue. Actions stay on
+// the CLI: adding, deleting and toggling autoconnect have nothing to parse and
+// nothing to gain from dbus.
+Singleton {
+    id: root
+
+    readonly property bool ready: NetworkProfiles.ready
+
+    readonly property list<var> list: {
+        const found = [];
+        for (const profile of NetworkProfiles.profiles)
+            found.push(profile);
+        return found;
+    }
+
+    readonly property list<var> wireless: root.list.filter(p => p.type === "802-11-wireless")
+
+    // SSIDs with a saved profile, deduplicated case-insensitively the way the
+    // parsed version was.
+    readonly property list<string> ssids: {
+        const seen = new Map();
+        for (const profile of root.wireless)
+            if (profile.ssid && !seen.has(profile.ssid.toLowerCase()))
+                seen.set(profile.ssid.toLowerCase(), profile.ssid);
+        return Array.from(seen.values());
+    }
+
+    // Key management per saved SSID, lowercased key, e.g. "wpa-psk".
+    readonly property var securityBySsid: {
+        const security = {};
+        for (const profile of root.wireless)
+            if (profile.ssid)
+                security[profile.ssid.toLowerCase()] = profile.keyMgmt;
+        return security;
+    }
+
+    function find(ssid: string): var {
+        if (!ssid)
+            return null;
+
+        const wanted = ssid.toLowerCase().trim();
+        return root.wireless.find(p => p.ssid && p.ssid.toLowerCase().trim() === wanted) ?? null;
+    }
+
+    function has(ssid: string): bool {
+        return root.find(ssid) !== null;
+    }
+
+    function keyMgmtFor(ssid: string): string {
+        return root.find(ssid)?.keyMgmt ?? "";
+    }
+
+    // Turns NetworkManager's key management into the label the UI shows.
+    function securityLabel(keyMgmt: string): string {
+        switch ((keyMgmt || "").trim().toLowerCase()) {
+        case "":
+        case "none":
+            return qsTr("Open");
+        case "sae":
+            return "WPA3";
+        case "wpa-psk":
+            return "WPA2";
+        case "wpa-eap":
+        case "wpa-eap-suite-b-192":
+            return qsTr("Enterprise");
+        case "owe":
+            return qsTr("Enhanced Open");
+        case "ieee8021x":
+            return "802.1X";
+        default:
+            return keyMgmt.trim();
+        }
+    }
+
+    function securityFor(ssid: string): string {
+        const profile = root.find(ssid);
+        return profile ? root.securityLabel(profile.keyMgmt) : "";
+    }
+
+    // One-shot nmcli call; only the exit code matters, so there's nothing to
+    // parse and no shared state to race.
+    function run(args: list<string>, callback: var): void {
+        const proc = actionProc.createObject(root, {
+            command: ["nmcli", ...args],
+            callback: callback ?? null
+        });
+        proc.running = true;
+    }
+
+    function forget(name: string, callback: var): void {
+        if (!name) {
+            if (callback)
+                callback(false);
+            return;
+        }
+        run(["connection", "delete", name], callback);
+    }
+
+    function setAutoconnect(name: string, autoconnect: bool, callback: var): void {
+        if (!name) {
+            if (callback)
+                callback(false);
+            return;
+        }
+        // No refetch afterwards: the profile reports its own edits over dbus.
+        run(["connection", "modify", name, "connection.autoconnect", autoconnect ? "yes" : "no"], callback);
+    }
+
+    Component {
+        id: actionProc
+
+        Process {
+            id: proc
+
+            property var callback: null
+
+            environment: ({
+                    LANG: "C.UTF-8",
+                    LC_ALL: "C.UTF-8"
+                })
+
+            onExited: code => { // qmllint disable signal-handler-parameters
+                const callback = proc.callback;
+                proc.destroy();
+                callback?.(code === 0);
+            }
+        }
+    }
+}

--- a/services/Profiles.qml
+++ b/services/Profiles.qml
@@ -2,7 +2,6 @@ pragma Singleton
 
 import QtQuick
 import Quickshell
-import Quickshell.Io
 import Caelestia.Services
 
 // Saved connection profiles, split out of Nmcli along their own boundary.
@@ -37,15 +36,6 @@ Singleton {
             if (profile.ssid && !seen.has(profile.ssid.toLowerCase()))
                 seen.set(profile.ssid.toLowerCase(), profile.ssid);
         return Array.from(seen.values());
-    }
-
-    // Key management per saved SSID, lowercased key, e.g. "wpa-psk".
-    readonly property var securityBySsid: {
-        const security = {};
-        for (const profile of root.wireless)
-            if (profile.ssid)
-                security[profile.ssid.toLowerCase()] = profile.keyMgmt;
-        return security;
     }
 
     function find(ssid: string): var {
@@ -83,14 +73,6 @@ Singleton {
         return root.has(ssid) || root.names.some(n => n && n.toLowerCase().trim() === wanted);
     }
 
-    function autoconnectFor(name: string): bool {
-        if (!name)
-            return true;
-
-        const wanted = name.toLowerCase().trim();
-        return (root.find(name) ?? root.list.find(p => p.id && p.id.toLowerCase().trim() === wanted))?.autoconnect ?? true;
-    }
-
     // Turns NetworkManager's key management into the label the UI shows.
     function securityLabel(keyMgmt: string): string {
         switch ((keyMgmt || "").trim().toLowerCase()) {
@@ -111,11 +93,6 @@ Singleton {
         default:
             return keyMgmt.trim();
         }
-    }
-
-    function securityFor(ssid: string): string {
-        const profile = root.find(ssid);
-        return profile ? root.securityLabel(profile.keyMgmt) : "";
     }
 
     // Looks a profile up by SSID first, then by name, since callers pass
@@ -148,23 +125,13 @@ Singleton {
         };
     }
 
-    // One-shot nmcli call; only the exit code matters, so there's nothing to
-    // parse and no shared state to race.
-    function run(args: list<string>, callback: var): void {
-        const proc = actionProc.createObject(root, {
-            command: ["nmcli", ...args],
-            callback: callback ?? null
-        });
-        proc.running = true;
-    }
-
     function forget(name: string, callback: var): void {
         if (!name) {
             if (callback)
                 callback(false);
             return;
         }
-        run(["connection", "delete", name], callback);
+        NmAction.run(["connection", "delete", name], callback);
     }
 
     // Turning autoconnect off also makes NetworkManager ask for the password on
@@ -182,43 +149,16 @@ Singleton {
         const cmd = autoconnect ? [...base, "802-11-wireless-security.psk-flags", "0"] : [...base, "802-11-wireless-security.psk-flags", "2", "802-11-wireless-security.psk", ""];
 
         // No refetch afterwards: the profile reports its own edits over dbus.
-        run(cmd, (success, error) => {
+        NmAction.run(cmd, (success, error) => {
             // Open networks have no security settings, so nmcli rejects those
             // fields. Retry with just the autoconnect change.
             if (!success && (error.includes("802-11-wireless-security") || error.includes("is not a valid property") || error.includes("Error: invalid"))) {
-                run(base, callback);
+                NmAction.run(base, callback);
                 return;
             }
 
             if (callback)
                 callback(success);
         });
-    }
-
-    Component {
-        id: actionProc
-
-        Process {
-            id: proc
-
-            property var callback: null
-            property string error: ""
-
-            environment: ({
-                    LANG: "C.UTF-8",
-                    LC_ALL: "C.UTF-8"
-                })
-
-            stderr: StdioCollector {
-                onStreamFinished: proc.error = text
-            }
-
-            onExited: code => { // qmllint disable signal-handler-parameters
-                const callback = proc.callback;
-                const error = proc.error;
-                proc.destroy();
-                callback?.(code === 0, error);
-            }
-        }
     }
 }

--- a/services/Profiles.qml
+++ b/services/Profiles.qml
@@ -118,6 +118,36 @@ Singleton {
         return profile ? root.securityLabel(profile.keyMgmt) : "";
     }
 
+    // Looks a profile up by SSID first, then by name, since callers pass
+    // whichever they have.
+    function profileFor(nameOrSsid: string): var {
+        if (!nameOrSsid)
+            return null;
+
+        const wanted = nameOrSsid.toLowerCase().trim();
+        return root.find(nameOrSsid) ?? root.list.find(p => p.id && p.id.toLowerCase().trim() === wanted) ?? null;
+    }
+
+    // The saved IPv4 configuration, in the shape the parsed nmcli output had.
+    function ipv4ConfigFor(nameOrSsid: string): var {
+        const profile = root.profileFor(nameOrSsid);
+        if (!profile)
+            return null;
+
+        // "auto-dns" isn't a NetworkManager method; it's how the UI
+        // distinguishes DHCP with custom DNS from plain DHCP.
+        const method = profile.ipv4Method || "auto";
+
+        return {
+            method: method === "auto" && profile.ipv4IgnoreAutoDns ? "auto-dns" : method,
+            address: profile.ipv4Address,
+            gateway: profile.ipv4Gateway,
+            dns: profile.ipv4Dns.join(", "),
+            ignoreAutoDns: profile.ipv4IgnoreAutoDns,
+            autoconnect: profile.autoconnect
+        };
+    }
+
     // One-shot nmcli call; only the exit code matters, so there's nothing to
     // parse and no shared state to race.
     function run(args: list<string>, callback: var): void {

--- a/services/Profiles.qml
+++ b/services/Profiles.qml
@@ -26,6 +26,9 @@ Singleton {
 
     readonly property list<var> wireless: root.list.filter(p => p.type === "802-11-wireless")
 
+    // Profile names, i.e. what nmcli takes as a connection argument.
+    readonly property list<string> names: root.list.map(p => p.id)
+
     // SSIDs with a saved profile, deduplicated case-insensitively the way the
     // parsed version was.
     readonly property list<string> ssids: {
@@ -59,6 +62,33 @@ Singleton {
 
     function keyMgmtFor(ssid: string): string {
         return root.find(ssid)?.keyMgmt ?? "";
+    }
+
+    // The profile name for an SSID. Falls back to the SSID itself, which is
+    // what NetworkManager names a profile by default.
+    function nameFor(ssid: string): string {
+        if (!ssid)
+            return "";
+
+        const wanted = ssid.toLowerCase().trim();
+        return root.find(ssid)?.id ?? root.names.find(n => n && n.toLowerCase().trim() === wanted) ?? ssid;
+    }
+
+    // Whether anything saved matches this SSID, by profile SSID or by name.
+    function hasName(ssid: string): bool {
+        if (!ssid)
+            return false;
+
+        const wanted = ssid.toLowerCase().trim();
+        return root.has(ssid) || root.names.some(n => n && n.toLowerCase().trim() === wanted);
+    }
+
+    function autoconnectFor(name: string): bool {
+        if (!name)
+            return true;
+
+        const wanted = name.toLowerCase().trim();
+        return (root.find(name) ?? root.list.find(p => p.id && p.id.toLowerCase().trim() === wanted))?.autoconnect ?? true;
     }
 
     // Turns NetworkManager's key management into the label the UI shows.
@@ -107,14 +137,32 @@ Singleton {
         run(["connection", "delete", name], callback);
     }
 
+    // Turning autoconnect off also makes NetworkManager ask for the password on
+    // the next manual connect rather than silently reusing the stored one
+    // (psk-flags 2 = "not saved, always ask"); turning it back on restores
+    // psk-flags 0 so the next password is saved.
     function setAutoconnect(name: string, autoconnect: bool, callback: var): void {
         if (!name) {
             if (callback)
                 callback(false);
             return;
         }
+
+        const base = ["connection", "modify", name, "connection.autoconnect", autoconnect ? "yes" : "no"];
+        const cmd = autoconnect ? [...base, "802-11-wireless-security.psk-flags", "0"] : [...base, "802-11-wireless-security.psk-flags", "2", "802-11-wireless-security.psk", ""];
+
         // No refetch afterwards: the profile reports its own edits over dbus.
-        run(["connection", "modify", name, "connection.autoconnect", autoconnect ? "yes" : "no"], callback);
+        run(cmd, (success, error) => {
+            // Open networks have no security settings, so nmcli rejects those
+            // fields. Retry with just the autoconnect change.
+            if (!success && (error.includes("802-11-wireless-security") || error.includes("is not a valid property") || error.includes("Error: invalid"))) {
+                run(base, callback);
+                return;
+            }
+
+            if (callback)
+                callback(success);
+        });
     }
 
     Component {
@@ -124,16 +172,22 @@ Singleton {
             id: proc
 
             property var callback: null
+            property string error: ""
 
             environment: ({
                     LANG: "C.UTF-8",
                     LC_ALL: "C.UTF-8"
                 })
 
+            stderr: StdioCollector {
+                onStreamFinished: proc.error = text
+            }
+
             onExited: code => { // qmllint disable signal-handler-parameters
                 const callback = proc.callback;
+                const error = proc.error;
                 proc.destroy();
-                callback?.(code === 0);
+                callback?.(code === 0, error);
             }
         }
     }

--- a/services/Profiles.qml
+++ b/services/Profiles.qml
@@ -135,10 +135,10 @@ Singleton {
         NmAction.run(["connection", "delete", name], callback);
     }
 
-    // Turning autoconnect off also makes NetworkManager ask for the password on
-    // the next manual connect rather than silently reusing the stored one
-    // (psk-flags 2 = "not saved, always ask"); turning it back on restores
-    // psk-flags 0 so the next password is saved.
+    // Only touches autoconnect. It used to clear the stored password as well,
+    // by way of psk-flags 2, so turning off "connect automatically" silently
+    // lost the key and the next connect had to ask for it again - which is not
+    // what the setting says it does, and isn't undone by turning it back on.
     function setAutoconnect(name: string, autoconnect: bool, callback: var): void {
         if (!name) {
             if (callback)
@@ -146,20 +146,7 @@ Singleton {
             return;
         }
 
-        const base = ["connection", "modify", name, "connection.autoconnect", autoconnect ? "yes" : "no"];
-        const cmd = autoconnect ? [...base, "802-11-wireless-security.psk-flags", "0"] : [...base, "802-11-wireless-security.psk-flags", "2", "802-11-wireless-security.psk", ""];
-
         // No refetch afterwards: the profile reports its own edits over dbus.
-        NmAction.run(cmd, (success, error) => {
-            // Open networks have no security settings, so nmcli rejects those
-            // fields. Retry with just the autoconnect change.
-            if (!success && (error.includes("802-11-wireless-security") || error.includes("is not a valid property") || error.includes("Error: invalid"))) {
-                NmAction.run(base, callback);
-                return;
-            }
-
-            if (callback)
-                callback(success);
-        });
+        NmAction.run(["connection", "modify", name, "connection.autoconnect", autoconnect ? "yes" : "no"], callback);
     }
 }

--- a/services/Profiles.qml
+++ b/services/Profiles.qml
@@ -55,23 +55,25 @@ Singleton {
         return root.find(ssid)?.keyMgmt ?? "";
     }
 
-    // The profile name for an SSID. Falls back to the SSID itself, which is
-    // what NetworkManager names a profile by default.
-    function nameFor(ssid: string): string {
-        if (!ssid)
-            return "";
+    // Looks a profile up by SSID first, then by name, since callers pass
+    // whichever they have.
+    function profileFor(nameOrSsid: string): var {
+        if (!nameOrSsid)
+            return null;
 
-        const wanted = ssid.toLowerCase().trim();
-        return root.find(ssid)?.id ?? root.names.find(n => n && n.toLowerCase().trim() === wanted) ?? ssid;
+        const wanted = nameOrSsid.toLowerCase().trim();
+        return root.find(nameOrSsid) ?? root.list.find(p => p.id && p.id.toLowerCase().trim() === wanted) ?? null;
     }
 
-    // Whether anything saved matches this SSID, by profile SSID or by name.
-    function hasName(ssid: string): bool {
-        if (!ssid)
-            return false;
+    // The profile name for an SSID. Falls back to the SSID itself, which is
+    // what NetworkManager names a profile by default.
+    function nameFor(nameOrSsid: string): string {
+        return root.profileFor(nameOrSsid)?.id ?? nameOrSsid ?? "";
+    }
 
-        const wanted = ssid.toLowerCase().trim();
-        return root.has(ssid) || root.names.some(n => n && n.toLowerCase().trim() === wanted);
+    // Whether anything saved matches, by profile SSID or by name.
+    function hasName(nameOrSsid: string): bool {
+        return root.profileFor(nameOrSsid) !== null;
     }
 
     // Turns NetworkManager's key management into the label the UI shows.
@@ -94,16 +96,6 @@ Singleton {
         default:
             return keyMgmt.trim();
         }
-    }
-
-    // Looks a profile up by SSID first, then by name, since callers pass
-    // whichever they have.
-    function profileFor(nameOrSsid: string): var {
-        if (!nameOrSsid)
-            return null;
-
-        const wanted = nameOrSsid.toLowerCase().trim();
-        return root.find(nameOrSsid) ?? root.list.find(p => p.id && p.id.toLowerCase().trim() === wanted) ?? null;
     }
 
     // The saved IPv4 configuration, in the shape the parsed nmcli output had.

--- a/services/Profiles.qml
+++ b/services/Profiles.qml
@@ -55,11 +55,6 @@ Singleton {
         return root.find(ssid)?.keyMgmt ?? "";
     }
 
-    // Whether the saved profile for an SSID says the network doesn't broadcast.
-    function isHidden(ssid: string): bool {
-        return root.find(ssid)?.hidden ?? false;
-    }
-
     // The profile name for an SSID. Falls back to the SSID itself, which is
     // what NetworkManager names a profile by default.
     function nameFor(ssid: string): string {

--- a/services/Profiles.qml
+++ b/services/Profiles.qml
@@ -55,6 +55,11 @@ Singleton {
         return root.find(ssid)?.keyMgmt ?? "";
     }
 
+    // Whether the saved profile for an SSID says the network doesn't broadcast.
+    function isHidden(ssid: string): bool {
+        return root.find(ssid)?.hidden ?? false;
+    }
+
     // The profile name for an SSID. Falls back to the SSID itself, which is
     // what NetworkManager names a profile by default.
     function nameFor(ssid: string): string {

--- a/services/VPN.qml
+++ b/services/VPN.qml
@@ -118,8 +118,7 @@ Singleton {
     }
 
     // Sync the normalised config into the `providers` object list, reusing
-    // existing entries by index. Same create/update/destroy diff as
-    // Nmcli.syncEthernetDevices / getNetworks.
+    // existing entries by index.
     function syncProviders(): void {
         const configs = root.providerConfigs;
         const rProviders = root.providers;

--- a/services/Wifi.qml
+++ b/services/Wifi.qml
@@ -4,6 +4,7 @@ import QtQuick
 import Quickshell
 import Caelestia.Services
 import Caelestia.Config
+import qs.services
 
 // Wifi networking, split out of Nmcli along its own boundary.
 //

--- a/services/Wifi.qml
+++ b/services/Wifi.qml
@@ -2,7 +2,6 @@ pragma Singleton
 
 import QtQuick
 import Quickshell
-import Quickshell.Io
 import Caelestia.Services
 import Caelestia.Config
 
@@ -84,20 +83,10 @@ Singleton {
         return root.networks.find(n => n.ssid === ssid) ?? null;
     }
 
-    // One-shot nmcli call; only the exit code matters, so there's nothing to
-    // parse and no shared state to race.
-    function run(args: list<string>, callback: var): void {
-        const proc = actionProc.createObject(root, {
-            command: ["nmcli", ...args],
-            callback: callback ?? null
-        });
-        proc.running = true;
-    }
-
     function setEnabled(enabled: bool, callback: var): void {
         // No refetch afterwards: wirelessEnabled is a live binding on
         // NetworkManager, so it updates itself once NM applies the change.
-        run(["radio", "wifi", enabled ? "on" : "off"], callback);
+        NmAction.run(["radio", "wifi", enabled ? "on" : "off"], callback);
     }
 
     function toggle(callback: var): void {
@@ -111,7 +100,7 @@ Singleton {
         root.scanBaseline = root.lastScan;
         root.scanning = true;
         scanTimeout.restart();
-        run(["device", "wifi", "rescan"], null);
+        NmAction.run(["device", "wifi", "rescan"], null);
     }
 
     // Brings down the profile on the wifi device, falling back to
@@ -119,7 +108,7 @@ Singleton {
     function disconnect(callback: var): void {
         const connection = root.device?.connection ?? "";
         if (connection) {
-            run(["connection", "down", connection], callback);
+            NmAction.run(["connection", "down", connection], callback);
             return;
         }
 
@@ -129,7 +118,7 @@ Singleton {
                 callback(false);
             return;
         }
-        run(["device", "disconnect", iface], callback);
+        NmAction.run(["device", "disconnect", iface], callback);
     }
 
     function forget(connectionName: string, callback: var): void {
@@ -138,7 +127,7 @@ Singleton {
                 callback(false);
             return;
         }
-        run(["connection", "delete", connectionName], callback);
+        NmAction.run(["connection", "delete", connectionName], callback);
     }
 
     // The only word NetworkManager gives that a scan finished.
@@ -146,27 +135,6 @@ Singleton {
         if (root.scanning && root.lastScan !== root.scanBaseline) {
             root.scanning = false;
             scanTimeout.stop();
-        }
-    }
-
-    Component {
-        id: actionProc
-
-        Process {
-            id: proc
-
-            property var callback: null
-
-            environment: ({
-                    LANG: "C.UTF-8",
-                    LC_ALL: "C.UTF-8"
-                })
-
-            onExited: code => { // qmllint disable signal-handler-parameters
-                const callback = proc.callback;
-                proc.destroy();
-                callback?.(code === 0);
-            }
         }
     }
 

--- a/services/Wifi.qml
+++ b/services/Wifi.qml
@@ -4,6 +4,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import Caelestia.Services
+import Caelestia.Config
 
 // Wifi networking, split out of Nmcli along its own boundary.
 //

--- a/services/Wifi.qml
+++ b/services/Wifi.qml
@@ -45,13 +45,18 @@ Singleton {
     readonly property var active: root.accessPoints.find(ap => ap.active) ?? null
     readonly property bool enabled: NetworkManager.wirelessEnabled
 
+    readonly property real lastScan: root.device?.lastScan ?? -1
+
     // `nmcli device wifi rescan` asks NetworkManager for a scan and returns
     // straight away, so a running process says nothing about whether a scan is
     // still going. NetworkManager publishes no scanning flag either, so track
     // the request instead: the scan is in flight from asking until lastScan
-    // moves off where it stood.
-    property var scanBaseline: null
-    readonly property bool scanning: root.scanBaseline !== null && (root.device?.lastScan ?? -1) === root.scanBaseline
+    // moves off where it stood when we asked.
+    //
+    // Set rather than bound: a binding that read scanBaseline while the
+    // handler wrote it would be a loop.
+    property bool scanning: false
+    property real scanBaseline: -1
 
     function findNetwork(ssid: string): var {
         return root.networks.find(n => n.ssid === ssid) ?? null;
@@ -81,7 +86,8 @@ Singleton {
         if (root.scanning)
             return;
 
-        root.scanBaseline = root.device?.lastScan ?? -1;
+        root.scanBaseline = root.lastScan;
+        root.scanning = true;
         scanTimeout.restart();
         run(["device", "wifi", "rescan"], null);
     }
@@ -105,9 +111,10 @@ Singleton {
         run(["connection", "delete", connectionName], callback);
     }
 
-    onScanningChanged: {
-        if (!root.scanning) {
-            root.scanBaseline = null;
+    // The only word NetworkManager gives that a scan finished.
+    onLastScanChanged: {
+        if (root.scanning && root.lastScan !== root.scanBaseline) {
+            root.scanning = false;
             scanTimeout.stop();
         }
     }
@@ -139,6 +146,6 @@ Singleton {
         id: scanTimeout
 
         interval: 20000
-        onTriggered: root.scanBaseline = null
+        onTriggered: root.scanning = false
     }
 }

--- a/services/Wifi.qml
+++ b/services/Wifi.qml
@@ -44,7 +44,14 @@ Singleton {
 
     readonly property var active: root.accessPoints.find(ap => ap.active) ?? null
     readonly property bool enabled: NetworkManager.wirelessEnabled
-    readonly property bool scanning: scanProc.running
+
+    // `nmcli device wifi rescan` asks NetworkManager for a scan and returns
+    // straight away, so a running process says nothing about whether a scan is
+    // still going. NetworkManager publishes no scanning flag either, so track
+    // the request instead: the scan is in flight from asking until lastScan
+    // moves off where it stood.
+    property var scanBaseline: null
+    readonly property bool scanning: root.scanBaseline !== null && (root.device?.lastScan ?? -1) === root.scanBaseline
 
     function findNetwork(ssid: string): var {
         return root.networks.find(n => n.ssid === ssid) ?? null;
@@ -71,8 +78,12 @@ Singleton {
     }
 
     function scan(): void {
-        if (!scanProc.running)
-            scanProc.running = true;
+        if (root.scanning)
+            return;
+
+        root.scanBaseline = root.device?.lastScan ?? -1;
+        scanTimeout.restart();
+        run(["device", "wifi", "rescan"], null);
     }
 
     function disconnect(callback: var): void {
@@ -92,6 +103,13 @@ Singleton {
             return;
         }
         run(["connection", "delete", connectionName], callback);
+    }
+
+    onScanningChanged: {
+        if (!root.scanning) {
+            root.scanBaseline = null;
+            scanTimeout.stop();
+        }
     }
 
     Component {
@@ -115,9 +133,12 @@ Singleton {
         }
     }
 
-    Process {
-        id: scanProc
+    // A scan that never reports back would otherwise leave the indicator
+    // spinning for good.
+    Timer {
+        id: scanTimeout
 
-        command: ["nmcli", "device", "wifi", "rescan"]
+        interval: 20000
+        onTriggered: root.scanBaseline = null
     }
 }

--- a/services/Wifi.qml
+++ b/services/Wifi.qml
@@ -1,0 +1,122 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import Caelestia.Services
+
+// Wifi networking, split out of Nmcli along its own boundary.
+//
+// State comes from NetworkManager over dbus: access points arrive as typed
+// objects that track their own signal strength, so there's no `nmcli device
+// wifi list` output to parse and no rescan needed just to refresh a bar. Actions
+// stay on the CLI - the connect flow has to read nmcli's stderr to tell a wrong
+// password from a dropped link, and dbus wouldn't make that any easier.
+Singleton {
+    id: root
+
+    readonly property var device: {
+        for (const device of NetworkManager.devices)
+            if (device.type === NetworkTransport.Wifi)
+                return device;
+        return null;
+    }
+
+    // Every access point in range, including several per SSID when a network is
+    // on more than one band or radio.
+    readonly property list<var> accessPoints: device?.accessPoints ?? []
+
+    // One entry per SSID: the active access point if there is one, otherwise the
+    // strongest. Same rule Nmcli's deduplicateNetworks applied to nmcli output.
+    readonly property list<var> networks: {
+        const best = new Map();
+        for (const ap of root.accessPoints) {
+            if (!ap.ssid)
+                continue;
+
+            const existing = best.get(ap.ssid);
+            if (!existing || (ap.active && !existing.active) || (!existing.active && ap.strength > existing.strength))
+                best.set(ap.ssid, ap);
+        }
+        return Array.from(best.values());
+    }
+
+    readonly property var active: root.accessPoints.find(ap => ap.active) ?? null
+    readonly property bool enabled: NetworkManager.wirelessEnabled
+    readonly property bool scanning: scanProc.running
+
+    function findNetwork(ssid: string): var {
+        return root.networks.find(n => n.ssid === ssid) ?? null;
+    }
+
+    // One-shot nmcli call; only the exit code matters, so there's nothing to
+    // parse and no shared state to race.
+    function run(args: list<string>, callback: var): void {
+        const proc = actionProc.createObject(root, {
+            command: ["nmcli", ...args],
+            callback: callback ?? null
+        });
+        proc.running = true;
+    }
+
+    function setEnabled(enabled: bool, callback: var): void {
+        // No refetch afterwards: wirelessEnabled is a live binding on
+        // NetworkManager, so it updates itself once NM applies the change.
+        run(["radio", "wifi", enabled ? "on" : "off"], callback);
+    }
+
+    function toggle(callback: var): void {
+        setEnabled(!root.enabled, callback);
+    }
+
+    function scan(): void {
+        if (!scanProc.running)
+            scanProc.running = true;
+    }
+
+    function disconnect(callback: var): void {
+        const iface = root.device?.iface ?? "";
+        if (!iface) {
+            if (callback)
+                callback(false);
+            return;
+        }
+        run(["device", "disconnect", iface], callback);
+    }
+
+    function forget(connectionName: string, callback: var): void {
+        if (!connectionName) {
+            if (callback)
+                callback(false);
+            return;
+        }
+        run(["connection", "delete", connectionName], callback);
+    }
+
+    Component {
+        id: actionProc
+
+        Process {
+            id: proc
+
+            property var callback: null
+
+            environment: ({
+                    LANG: "C.UTF-8",
+                    LC_ALL: "C.UTF-8"
+                })
+
+            onExited: code => {
+                const callback = proc.callback;
+                proc.destroy();
+                callback?.(code === 0);
+            }
+        }
+    }
+
+    Process {
+        id: scanProc
+
+        command: ["nmcli", "device", "wifi", "rescan"]
+    }
+}

--- a/services/Wifi.qml
+++ b/services/Wifi.qml
@@ -49,6 +49,22 @@ Singleton {
     }
 
     readonly property var active: root.accessPoints.find(ap => ap.active) ?? null
+
+    // Active IPv4 details, or null when nothing is connected. Same shape the
+    // parsed `nmcli device show` output produced, minus the subnet mask and
+    // link speed, which nothing read.
+    readonly property var details: {
+        const device = root.device;
+        if (!device?.connected)
+            return null;
+
+        return {
+            ipAddress: device.address,
+            gateway: device.gateway,
+            dns: device.dns,
+            macAddress: device.hwAddress
+        };
+    }
     readonly property bool enabled: NetworkManager.wirelessEnabled
 
     readonly property real lastScan: root.device?.lastScan ?? -1

--- a/services/Wifi.qml
+++ b/services/Wifi.qml
@@ -98,7 +98,15 @@ Singleton {
         run(["device", "wifi", "rescan"], null);
     }
 
+    // Brings down the profile on the wifi device, falling back to
+    // disconnecting the device itself when nothing is named.
     function disconnect(callback: var): void {
+        const connection = root.device?.connection ?? "";
+        if (connection) {
+            run(["connection", "down", connection], callback);
+            return;
+        }
+
         const iface = root.device?.iface ?? "";
         if (!iface) {
             if (callback)

--- a/services/Wifi.qml
+++ b/services/Wifi.qml
@@ -66,6 +66,17 @@ Singleton {
     }
     readonly property bool enabled: NetworkManager.wirelessEnabled
 
+    // NetworkManager runs device states 40 through 90 as the activation
+    // sequence; 100 is up.
+    readonly property bool connecting: {
+        const state = root.device?.state ?? 0;
+        return state >= 40 && state < 100;
+    }
+
+    // The profile being activated, which is the SSID for the profiles
+    // NetworkManager names after the network.
+    readonly property string connectingSsid: root.connecting ? (root.device?.connection ?? "") : ""
+
     readonly property real lastScan: root.device?.lastScan ?? -1
 
     // `nmcli device wifi rescan` asks NetworkManager for a scan and returns

--- a/services/Wifi.qml
+++ b/services/Wifi.qml
@@ -25,7 +25,13 @@ Singleton {
 
     // Every access point in range, including several per SSID when a network is
     // on more than one band or radio.
-    readonly property list<var> accessPoints: device?.accessPoints ?? []
+    readonly property list<var> accessPoints: {
+        const found = [];
+        if (root.device)
+            for (const ap of root.device.accessPoints)
+                found.push(ap);
+        return found;
+    }
 
     // One entry per SSID: the active access point if there is one, otherwise the
     // strongest. Same rule Nmcli's deduplicateNetworks applied to nmcli output.
@@ -132,7 +138,7 @@ Singleton {
                     LC_ALL: "C.UTF-8"
                 })
 
-            onExited: code => {
+            onExited: code => { // qmllint disable signal-handler-parameters
                 const callback = proc.callback;
                 proc.destroy();
                 callback?.(code === 0);

--- a/services/Wifi.qml
+++ b/services/Wifi.qml
@@ -91,9 +91,16 @@ Singleton {
         return state >= 40 && state < 100;
     }
 
-    // The profile being activated, which is the SSID for the profiles
-    // NetworkManager names after the network.
-    readonly property string connectingSsid: root.connecting ? (root.device?.connection ?? "") : ""
+    // SSID being connected to. The device reports the profile name, which is
+    // usually the SSID but isn't when the profile was created with an explicit
+    // con-name, and every consumer compares this against a network's SSID.
+    readonly property string connectingSsid: {
+        if (!root.connecting)
+            return "";
+
+        const profile = root.device?.connection ?? "";
+        return Profiles.profileFor(profile)?.ssid || profile;
+    }
 
     readonly property real lastScan: root.device?.lastScan ?? -1
 
@@ -132,22 +139,19 @@ Singleton {
         NmAction.run(["device", "wifi", "rescan"], null);
     }
 
-    // Brings down the profile on the wifi device, falling back to
-    // disconnecting the device itself when nothing is named.
+    // Brings the profile down rather than the device: `device disconnect` tells
+    // NetworkManager to stop activating connections on it by itself, and that
+    // survives a reboot. With no profile named there is nothing up to
+    // disconnect from anyway.
     function disconnect(callback: var): void {
         const connection = root.device?.connection ?? "";
-        if (connection) {
-            NmAction.run(["connection", "down", connection], callback);
-            return;
-        }
-
-        const iface = root.device?.iface ?? "";
-        if (!iface) {
+        if (!connection) {
             if (callback)
                 callback(false);
             return;
         }
-        NmAction.run(["device", "disconnect", iface], callback);
+
+        NmAction.run(["connection", "down", connection], callback);
     }
 
     // The only word NetworkManager gives that a scan finished.

--- a/services/Wifi.qml
+++ b/services/Wifi.qml
@@ -33,12 +33,29 @@ Singleton {
         return found;
     }
 
+    // Radios that are also seen broadcasting no name at all. A hidden network
+    // shows up twice: once as itself, with an empty SSID, and once more under
+    // the name NetworkManager learned from a directed probe while it was
+    // associated. That second entry is the only reason a hidden network is in
+    // this list, and it outlives the profile that produced it.
+    readonly property var hiddenRadios: {
+        const hidden = {};
+        for (const ap of root.accessPoints)
+            if (!ap.ssid && ap.bssid)
+                hidden[ap.bssid] = true;
+        return hidden;
+    }
+
     // One entry per SSID: the active access point if there is one, otherwise the
     // strongest. Same rule Nmcli's deduplicateNetworks applied to nmcli output.
     readonly property list<var> networks: {
         const best = new Map();
         for (const ap of root.accessPoints) {
             if (!ap.ssid)
+                continue;
+            // A network that isn't broadcasting its name is only worth offering
+            // while it's saved; without a profile, tapping it can't do anything.
+            if (root.hiddenRadios[ap.bssid] && !Profiles.has(ap.ssid))
                 continue;
 
             const existing = best.get(ap.ssid);

--- a/services/Wifi.qml
+++ b/services/Wifi.qml
@@ -33,12 +33,22 @@ Singleton {
         return found;
     }
 
+    // SSIDs of hidden networks that have been forgotten. NetworkManager learns
+    // a hidden network's SSID while associated and keeps it on the access point
+    // afterwards, so it would otherwise sit in the list forever even though
+    // nothing is broadcasting it. Cleared when a profile for it exists again,
+    // and not remembered across restarts, since by then the access point has
+    // usually gone with it.
+    property var forgottenHidden: ({})
+
     // One entry per SSID: the active access point if there is one, otherwise the
     // strongest. Same rule Nmcli's deduplicateNetworks applied to nmcli output.
     readonly property list<var> networks: {
         const best = new Map();
         for (const ap of root.accessPoints) {
             if (!ap.ssid)
+                continue;
+            if (root.forgottenHidden[ap.ssid] && !Profiles.has(ap.ssid))
                 continue;
 
             const existing = best.get(ap.ssid);
@@ -90,6 +100,19 @@ Singleton {
     // handler wrote it would be a loop.
     property bool scanning: false
     property real scanBaseline: -1
+
+    // Called before the profile goes, while it can still be asked whether the
+    // network broadcasts.
+    function noteForgotten(ssid: string): void {
+        if (!ssid || !Profiles.isHidden(ssid))
+            return;
+
+        // A new object: assigning the same one back doesn't notify, so nothing
+        // bound to this would re-evaluate.
+        root.forgottenHidden = Object.assign({}, root.forgottenHidden, {
+            [ssid]: true
+        });
+    }
 
     function findNetwork(ssid: string): var {
         return root.networks.find(n => n.ssid === ssid) ?? null;

--- a/services/Wifi.qml
+++ b/services/Wifi.qml
@@ -150,15 +150,6 @@ Singleton {
         NmAction.run(["device", "disconnect", iface], callback);
     }
 
-    function forget(connectionName: string, callback: var): void {
-        if (!connectionName) {
-            if (callback)
-                callback(false);
-            return;
-        }
-        NmAction.run(["connection", "delete", connectionName], callback);
-    }
-
     // The only word NetworkManager gives that a scan finished.
     onLastScanChanged: {
         if (root.scanning && root.lastScan !== root.scanBaseline) {

--- a/services/Wifi.qml
+++ b/services/Wifi.qml
@@ -33,22 +33,12 @@ Singleton {
         return found;
     }
 
-    // SSIDs of hidden networks that have been forgotten. NetworkManager learns
-    // a hidden network's SSID while associated and keeps it on the access point
-    // afterwards, so it would otherwise sit in the list forever even though
-    // nothing is broadcasting it. Cleared when a profile for it exists again,
-    // and not remembered across restarts, since by then the access point has
-    // usually gone with it.
-    property var forgottenHidden: ({})
-
     // One entry per SSID: the active access point if there is one, otherwise the
     // strongest. Same rule Nmcli's deduplicateNetworks applied to nmcli output.
     readonly property list<var> networks: {
         const best = new Map();
         for (const ap of root.accessPoints) {
             if (!ap.ssid)
-                continue;
-            if (root.forgottenHidden[ap.ssid] && !Profiles.has(ap.ssid))
                 continue;
 
             const existing = best.get(ap.ssid);
@@ -100,19 +90,6 @@ Singleton {
     // handler wrote it would be a loop.
     property bool scanning: false
     property real scanBaseline: -1
-
-    // Called before the profile goes, while it can still be asked whether the
-    // network broadcasts.
-    function noteForgotten(ssid: string): void {
-        if (!ssid || !Profiles.isHidden(ssid))
-            return;
-
-        // A new object: assigning the same one back doesn't notify, so nothing
-        // bound to this would re-evaluate.
-        root.forgottenHidden = Object.assign({}, root.forgottenHidden, {
-            [ssid]: true
-        });
-    }
 
     function findNetwork(ssid: string): var {
         return root.networks.find(n => n.ssid === ssid) ?? null;

--- a/services/Wired.qml
+++ b/services/Wired.qml
@@ -5,6 +5,7 @@ import Quickshell
 import Quickshell.Io
 import Caelestia.Services
 import Caelestia.Config
+import qs.services
 
 // Wired networking, split out of Nmcli along its own boundary.
 //

--- a/services/Wired.qml
+++ b/services/Wired.qml
@@ -1,0 +1,151 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import Caelestia.Services
+import Caelestia.Config
+
+// Wired networking, split out of Nmcli along its own boundary.
+//
+// State comes from NetworkManager over dbus: devices arrive as typed objects
+// with change signals, so there's no `nmcli device status` output to parse and
+// nothing to poll. Actions stay on the CLI - connecting, disconnecting and
+// reading counters have nothing to parse and nothing to gain from moving.
+Singleton {
+    id: root
+
+    readonly property list<var> devices: {
+        const found = [];
+        for (const device of NetworkManager.devices)
+            if (device.type === NetworkTransport.Ethernet)
+                found.push(device);
+        return found;
+    }
+
+    // The wired device that finished activating, if any.
+    readonly property var active: devices.find(d => d.connected) ?? null
+    // Whether any wired device is usable. NM reports state 20 (unavailable)
+    // for a NIC with no carrier, so anything past that means a cable is in.
+    readonly property bool available: devices.some(d => d.state > 20)
+
+    // Negotiated link speed of the active device, e.g. "1 Gbps". NM doesn't
+    // expose this, so it comes from sysfs - a plain file read, no daemon.
+    property string speed: ""
+    property string dataUsage: ""
+
+    function connect(connectionName: string, interfaceName: string, callback: var): void {
+        if (connectionName)
+            run(["connection", "up", connectionName], callback);
+        else if (interfaceName)
+            run(["device", "connect", interfaceName], callback);
+        else if (callback)
+            callback(false);
+    }
+
+    function disconnect(connectionName: string, callback: var): void {
+        if (!connectionName) {
+            if (callback)
+                callback(false);
+            return;
+        }
+        run(["connection", "down", connectionName], callback);
+    }
+
+    // One-shot nmcli call; only the exit code matters, so there's nothing to
+    // parse and no shared state to race.
+    function run(args: list<string>, callback: var): void {
+        const proc = actionProc.createObject(root, {
+            command: ["nmcli", ...args],
+            callback: callback ?? null
+        });
+        proc.running = true;
+    }
+
+    function refreshSpeed(interfaceName: string): void {
+        if (!interfaceName) {
+            root.speed = "";
+            return;
+        }
+        speedProc.command = ["cat", `/sys/class/net/${interfaceName}/speed`];
+        speedProc.running = true;
+    }
+
+    function refreshDataUsage(interfaceName: string): void {
+        if (!interfaceName) {
+            root.dataUsage = "";
+            return;
+        }
+        usageProc.command = ["cat", `/sys/class/net/${interfaceName}/statistics/rx_bytes`, `/sys/class/net/${interfaceName}/statistics/tx_bytes`];
+        usageProc.running = true;
+    }
+
+    function formatBytes(bytes: var): string {
+        if (!bytes || bytes <= 0)
+            return "0 B";
+        const units = ["B", "KB", "MB", "GB", "TB"];
+        let i = 0;
+        let v = bytes;
+        while (v >= 1024 && i < units.length - 1) {
+            v /= 1024;
+            i++;
+        }
+        return `${v.toFixed(v < 10 && i > 0 ? 1 : 0)} ${units[i]}`;
+    }
+
+    // Follows whichever device is active, so consumers don't have to ask.
+    onActiveChanged: {
+        refreshSpeed(active?.interface ?? "");
+        refreshDataUsage(active?.interface ?? "");
+    }
+
+    Component {
+        id: actionProc
+
+        Process {
+            id: proc
+
+            property var callback: null
+
+            environment: ({
+                    LANG: "C.UTF-8",
+                    LC_ALL: "C.UTF-8"
+                })
+
+            onExited: code => {
+                const callback = proc.callback;
+                proc.destroy();
+                callback?.(code === 0);
+            }
+        }
+    }
+
+    Process {
+        id: speedProc
+
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const mbit = parseInt(text.trim(), 10);
+                // Disconnected or virtual interfaces report -1, or nothing.
+                if (isNaN(mbit) || mbit <= 0)
+                    root.speed = "";
+                else if (mbit >= 1000) {
+                    const gbps = mbit / 1000;
+                    root.speed = `${Number.isInteger(gbps) ? gbps : gbps.toFixed(1)} Gbps`;
+                } else
+                    root.speed = `${mbit} Mbps`;
+            }
+        }
+    }
+
+    Process {
+        id: usageProc
+
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const nums = text.trim().split("\n").map(n => parseInt(n.trim(), 10)).filter(n => !isNaN(n));
+                root.dataUsage = nums.length < 2 ? "" : root.formatBytes(nums[0] + nums[1]);
+            }
+        }
+    }
+}

--- a/services/Wired.qml
+++ b/services/Wired.qml
@@ -25,9 +25,8 @@ Singleton {
 
     // The wired device that finished activating, if any.
     readonly property var active: devices.find(d => d.connected) ?? null
-    // Whether any wired device is usable. NM reports state 20 (unavailable)
-    // for a NIC with no carrier, so anything past that means a cable is in.
-    readonly property bool available: devices.some(d => d.state > 20)
+    // Whether any wired device has a cable in it.
+    readonly property bool available: devices.some(d => d.carrier)
 
     // Active IPv4 details, or null when nothing is connected. Same shape the
     // parsed `nmcli device show` output produced, minus the subnet mask and
@@ -45,9 +44,20 @@ Singleton {
         };
     }
 
-    // Negotiated link speed of the active device, e.g. "1 Gbps". NM doesn't
-    // expose this, so it comes from sysfs - a plain file read, no daemon.
-    property string speed: ""
+    // Negotiated link speed of the active device, e.g. "1 Gbps".
+    readonly property string speed: {
+        const mbit = root.active?.speed ?? 0;
+        if (mbit <= 0)
+            return "";
+        if (mbit < 1000)
+            return `${mbit} Mbps`;
+
+        const gbps = mbit / 1000;
+        return `${Number.isInteger(gbps) ? gbps : gbps.toFixed(1)} Gbps`;
+    }
+
+    // Cumulative since-boot byte counters, which NetworkManager doesn't keep,
+    // so this stays a sysfs read.
     property string dataUsage: ""
 
     function connect(connectionName: string, interfaceName: string, callback: var): void {
@@ -78,13 +88,8 @@ Singleton {
         proc.running = true;
     }
 
+    // Kept for existing callers; the speed is a live binding on the device now.
     function refreshSpeed(interfaceName: string): void {
-        if (!interfaceName) {
-            root.speed = "";
-            return;
-        }
-        speedProc.command = ["cat", `/sys/class/net/${interfaceName}/speed`];
-        speedProc.running = true;
     }
 
     function refreshDataUsage(interfaceName: string): void {
@@ -111,7 +116,6 @@ Singleton {
 
     // Follows whichever device is active, so consumers don't have to ask.
     onActiveChanged: {
-        refreshSpeed(active?.interface ?? "");
         refreshDataUsage(active?.interface ?? "");
     }
 
@@ -132,24 +136,6 @@ Singleton {
                 const callback = proc.callback;
                 proc.destroy();
                 callback?.(code === 0);
-            }
-        }
-    }
-
-    Process {
-        id: speedProc
-
-        stdout: StdioCollector {
-            onStreamFinished: {
-                const mbit = parseInt(text.trim(), 10);
-                // Disconnected or virtual interfaces report -1, or nothing.
-                if (isNaN(mbit) || mbit <= 0)
-                    root.speed = "";
-                else if (mbit >= 1000) {
-                    const gbps = mbit / 1000;
-                    root.speed = `${Number.isInteger(gbps) ? gbps : gbps.toFixed(1)} Gbps`;
-                } else
-                    root.speed = `${mbit} Mbps`;
             }
         }
     }

--- a/services/Wired.qml
+++ b/services/Wired.qml
@@ -62,9 +62,9 @@ Singleton {
 
     function connect(connectionName: string, interfaceName: string, callback: var): void {
         if (connectionName)
-            run(["connection", "up", connectionName], callback);
+            NmAction.run(["connection", "up", connectionName], callback);
         else if (interfaceName)
-            run(["device", "connect", interfaceName], callback);
+            NmAction.run(["device", "connect", interfaceName], callback);
         else if (callback)
             callback(false);
     }
@@ -75,21 +75,7 @@ Singleton {
                 callback(false);
             return;
         }
-        run(["connection", "down", connectionName], callback);
-    }
-
-    // One-shot nmcli call; only the exit code matters, so there's nothing to
-    // parse and no shared state to race.
-    function run(args: list<string>, callback: var): void {
-        const proc = actionProc.createObject(root, {
-            command: ["nmcli", ...args],
-            callback: callback ?? null
-        });
-        proc.running = true;
-    }
-
-    // Kept for existing callers; the speed is a live binding on the device now.
-    function refreshSpeed(interfaceName: string): void {
+        NmAction.run(["connection", "down", connectionName], callback);
     }
 
     function refreshDataUsage(interfaceName: string): void {
@@ -117,27 +103,6 @@ Singleton {
     // Follows whichever device is active, so consumers don't have to ask.
     onActiveChanged: {
         refreshDataUsage(active?.interface ?? "");
-    }
-
-    Component {
-        id: actionProc
-
-        Process {
-            id: proc
-
-            property var callback: null
-
-            environment: ({
-                    LANG: "C.UTF-8",
-                    LC_ALL: "C.UTF-8"
-                })
-
-            onExited: code => { // qmllint disable signal-handler-parameters
-                const callback = proc.callback;
-                proc.destroy();
-                callback?.(code === 0);
-            }
-        }
     }
 
     Process {

--- a/services/Wired.qml
+++ b/services/Wired.qml
@@ -112,7 +112,7 @@ Singleton {
                     LC_ALL: "C.UTF-8"
                 })
 
-            onExited: code => {
+            onExited: code => { // qmllint disable signal-handler-parameters
                 const callback = proc.callback;
                 proc.destroy();
                 callback?.(code === 0);

--- a/services/Wired.qml
+++ b/services/Wired.qml
@@ -29,6 +29,22 @@ Singleton {
     // for a NIC with no carrier, so anything past that means a cable is in.
     readonly property bool available: devices.some(d => d.state > 20)
 
+    // Active IPv4 details, or null when nothing is connected. Same shape the
+    // parsed `nmcli device show` output produced, minus the subnet mask and
+    // link speed, which nothing read.
+    readonly property var details: {
+        const device = root.active;
+        if (!device)
+            return null;
+
+        return {
+            ipAddress: device.address,
+            gateway: device.gateway,
+            dns: device.dns,
+            macAddress: device.hwAddress
+        };
+    }
+
     // Negotiated link speed of the active device, e.g. "1 Gbps". NM doesn't
     // expose this, so it comes from sysfs - a plain file read, no daemon.
     property string speed: ""

--- a/services/Wired.qml
+++ b/services/Wired.qml
@@ -103,7 +103,7 @@ Singleton {
 
     // Follows whichever device is active, so consumers don't have to ask.
     onActiveChanged: {
-        refreshDataUsage(active?.interface ?? "");
+        refreshDataUsage(active?.iface ?? "");
     }
 
     Process {

--- a/utils/NetworkConnection.qml
+++ b/utils/NetworkConnection.qml
@@ -78,8 +78,6 @@ QtObject {
                         // Clear pending connection if exists
                         if (Nmcli.pendingConnection) {
                             Nmcli.connectionCheckTimer.stop();
-                            Nmcli.immediateCheckTimer.stop();
-                            Nmcli.immediateCheckTimer.checkCount = 0;
                             Nmcli.pendingConnection = null;
                         }
 

--- a/utils/NetworkConnection.qml
+++ b/utils/NetworkConnection.qml
@@ -57,7 +57,7 @@ QtObject {
      * Handles both secured and open networks, checks for saved profiles,
      * and shows password dialog if needed.
      *
-     * @param network The network object to connect to (must have ssid, isSecure, bssid properties)
+     * @param network The network object to connect to (must have ssid and isSecure properties)
      * @param session Optional Session object (for controlcenter - must have network property with showPasswordDialog and pendingNetwork)
      * @param onPasswordNeeded Optional callback function(network) called when password is needed (for bar popouts)
      */
@@ -70,7 +70,7 @@ QtObject {
             const hasSavedProfile = Nmcli.hasSavedProfile(network.ssid);
 
             if (hasSavedProfile) {
-                Nmcli.connectToNetwork(network.ssid, "", network.bssid, null);
+                Nmcli.connectToNetwork(network.ssid, "", null);
             } else {
                 // Use password check with callback
                 Nmcli.connectToNetworkWithPasswordCheck(network.ssid, network.isSecure, result => {
@@ -89,10 +89,10 @@ QtObject {
                             onPasswordNeeded(network);
                         }
                     }
-                }, network.bssid);
+                });
             }
         } else {
-            Nmcli.connectToNetwork(network.ssid, "", network.bssid, null);
+            Nmcli.connectToNetwork(network.ssid, "", null);
         }
     }
 
@@ -100,7 +100,7 @@ QtObject {
      * Connect to a wireless network with a provided password.
      * Used by password dialogs when the user has already entered a password.
      *
-     * @param network The network object to connect to (must have ssid, bssid properties)
+     * @param network The network object to connect to (must have an ssid property)
      * @param password The password to use for connection
      * @param onResult Optional callback function(result) called with connection result
      */
@@ -109,6 +109,6 @@ QtObject {
             return;
         }
 
-        Nmcli.connectToNetwork(network.ssid, password || "", network.bssid || "", onResult || null);
+        Nmcli.connectToNetwork(network.ssid, password || "", onResult || null);
     }
 }

--- a/utils/NetworkConnection.qml
+++ b/utils/NetworkConnection.qml
@@ -67,30 +67,26 @@ QtObject {
         }
 
         if (network.isSecure) {
-            const hasSavedProfile = Nmcli.hasSavedProfile(network.ssid);
-
-            if (hasSavedProfile) {
-                Nmcli.connectToNetwork(network.ssid, "", null);
-            } else {
-                // Use password check with callback
-                Nmcli.connectToNetworkWithPasswordCheck(network.ssid, network.isSecure, result => {
-                    if (result.needsPassword) {
-                        // Clear pending connection if exists
-                        if (Nmcli.pendingConnection) {
-                            Nmcli.connectionCheckTimer.stop();
-                            Nmcli.pendingConnection = null;
-                        }
-
-                        // Handle password dialog - use session if available, otherwise use callback
-                        if (session && session.network) {
-                            session.network.showPasswordDialog = true;
-                            session.network.pendingNetwork = network;
-                        } else if (onPasswordNeeded) {
-                            onPasswordNeeded(network);
-                        }
+            // Saved networks go through the same path: a profile whose password
+            // is missing or no longer right has to be able to ask for one, and
+            // a profile left behind by a cancelled prompt looks saved too.
+            Nmcli.connectToNetworkWithPasswordCheck(network.ssid, network.isSecure, result => {
+                if (result.needsPassword) {
+                    // Clear pending connection if exists
+                    if (Nmcli.pendingConnection) {
+                        Nmcli.connectionCheckTimer.stop();
+                        Nmcli.pendingConnection = null;
                     }
-                });
-            }
+
+                    // Handle password dialog - use session if available, otherwise use callback
+                    if (session && session.network) {
+                        session.network.showPasswordDialog = true;
+                        session.network.pendingNetwork = network;
+                    } else if (onPasswordNeeded) {
+                        onPasswordNeeded(network);
+                    }
+                }
+            });
         } else {
             Nmcli.connectToNetwork(network.ssid, "", null);
         }

--- a/utils/NetworkConnection.qml
+++ b/utils/NetworkConnection.qml
@@ -67,26 +67,30 @@ QtObject {
         }
 
         if (network.isSecure) {
-            // Saved networks go through the same path: a profile whose password
-            // is missing or no longer right has to be able to ask for one, and
-            // a profile left behind by a cancelled prompt looks saved too.
-            Nmcli.connectToNetworkWithPasswordCheck(network.ssid, network.isSecure, result => {
-                if (result.needsPassword) {
-                    // Clear pending connection if exists
-                    if (Nmcli.pendingConnection) {
-                        Nmcli.connectionCheckTimer.stop();
-                        Nmcli.pendingConnection = null;
-                    }
+            const hasSavedProfile = Nmcli.hasSavedProfile(network.ssid);
 
-                    // Handle password dialog - use session if available, otherwise use callback
-                    if (session && session.network) {
-                        session.network.showPasswordDialog = true;
-                        session.network.pendingNetwork = network;
-                    } else if (onPasswordNeeded) {
-                        onPasswordNeeded(network);
+            if (hasSavedProfile) {
+                Nmcli.connectToNetwork(network.ssid, "", null);
+            } else {
+                // Use password check with callback
+                Nmcli.connectToNetworkWithPasswordCheck(network.ssid, network.isSecure, result => {
+                    if (result.needsPassword) {
+                        // Clear pending connection if exists
+                        if (Nmcli.pendingConnection) {
+                            Nmcli.connectionCheckTimer.stop();
+                            Nmcli.pendingConnection = null;
+                        }
+
+                        // Handle password dialog - use session if available, otherwise use callback
+                        if (session && session.network) {
+                            session.network.showPasswordDialog = true;
+                            session.network.pendingNetwork = network;
+                        } else if (onPasswordNeeded) {
+                            onPasswordNeeded(network);
+                        }
                     }
-                }
-            });
+                });
+            }
         } else {
             Nmcli.connectToNetwork(network.ssid, "", null);
         }

--- a/utils/NetworkConnection.qml
+++ b/utils/NetworkConnection.qml
@@ -67,30 +67,28 @@ QtObject {
         }
 
         if (network.isSecure) {
-            const hasSavedProfile = Nmcli.hasSavedProfile(network.ssid);
+            // Saved networks go through the same path. A profile whose password
+            // is missing or no longer right fails with "secrets were required",
+            // and passing no callback there left nothing to open the prompt, so
+            // tapping such a network did nothing at all.
+            Nmcli.connectToNetworkWithPasswordCheck(network.ssid, network.isSecure, result => {
+                if (!result.needsPassword)
+                    return;
 
-            if (hasSavedProfile) {
-                Nmcli.connectToNetwork(network.ssid, "", null);
-            } else {
-                // Use password check with callback
-                Nmcli.connectToNetworkWithPasswordCheck(network.ssid, network.isSecure, result => {
-                    if (result.needsPassword) {
-                        // Clear pending connection if exists
-                        if (Nmcli.pendingConnection) {
-                            Nmcli.connectionCheckTimer.stop();
-                            Nmcli.pendingConnection = null;
-                        }
+                // Clear pending connection if exists
+                if (Nmcli.pendingConnection) {
+                    Nmcli.connectionCheckTimer.stop();
+                    Nmcli.pendingConnection = null;
+                }
 
-                        // Handle password dialog - use session if available, otherwise use callback
-                        if (session && session.network) {
-                            session.network.showPasswordDialog = true;
-                            session.network.pendingNetwork = network;
-                        } else if (onPasswordNeeded) {
-                            onPasswordNeeded(network);
-                        }
-                    }
-                });
-            }
+                // Handle password dialog - use session if available, otherwise use callback
+                if (session && session.network) {
+                    session.network.showPasswordDialog = true;
+                    session.network.pendingNetwork = network;
+                } else if (onPasswordNeeded) {
+                    onPasswordNeeded(network);
+                }
+            });
         } else {
             Nmcli.connectToNetwork(network.ssid, "", null);
         }


### PR DESCRIPTION
# Move network state to D-Bus, split Nmcli along its boundaries

`Nmcli.qml` grew into a single service that owned wired, wireless and profile
handling all at once, and got every piece of state by shelling out to `nmcli`
and parsing the output. This reworks that: **state comes from NetworkManager
over D-Bus, actions stay on the CLI**, and the service is split along the
boundaries it already had.

`services/Nmcli.qml` goes from 1841 lines to 685. What is left is the connect
flow — activation, hidden networks, the password prompt and IPv4 writes — which
are actions, and belong on `nmcli`.

## What's new

**Plugin.** `NmWalker` holds the shared D-Bus plumbing: subscribe, walk, keep
every async read open so a partial tree is never published, drop what the walk
didn't see. `NetworkManager` exposes devices as typed `NmDevice` objects, with
`NmAccessPoint` children for wifi. `NetworkProfiles` exposes saved profiles as
`NmConnection` objects from NetworkManager's `Settings` interface.

```cpp
Q_PROPERTY(QString connection READ connection NOTIFY changed)
Q_PROPERTY(bool carrier READ carrier NOTIFY changed)
Q_PROPERTY(uint speed READ speed NOTIFY changed)
Q_PROPERTY(QString address READ address NOTIFY changed)
Q_PROPERTY(QStringList dns READ dns NOTIFY changed)
```

**Services.** `Wired`, `Wifi` and `Profiles` are the boundaries; each reads its
own state from the plugin and runs its own actions through `NmAction`, a shared
one-shot `nmcli` runner. `Nmcli` forwards its old members to them, so **no
consumer had to change behaviour**:

```qml
readonly property list<var> ethernetDevices: Wired.devices
readonly property var activeEthernet: Wired.active
readonly property bool hasAvailableEthernet: Wired.available
readonly property list<var> networks: Wifi.networks
readonly property bool wifiEnabled: Wifi.enabled
```

The UI files here only lose type annotations for components that no longer
exist, and calls to refreshers that are live bindings now.


**Nothing polls.** Signal strength, device state, IP configuration and profile
edits arrive as change signals. A 4s timer, a 500ms timer and a 5s timer drove
refreshes before, and a `nmcli monitor` subprocess ran for the whole life of the
shell just to trigger reparsing:

```qml
Process {
    id: monitorProc
    running: true
    command: ["nmcli", "monitor"]
    stdout: SplitParser {
        onRead: root.refreshOnConnectionChange()
    }
}
```

All of that is gone. Whether a connect succeeded, for instance, is no longer
polled every 500ms up to six times — the active access point is a binding now:

```qml
onActiveChanged: checkPendingConnection()
```

**Far fewer processes.** Loading saved networks parsed `nmcli connection show`
and then spawned one more `nmcli` per wifi profile, in series, purely to read
each SSID:

```qml
function queryNextSsid(callback: var): void {
    if (root.currentSsidQueryIndex < root.wifiConnectionQueue.length) {
        const connectionName = root.wifiConnectionQueue[root.currentSsidQueryIndex];
        root.currentSsidQueryIndex++;
        executeCommand([..., "show", connectionName], result => {
            if (result.success)
                processSsidOutput(result.output);
            queryNextSsid(callback);   // then the next, and the next
        });
    }
}
```

Ten saved networks meant eleven `nmcli` processes one after another. Now each
profile answers a single `GetSettings` call, the calls run in parallel, and the
QML side is a binding:

```qml
readonly property list<var> wireless: root.list.filter(p => p.type === "802-11-wireless")
```

Signal strength no longer costs a `nmcli device wifi list` reparse either, and an
access point that changes strength updates itself rather than triggering a
re-read of every device on the system.

**No output parsing for state.** Nothing depends on nmcli's column layout,
locale or terse-mode escaping any more — including this, which existed because
`:` is both the field separator and a legal character in an SSID:

```qml
const PLACEHOLDER = "STRINGWHICHHOPEFULLYWONTBEUSED";
const net = n.replace(rep, PLACEHOLDER).split(":");
```

The parsers, the CIDR-to-netmask helper and the sysfs reads for link speed went
with it.

## Fixes

**Closes #1172 — "Forget" failing when the profile name isn't the SSID.** The
old path searched the saved *profile names* for one equal to the SSID and fell
back to the SSID itself, so `nmcli connection delete <ssid>` failed on any
profile created with an explicit `con-name`. The SSID is resolved through the
profile's `802-11-wireless.ssid` now.

*Verified with a profile named `test-mismatch` for SSID `TestNet123`: it appears
under the SSID in the saved list, and Forget deletes it.*

**Closes #1864 — container interfaces in the ethernet list.** They're filtered by
NetworkManager's device type now, rather than by shelling out to sysfs to ask
which interfaces are physical:

```qml
// veth pairs report as "ethernet" too, so ask sysfs which ones are physical
proc.exec(["sh", "-c", 'for i do [ -e "/sys/class/net/$i/device" ] && printf "%s\n" "$i"; done', ...]);
```

*Verified with Docker running: `docker0` and the `veth*` pairs stay out of the
list.*

**Fixes #1888 — bar icon showing ethernet while wifi is connected.** The icon
follows NetworkManager's `PrimaryConnection` rather than inferring from whether
an ethernet device exists, so a plugged-in cable that isn't carrying the default
route no longer wins:

```qml
readonly property bool onEthernet: NetworkRoute.ready
    ? NetworkRoute.primaryTransport === NetworkTransport.Ethernet
    : !!activeEthernet
```

*Verified with both links up and the default route on wifi.*

**Closes #1881 — profiles rewritten on connect.** Connecting with a password
deleted whatever profile was saved for the SSID and built a fresh one, pinned to
the access point's BSSID and hardcoded to `wpa-psk`:

```qml
checkAndDeleteConnection(ssid, () => {
    const cmd = ["connection", "add", "type", "wifi", "con-name", ssid, ...,
                 "802-11-wireless.bssid", bssidUpper,
                 "wifi-sec.key-mgmt", "wpa-psk", "wifi-sec.psk", password];
```

A pinned BSSID stops the device roaming between access points on a mesh, and it
stops the profile matching the other access points, so the next connect through
one of them leaves a second profile behind. Anything the user had set — a static
address, a custom name, an autoconnect preference — went with the delete. And
`wpa-psk` is wrong for WPA3.

nmcli already does this correctly: `device wifi connect` reuses a saved profile
when one matches and updates it in place, and picks WEP, WPA-PSK or SAE from the
access point's own security flags. A saved profile is now brought up as it
stands with `connection up`, resolved through `Profiles` so one saved under a
different name still matches, and everything else goes to `device wifi connect`
with no BSSID.

*Verified by putting `connection.autoconnect-priority 42` on a saved profile:
after disconnecting and reconnecting through the UI the priority survives, the
BSSID stays empty and the profile count is unchanged. Forgetting the network and
reconnecting with a password — wrong one first, then right — leaves exactly one
profile, again with no BSSID.*

**A network is no longer saved just because it was tapped.** `nmcli device wifi
connect` goes through `AddAndActivateConnection`: NetworkManager writes the
profile and only then asks the secret agent for the password. Cancelling that
prompt, or getting the password wrong, left the profile behind, so a network
appeared under saved networks without ever having connected. The command has to
stay — it's what makes NetworkManager ask in the first place — so the profile is
removed afterwards instead, and only when there wasn't one before the attempt.

**A forgotten hidden network drops out of the list.** NetworkManager keeps two
access point entries for a hidden radio: the radio itself, broadcasting no name,
and a second one carrying the SSID it learned from a directed probe while
associated. The second entry outlives the profile that produced it, so
forgetting a hidden network left it listed:

```
SSID                 BSSID              SIGNAL
--                   AB:CD:EF:GG:FF:TT  100
ssid-5GHz            AB:CD:EF:GG:FF:TT  80
```

So the scan already says which networks are hidden — a BSSID that also appears
with an empty SSID. Those are offered only while a profile for them exists, and
adding one back through the add-network form brings it straight back. Networks
that broadcast are unaffected: forgetting one still leaves it listed.

**Also fixes two ways the UI destroyed a saved profile.** The add-network page
called `forgetNetwork` with whatever was in the SSID field when the sub-page
closed, so typing the name of a network you already had and then backing out
deleted it. It now only removes a profile that page created. And the "Connect
automatically" toggle ran

```
nmcli connection modify <profile> connection.autoconnect no \
      802-11-wireless-security.psk-flags 2 \
      802-11-wireless-security.psk ""
```

so turning it off also wiped the stored key and the next connect had to ask for
the password again — which turning the toggle back on did not undo. It only
writes `connection.autoconnect` now.

Not claimed as a fix, but related to #1179: disconnecting now resolves the
profile name from the device's active connection, which comes from D-Bus, so it
no longer falls back to `nmcli device disconnect` when a stale parsed list makes
the active network look empty. That fallback is what clears a device's
autoconnect flag and leaves wifi down on the next login. After disconnecting
through the UI, `GENERAL.AUTOCONNECT` on the device stays `yes` and the profile
reconnects on a NetworkManager restart.