### PR TITLE
fix(nexus): contain wheel events in NavLocations to keep search bar fixed

### DIFF
--- a/modules/nexus/navpane/NavLocations.qml
+++ b/modules/nexus/navpane/NavLocations.qml
@@ -16,6 +16,17 @@ VerticalFadeFlickable {
     topMargin: Tokens.padding.large
     bottomMargin: Tokens.padding.large
     contentHeight: content.implicitHeight
+    // Accept wheel events when content fits inside the viewport so the
+    // event does not propagate up to Nexus / FloatingWindow and scroll the
+    // whole panel (taking the search bar off-screen with it).
+    WheelHandler {
+        onWheel: (event: WheelEvent) => {
+            if (root.contentHeight + root.topMargin + root.bottomMargin <= root.height) {
+                event.accepted = true
+            }
+        }
+    }
+
 
     TapHandler {
         onTapped: root.focus = true

--- a/modules/nexus/navpane/NavLocations.qml
+++ b/modules/nexus/navpane/NavLocations.qml
@@ -22,7 +22,7 @@ VerticalFadeFlickable {
     WheelHandler {
         onWheel: event => {
             if (root.contentHeight + root.topMargin + root.bottomMargin <= root.height) {
-                event.accepted = true
+                event.accepted = true;
             }
         }
     }

--- a/modules/nexus/navpane/NavLocations.qml
+++ b/modules/nexus/navpane/NavLocations.qml
@@ -19,6 +19,7 @@ VerticalFadeFlickable {
     // Accept wheel events when content fits inside the viewport so the
     // event does not propagate up to Nexus / FloatingWindow and scroll the
     // whole panel (taking the search bar off-screen with it).
+
     WheelHandler {
         onWheel: event => {
             if (root.contentHeight + root.topMargin + root.bottomMargin <= root.height) {

--- a/modules/nexus/navpane/NavLocations.qml
+++ b/modules/nexus/navpane/NavLocations.qml
@@ -20,7 +20,7 @@ VerticalFadeFlickable {
     // event does not propagate up to Nexus / FloatingWindow and scroll the
     // whole panel (taking the search bar off-screen with it).
     WheelHandler {
-        onWheel: (event: WheelEvent) => {
+        onWheel: event => {
             if (root.contentHeight + root.topMargin + root.bottomMargin <= root.height) {
                 event.accepted = true
             }

--- a/modules/nexus/navpane/NavLocations.qml
+++ b/modules/nexus/navpane/NavLocations.qml
@@ -27,7 +27,6 @@ VerticalFadeFlickable {
         }
     }
 
-
     TapHandler {
         onTapped: root.focus = true
     }

--- a/modules/nexus/navpane/NavLocations.qml
+++ b/modules/nexus/navpane/NavLocations.qml
@@ -28,7 +28,6 @@ VerticalFadeFlickable {
     }
 
 
-
     TapHandler {
         onTapped: root.focus = true
     }

--- a/modules/nexus/navpane/NavLocations.qml
+++ b/modules/nexus/navpane/NavLocations.qml
@@ -27,6 +27,8 @@ VerticalFadeFlickable {
         }
     }
 
+
+
     TapHandler {
         onTapped: root.focus = true
     }


### PR DESCRIPTION
## Summary

- Adds a `WheelHandler` to `NavLocations.qml` (the left navigation pane in Nexus settings) that accepts wheel events when the navigation content fits inside the viewport.
- Prevents wheel events from propagating up to `Nexus` / `FloatingWindow` and causing the entire settings panel — including the "Search settings" field — to scroll off-screen.

## Problem

When scrolling through long settings pages (e.g. Network), the left navigation sidebar and search bar move off-screen with the rest of the panel. The intended layout keeps the left nav fixed while only the right-hand content scrolls, but in practice the whole `Nexus` window moves together.

Root cause: `NavLocations` is a `VerticalFadeFlickable`. When its content is shorter than the available height, the underlying `Flickable` does not accept the wheel event, so the event propagates to the parent `Nexus` item and then to the `FloatingWindow`, moving the entire panel. The search bar is part of that panel and gets scrolled away with it.

## Fix

A `WheelHandler` on `NavLocations` accepts the wheel event when
`contentHeight + topMargin + bottomMargin <= height` — i.e. when there is nothing to scroll in the nav list. When the nav list is long enough to scroll, the `Flickable` continues to handle the wheel normally.

Single-file QML change, no layout restructuring, no behavioural change when the nav list actually scrolls.

## Testing

- Open Nexus and navigate to a long page (Network or similar). Scroll the right content area — the left nav and search bar should remain fixed and accessible.
- With the nav list short enough to fit without scrolling, wheel events on the left side no longer move the window.
- Nav items remain clickable; the search field remains reachable at all scroll positions.
- Different window sizes / screen heights: search bar stays in view.

Closes #1982
