### PR TITLE
fix(dashboard): wrap long weather conditions

### DIFF
--- a/modules/dashboard/dash/SmallWeather.qml
+++ b/modules/dashboard/dash/SmallWeather.qml
@@ -50,7 +50,8 @@ Item {
             text: Weather.description
             font: Tokens.font.body.small
 
-            elide: Text.ElideRight
+            wrapMode: Text.WordWrap
+            maximumLineCount: 2
             width: Math.min(implicitWidth, root.parent.width - icon.implicitWidth - info.anchors.leftMargin - Tokens.padding.extraLargeIncreased)
         }
     }

--- a/modules/dashboard/dash/SmallWeather.qml
+++ b/modules/dashboard/dash/SmallWeather.qml
@@ -50,8 +50,10 @@ Item {
             text: Weather.description
             font: Tokens.font.body.small
 
+            elide: Text.ElideRight
             wrapMode: Text.WordWrap
             maximumLineCount: 2
+            horizontalAlignment: Text.AlignHCenter
             width: Math.min(implicitWidth, root.parent.width - icon.implicitWidth - info.anchors.leftMargin - Tokens.padding.extraLargeIncreased)
         }
     }


### PR DESCRIPTION
## Summary
- allow long compact-dashboard weather conditions to wrap naturally
- cap the description at two lines while retaining the existing width constraint

## Verification
- `cmake -B build -G Ninja -DVERSION= -DGIT_REVISION= && cmake --build build`
- local weather-description contract test
- `qmllint -I "$PWD/build/qml" modules/dashboard/dash/SmallWeather.qml`
- `python3 scripts/qml-lint-conventions.py`
- `git diff --check`

## Scope
This changes only `modules/dashboard/dash/SmallWeather.qml`.