### PR TITLE
fix(bar): constrain audio device labels

### DIFF
--- a/components/controls/StyledRadioButton.qml
+++ b/components/controls/StyledRadioButton.qml
@@ -7,9 +7,11 @@ import qs.services
 RadioButton {
     id: root
 
+    property real maximumTextWidth: -1
+
     font: Tokens.font.body.small
 
-    implicitWidth: implicitIndicatorWidth + implicitContentWidth + contentItem.anchors.leftMargin
+    implicitWidth: implicitIndicatorWidth + (root.maximumTextWidth > 0 ? Math.min(implicitContentWidth, root.maximumTextWidth) : implicitContentWidth) + contentItem.anchors.leftMargin
     implicitHeight: Math.max(implicitIndicatorHeight, implicitContentHeight)
 
     indicator: Rectangle {
@@ -50,5 +52,7 @@ RadioButton {
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: outerCircle.right
         anchors.leftMargin: Tokens.spacing.medium
+        width: root.maximumTextWidth > 0 ? root.maximumTextWidth : implicitWidth
+        elide: root.maximumTextWidth > 0 ? Text.ElideRight : Text.ElideNone
     }
 }

--- a/components/controls/StyledRadioButton.qml
+++ b/components/controls/StyledRadioButton.qml
@@ -7,11 +7,9 @@ import qs.services
 RadioButton {
     id: root
 
-    property real maximumTextWidth: -1
-
     font: Tokens.font.body.small
 
-    implicitWidth: implicitIndicatorWidth + (root.maximumTextWidth > 0 ? Math.min(implicitContentWidth, root.maximumTextWidth) : implicitContentWidth) + contentItem.anchors.leftMargin
+    implicitWidth: implicitIndicatorWidth + implicitContentWidth + contentItem.anchors.leftMargin
     implicitHeight: Math.max(implicitIndicatorHeight, implicitContentHeight)
 
     indicator: Rectangle {
@@ -51,8 +49,8 @@ RadioButton {
         font: root.font
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: outerCircle.right
+        anchors.right: parent.right
         anchors.leftMargin: Tokens.spacing.medium
-        width: root.maximumTextWidth > 0 ? root.maximumTextWidth : implicitWidth
-        elide: root.maximumTextWidth > 0 ? Text.ElideRight : Text.ElideNone
+        elide: Text.ElideRight
     }
 }

--- a/modules/bar/popouts/AudioPopout.qml
+++ b/modules/bar/popouts/AudioPopout.qml
@@ -15,7 +15,7 @@ Item {
 
     required property PopoutState popouts
 
-    implicitWidth: layout.implicitWidth + Tokens.padding.medium * 2
+    implicitWidth: Tokens.sizes.bar.audioWidth
     implicitHeight: layout.implicitHeight + Tokens.padding.medium * 2
 
     ButtonGroup {
@@ -30,6 +30,7 @@ Item {
         id: layout
 
         anchors.left: parent.left
+        anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
         spacing: Tokens.spacing.medium
 
@@ -46,10 +47,12 @@ Item {
 
                 required property PwNode modelData
 
+                Layout.fillWidth: true
                 ButtonGroup.group: sinks
                 checked: Audio.sink?.id === modelData.id
                 onClicked: Audio.setAudioSink(modelData)
                 text: modelData.description
+                maximumTextWidth: Math.max(0, layout.width - implicitIndicatorWidth - Tokens.spacing.medium)
             }
         }
 
@@ -65,10 +68,12 @@ Item {
             StyledRadioButton {
                 required property PwNode modelData
 
+                Layout.fillWidth: true
                 ButtonGroup.group: sources
                 checked: Audio.source?.id === modelData.id
                 onClicked: Audio.setAudioSource(modelData)
                 text: modelData.description
+                maximumTextWidth: Math.max(0, layout.width - implicitIndicatorWidth - Tokens.spacing.medium)
             }
         }
 

--- a/modules/bar/popouts/AudioPopout.qml
+++ b/modules/bar/popouts/AudioPopout.qml
@@ -52,7 +52,6 @@ Item {
                 checked: Audio.sink?.id === modelData.id
                 onClicked: Audio.setAudioSink(modelData)
                 text: modelData.description
-                maximumTextWidth: Math.max(0, layout.width - implicitIndicatorWidth - Tokens.spacing.medium)
             }
         }
 
@@ -73,7 +72,6 @@ Item {
                 checked: Audio.source?.id === modelData.id
                 onClicked: Audio.setAudioSource(modelData)
                 text: modelData.description
-                maximumTextWidth: Math.max(0, layout.width - implicitIndicatorWidth - Tokens.spacing.medium)
             }
         }
 

--- a/plugin/src/Caelestia/Config/tokens.hpp
+++ b/plugin/src/Caelestia/Config/tokens.hpp
@@ -112,6 +112,7 @@ class BarTokens : public settings::ObjectNode {
     CONFIG_PROPERTY(int, trayMenuWidth, 300)
     CONFIG_PROPERTY(int, batteryWidth, 250)
     CONFIG_PROPERTY(int, networkWidth, 320)
+    CONFIG_PROPERTY(int, audioWidth, 320)
     CONFIG_PROPERTY(int, kbLayoutWidth, 320)
 };
 


### PR DESCRIPTION
## Summary
- keep the audio bar popout at a predictable, configurable width
- elide long PipeWire device labels without changing the underlying device description
- preserve the unconstrained behavior of `StyledRadioButton` outside this popout

## Verification
- `cmake -B build -G Ninja -DVERSION= -DGIT_REVISION= && cmake --build build`
- local audio-popout-width contract test
- `qmllint components/controls/StyledRadioButton.qml`
- `python3 scripts/qml-lint-conventions.py`
- `git diff --check`

## Scope
Changes are limited to the bar audio popout, its opt-in radio-label constraint, and the `audioWidth` bar token.