### PR TITLE
feat(launcher): add wallpaper picker shortcut

### DIFF
--- a/components/ScreenState.qml
+++ b/components/ScreenState.qml
@@ -8,6 +8,7 @@ PersistentProperties {
     property bool osd
     property bool session
     property bool launcher
+    property bool launcherWallpaperMode
     property bool dashboard
     property bool utilities
     property bool sidebar

--- a/modules/Shortcuts.qml
+++ b/modules/Shortcuts.qml
@@ -68,9 +68,30 @@ Scope {
         onReleased: {
             if (!root.launcherInterrupted && !root.hasFullscreen) {
                 const screenState = ShellState.forActive();
+                if (!screenState.launcher)
+                    screenState.launcherWallpaperMode = false;
                 screenState.launcher = !screenState.launcher;
             }
             root.launcherInterrupted = false;
+        }
+    }
+
+    // qmllint disable unresolved-type
+    CustomShortcut {
+        // qmllint enable unresolved-type
+        name: "wallpaper"
+        description: "Toggle wallpaper picker"
+        onPressed: {
+            if (root.hasFullscreen)
+                return;
+
+            const screenState = ShellState.forActive();
+            if (screenState.launcher && screenState.launcherWallpaperMode) {
+                screenState.launcher = false;
+            } else {
+                screenState.launcherWallpaperMode = true;
+                screenState.launcher = true;
+            }
         }
     }
 

--- a/modules/launcher/Content.qml
+++ b/modules/launcher/Content.qml
@@ -18,6 +18,7 @@ Item {
 
     readonly property int padding: Tokens.padding.large
     readonly property int rounding: Tokens.rounding.extraLarge
+    readonly property bool wallpaperMode: screenState.launcherWallpaperMode
 
     implicitWidth: listWrapper.width + padding * 2
     implicitHeight: search.height + listWrapper.height + padding + search.anchors.bottomMargin
@@ -56,10 +57,11 @@ Item {
         anchors.margins: root.padding
         anchors.bottomMargin: CUtils.clamp(root.padding - Config.border.thickness, 0, root.padding)
 
+        leftPadding: root.wallpaperMode ? wallpaperPrefix.x + wallpaperPrefix.implicitWidth + Tokens.spacing.medium : searchIcon.width + searchIcon.anchors.leftMargin + Tokens.spacing.medium
         topPadding: Math.round((Tokens.padding.medium + Tokens.padding.large) / 2)
         bottomPadding: Math.round((Tokens.padding.medium + Tokens.padding.large) / 2)
 
-        placeholderText: Tr.tr("Type \"%1\" for commands").arg(GlobalConfig.launcher.actionPrefix)
+        placeholderText: root.wallpaperMode ? Tr.tr("Search") : Tr.tr("Type \"%1\" for commands").arg(GlobalConfig.launcher.actionPrefix)
 
         onAccepted: {
             const currentItem = list.currentList?.currentItem;
@@ -122,5 +124,20 @@ Item {
 
             target: root.screenState
         }
+    }
+
+    StyledText {
+        id: wallpaperPrefix
+
+        parent: search
+
+        anchors.verticalCenter: search.verticalCenter
+        x: search.searchIcon.x + search.searchIcon.width + Tokens.spacing.small
+        z: search.z + 1
+
+        visible: root.wallpaperMode
+        text: Tr.tr("Wallpapers")
+        color: Colours.palette.m3outline
+        font: search.font
     }
 }

--- a/modules/launcher/ContentList.qml
+++ b/modules/launcher/ContentList.qml
@@ -19,7 +19,7 @@ Item {
     required property int padding
     required property int rounding
 
-    readonly property bool showWallpapers: search.text.startsWith(`${GlobalConfig.launcher.actionPrefix}wallpaper `)
+    readonly property bool showWallpapers: content.wallpaperMode || search.text.startsWith(`${GlobalConfig.launcher.actionPrefix}wallpaper `)
     readonly property var currentList: showWallpapers ? wallpaperList.item : appList.item // Can be either ListView or PathView, so can't type properly
     property string animState: showWallpapers ? "wallpapers" : "apps"
 

--- a/modules/launcher/WallpaperList.qml
+++ b/modules/launcher/WallpaperList.qml
@@ -47,7 +47,7 @@ PathView {
     model: ScriptModel {
         id: scriptModel
 
-        readonly property string search: root.search.text.split(" ").slice(1).join(" ")
+        readonly property string search: root.content.wallpaperMode ? root.search.text : root.search.text.split(" ").slice(1).join(" ")
 
         values: Wallpapers.query(search)
         onValuesChanged: root.currentIndex = search ? 0 : values.findIndex(w => w.path === Wallpapers.actualCurrent)


### PR DESCRIPTION
## Summary

Adds a global shortcut that opens the launcher directly in wallpaper mode.

The wallpaper list already exists behind the `>wallpaper` action. This exposes the same view directly, without entering the action first or simulating keyboard input.

Wallpaper mode keeps the existing preview, search, arrow-key navigation, and selection behavior. The search field shows a fixed `Wallpapers` label beside the editable query.

## Preview

### What the Panel looks like

<img width="2164" height="534" alt="wallpaper-picker" src="https://github.com/user-attachments/assets/0b056c53-8722-47fc-95b8-f480e688822e" />

### Demo Video

https://github.com/user-attachments/assets/3ae5190f-9f7f-4240-881f-81297fa67dac


## Shortcut

The new global shortcut is `caelestia:wallpaper`. This PR does not assign a key, so compositor configs can choose their own binding.

I use `SUPER + SHIFT + W` which could be a reasonable default for the dots, but I have left that decision to the maintainers.

## Testing

Tested on Hyprland with two monitors. The shortcut, search, keyboard navigation, preview, apply, and existing launcher paths all work as expected.

Closes #1342 as well.