### PR TITLE
fix(services): collect storage disks asynchronously

### DIFF
--- a/plugin/src/Caelestia/Services/CMakeLists.txt
+++ b/plugin/src/Caelestia/Services/CMakeLists.txt
@@ -22,6 +22,7 @@ qml_module(caelestia-services
         hyprdevices.cpp
         hyprextras.cpp
     LIBRARIES
+        Qt::Concurrent
         Qt::DBus
         Qt::Network
         PkgConfig::Pipewire

--- a/plugin/src/Caelestia/Services/storage.cpp
+++ b/plugin/src/Caelestia/Services/storage.cpp
@@ -5,6 +5,7 @@
 #include <qfileinfo.h>
 #include <qhash.h>
 #include <qstorageinfo.h>
+#include <qtconcurrentrun.h>
 
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
@@ -93,7 +94,12 @@ QStringList resolveByDevt(uint major, uint minor, int depth) {
 } // namespace
 
 Storage::Storage(QObject* parent)
-    : TickingService(parent) {}
+    : TickingService(parent)
+    , m_futureWatcher(new QFutureWatcher<AccumHash>(this)) {
+    QObject::connect(m_futureWatcher, &QFutureWatcher<AccumHash>::finished, this, [this] {
+        applyDisks(m_futureWatcher->result());
+    });
+}
 
 qreal Storage::percentage() const {
     qreal totalUsed = 0.0;
@@ -225,8 +231,8 @@ QHash<QByteArray, Storage::DeviceEntry> Storage::collectDevices() {
     return byDevice;
 }
 
-QHash<QString, Storage::Accum> Storage::foldToDisks(const QHash<QByteArray, DeviceEntry>& byDevice) {
-    QHash<QString, Accum> byDisk;
+Storage::AccumHash Storage::foldToDisks(const QHash<QByteArray, DeviceEntry>& byDevice) {
+    AccumHash byDisk;
 
     for (auto it = byDevice.constBegin(); it != byDevice.constEnd(); ++it) {
         const auto& e = it.value();
@@ -268,8 +274,16 @@ QHash<QString, Storage::Accum> Storage::foldToDisks(const QHash<QByteArray, Devi
 }
 
 void Storage::tick() {
+    if (m_futureWatcher->isRunning())
+        return;
+
+    m_futureWatcher->setFuture(QtConcurrent::run([] {
+        return foldToDisks(collectDevices());
+    }));
+}
+
+void Storage::applyDisks(const AccumHash& byDisk) {
     const auto prevPercentage = percentage();
-    const auto byDisk = foldToDisks(collectDevices());
 
     QHash<QString, DiskInfo*> existing;
     existing.reserve(m_disks.size());

--- a/plugin/src/Caelestia/Services/storage.hpp
+++ b/plugin/src/Caelestia/Services/storage.hpp
@@ -2,6 +2,7 @@
 
 #include <qbytearray.h>
 #include <qbytearrayview.h>
+#include <qfuturewatcher.h>
 #include <qhash.h>
 #include <qpointer.h>
 #include <qqmlintegration.h>
@@ -50,6 +51,8 @@ private:
         bool hasRoot = false;
     };
 
+    using AccumHash = QHash<QString, Accum>;
+
     // Mounts sharing a backing filesystem report identical usage, so they are deduped by source device first
     struct DeviceEntry {
         quint64 totalBytes = 0;
@@ -60,7 +63,9 @@ private:
     };
 
     [[nodiscard]] static QHash<QByteArray, DeviceEntry> collectDevices();
-    [[nodiscard]] static QHash<QString, Accum> foldToDisks(const QHash<QByteArray, DeviceEntry>& byDevice);
+    [[nodiscard]] static AccumHash foldToDisks(const QHash<QByteArray, DeviceEntry>& byDevice);
+
+    void applyDisks(const AccumHash& byDisk);
 
     [[nodiscard]] static QStringList resolveToPhysicalDisks(const QString& devicePath);
     [[nodiscard]] static bool isPseudoFs(QByteArrayView fsType);
@@ -71,6 +76,7 @@ private:
 
     QList<DiskInfo*> m_disks;
     QPointer<DiskInfo> m_manualPrimaryDisk;
+    QFutureWatcher<AccumHash>* const m_futureWatcher;
 };
 
 } // namespace caelestia::services


### PR DESCRIPTION
Closes #1873 

Storage disks were collected synchronously, which would block the UI when attempting to fetch network disks that are not reachable