### PR TITLE
ci: ignore non-code files for PR workflow runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - "**"
+      - "!**/*.md"
+      - "!.github/**"
+      - ".github/workflows/build.yml"
+      - "!.vscode/**"
+      - "!assets/**"
+      - "!.gitignore"
 
 jobs:
   build-nix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,16 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - "**"
+      - "!**/*.md"
+      - "!.github/**"
+      - ".github/workflows/build.yml"
+      - "!.vscode/**"
+      - "!assets/**"
+      - "!.gitignore"
+      - "**/flake.nix"
+      - "**/flake.lock"
 
 jobs:
   lint-qml:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,8 @@ on:
       - "!.vscode/**"
       - "!assets/**"
       - "!.gitignore"
-      - "**/flake.nix"
-      - "**/flake.lock"
+      - "!**/*.nix"
+      - "!**/flake.lock"
 
 jobs:
   lint-qml:


### PR DESCRIPTION
## Summary

Skips unnecessary linting/building when only documentation, assets, VSCode, or CI/GitHub files are modified in PRs.
`paths` is used since `paths-ignore` can't re-include files via negative matching.