### PR TITLE
ci: add pr approval check workflow

### DIFF
--- a/.github/workflows/check-pr-approvals.yml
+++ b/.github/workflows/check-pr-approvals.yml
@@ -1,0 +1,26 @@
+name: Check PR approvals
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+      - dismissed
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: check-pr-approvals-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-pr-approvals:
+    uses: caelestia-dots/.github/.github/workflows/check-pr-approvals.yml@main


### PR DESCRIPTION
Because GitHub rulesets can't do dynamic numbers of required reviews based on PR author, so we need to use a workflow as a check instead