### PR TITLE
feat(config)!: convert unit options to enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ For example, to automatically hide the bar on the monitor named `DP-1`:
 > - `nexus`: `networkRescanInterval`
 > - `notifs`: `actionOnClick`, `defaultExpireTimeout`, `expire`, `fullscreen`, `fullscreenExpireTimeout`
 > - `paths`: `lyricsDir`, `wallpaperDir`
-> - `services`: `audioIncrement`, `brightnessIncrement`, `defaultPlayer`, `gpuType`, `lyricsBackend`, `maxVolume`, `playerAliases`, `smartScheme`, `useFahrenheit`, `useFahrenheitPerformance`, `useTwelveHourClock`, `visualiserBars`, `weatherLocation`
+> - `services`: `audioIncrement`, `brightnessIncrement`, `defaultPlayer`, `gpuType`, `lyricsBackend`, `maxVolume`, `playerAliases`, `sensorUnits`, `smartScheme`, `useTwelveHourClock`, `visualiserBars`, `weatherLocation`, `weatherUnits`
 > - `utilities.toasts`: all except `fullscreen`
 > - `utilities.vpn`: `enabled`, `provider`, `selectedProvider`
 >
@@ -723,8 +723,8 @@ For example, to automatically hide the bar on the monitor named `DP-1`:
     },
     "services": {
         "weatherLocation": "",
-        "useFahrenheit": false,
-        "useFahrenheitPerformance": false,
+        "weatherUnits": "Celsius",
+        "sensorUnits": "Celsius",
         "useTwelveHourClock": false,
         "gpuType": "Auto",
         "visualiserBars": 60,

--- a/components/controls/MenuItem.qml
+++ b/components/controls/MenuItem.qml
@@ -6,6 +6,7 @@ QtObject {
     property string trailingIcon
     property string activeIcon: icon
     property string activeText: text
+    property var value
 
     signal clicked
 }

--- a/modules/dashboard/WeatherTab.qml
+++ b/modules/dashboard/WeatherTab.qml
@@ -192,9 +192,9 @@ Item {
                         StyledText {
                             Layout.alignment: Qt.AlignHCenter
                             text: {
-                                const min = Weather.formatTemp(forecastItem.modelData.minTempC).slice(0, -1);
-                                const max = Weather.formatTemp(forecastItem.modelData.maxTempC).slice(0, -1);
-                                return `${min} / ${max}`;
+                                const min = Weather.formatTemp(forecastItem.modelData.minTempC, true);
+                                const max = Weather.formatTemp(forecastItem.modelData.maxTempC, true);
+                                return Tr.trCtx("%1 / %2", "min/max temperature").arg(min).arg(max);
                             }
                             font: Tokens.font.body.builders.small.weight(Font.DemiBold).build()
                             color: Colours.palette.m3tertiary

--- a/modules/dashboard/performance/HeroCard.qml
+++ b/modules/dashboard/performance/HeroCard.qml
@@ -95,11 +95,7 @@ StyledRect {
             }
 
             StyledText {
-                text: {
-                    const unit = GlobalConfig.services.sensorUnits;
-                    const value = Math.ceil(Units.toTemperature(root.temperature, unit));
-                    return Units.formatTemp(value, unit);
-                }
+                text: Units.formatSensorTemp(root.temperature)
                 font: Tokens.font.body.builders.medium.build()
             }
         }

--- a/modules/dashboard/performance/HeroCard.qml
+++ b/modules/dashboard/performance/HeroCard.qml
@@ -96,9 +96,9 @@ StyledRect {
 
             StyledText {
                 text: {
-                    const useF = GlobalConfig.services.useFahrenheitPerformance;
-                    const value = Math.ceil(useF ? root.temperature * 1.8 + 32 : root.temperature);
-                    return useF ? Tr.tr("%1°F").arg(value) : Tr.tr("%1°C").arg(value);
+                    const unit = GlobalConfig.services.sensorUnits;
+                    const value = Math.ceil(Units.toTemperature(root.temperature, unit));
+                    return Units.formatTemp(value, unit);
                 }
                 font: Tokens.font.body.builders.medium.build()
             }

--- a/modules/lock/Resources.qml
+++ b/modules/lock/Resources.qml
@@ -76,10 +76,9 @@ StyledRect {
                     anchors.verticalCenterOffset: Math.round(fontInfo.pointSize * 0.04)
 
                     text: {
-                        const temp = Cpu.temperature;
-                        const useF = GlobalConfig.services.useFahrenheitPerformance;
-                        const value = Math.ceil(useF ? temp * 1.8 + 32 : temp);
-                        return useF ? Tr.tr("%1°F").arg(value) : Tr.tr("%1°C").arg(value);
+                        const unit = GlobalConfig.services.sensorUnits;
+                        const value = Math.ceil(Units.toTemperature(Cpu.temperature, unit));
+                        return Units.formatTemp(value, unit);
                     }
                     color: Cpu.temperature > 90 ? Colours.palette.m3onErrorContainer : Colours.palette.m3secondary
                     font: Tokens.font.title.builders.medium.scale(cpu.width / 112).width(50).build()

--- a/modules/lock/Resources.qml
+++ b/modules/lock/Resources.qml
@@ -75,11 +75,7 @@ StyledRect {
                     anchors.centerIn: parent
                     anchors.verticalCenterOffset: Math.round(fontInfo.pointSize * 0.04)
 
-                    text: {
-                        const unit = GlobalConfig.services.sensorUnits;
-                        const value = Math.ceil(Units.toTemperature(Cpu.temperature, unit));
-                        return Units.formatTemp(value, unit);
-                    }
+                    text: Units.formatSensorTemp(Cpu.temperature)
                     color: Cpu.temperature > 90 ? Colours.palette.m3onErrorContainer : Colours.palette.m3secondary
                     font: Tokens.font.title.builders.medium.scale(cpu.width / 112).width(50).build()
                 }

--- a/modules/lock/weather/Forecast.qml
+++ b/modules/lock/weather/Forecast.qml
@@ -75,7 +75,7 @@ StyledRect {
                         id: temp
 
                         anchors.centerIn: parent
-                        text: Weather.formatTemp(hour.cond.tempC).slice(0, -1) // Remove C/F
+                        text: Weather.formatTemp(hour.cond.tempC, true)
                         color: hour.index === 0 ? Colours.palette.m3onPrimary : Colours.palette.m3onSurface
                         font: Tokens.font.title.medium
                     }

--- a/modules/nexus/pages/LanguageAndRegion.qml
+++ b/modules/nexus/pages/LanguageAndRegion.qml
@@ -11,13 +11,19 @@ import qs.modules.nexus.common
 PageBase {
     id: root
 
-    // Temperature units (index 0 = Celsius, 1 = Fahrenheit — matches Weather.formatTemp)
+    // Temperature units (there must be one for each value of the TemperatureUnit enum)
     readonly property list<MenuItem> tempItems: [
         MenuItem {
             text: Tr.tr("°C")
+            value: TemperatureUnit.Celsius
         },
         MenuItem {
             text: Tr.tr("°F")
+            value: TemperatureUnit.Fahrenheit
+        },
+        MenuItem {
+            text: Tr.tr("K")
+            value: TemperatureUnit.Kelvin
         }
     ]
 
@@ -133,8 +139,8 @@ PageBase {
             label: Tr.tr("Temperature")
             subtext: Tr.tr("Units for weather temperatures")
             menuItems: root.tempItems
-            active: root.tempItems[GlobalConfig.services.useFahrenheit ? 1 : 0]
-            onSelected: item => GlobalConfig.services.useFahrenheit = root.tempItems.indexOf(item) === 1
+            active: root.tempItems.find(i => i.value === GlobalConfig.services.weatherUnits)
+            onSelected: item => GlobalConfig.services.weatherUnits = item.value
         }
 
         SelectRow {
@@ -142,8 +148,8 @@ PageBase {
             label: Tr.tr("System temperatures")
             subtext: Tr.tr("Units for CPU and GPU temperatures")
             menuItems: root.tempItems
-            active: root.tempItems[GlobalConfig.services.useFahrenheitPerformance ? 1 : 0]
-            onSelected: item => GlobalConfig.services.useFahrenheitPerformance = root.tempItems.indexOf(item) === 1
+            active: root.tempItems.find(i => i.value === GlobalConfig.services.sensorUnits)
+            onSelected: item => GlobalConfig.services.sensorUnits = item.value
         }
 
         // Time & date

--- a/plugin/src/Caelestia/Config/enums.hpp
+++ b/plugin/src/Caelestia/Config/enums.hpp
@@ -23,6 +23,7 @@ ENUM(BarWorkspaceCapitalisation, Preserve, Upper, Lower)
 ENUM(LyricsBackend, Auto, Local, LRCLIB, NetEase)
 ENUM(GpuType, Auto, Nvidia, Generic, None)
 ENUM(NotifsFullscreen, On, Off)
+ENUM(TemperatureUnit, Celsius, Fahrenheit, Kelvin)
 
 #undef ENUM
 

--- a/plugin/src/Caelestia/Config/serviceconfig.hpp
+++ b/plugin/src/Caelestia/Config/serviceconfig.hpp
@@ -18,11 +18,13 @@ class ServiceConfig : public settings::ObjectNode {
 
     CONFIG_GLOBAL_PROPERTY(QString, weatherLocation, QString())
     // Guess based on locale
-    CONFIG_GLOBAL_PROPERTY(bool, useFahrenheit,
+    CONFIG_GLOBAL_ENUM_PROPERTY(TemperatureUnit, weatherUnits,
         QLocale().measurementSystem() == QLocale::ImperialUSSystem ||
-            QLocale().measurementSystem() == QLocale::ImperialUKSystem)
+                QLocale().measurementSystem() == QLocale::ImperialUKSystem
+            ? TemperatureUnit::Fahrenheit
+            : TemperatureUnit::Celsius)
     // This is always false by default cause apparently even imperial system users don't use it for perf temps?
-    CONFIG_GLOBAL_PROPERTY(bool, useFahrenheitPerformance, false)
+    CONFIG_GLOBAL_ENUM_PROPERTY(TemperatureUnit, sensorUnits, TemperatureUnit::Celsius)
     // Attempt to guess based on locale
     CONFIG_GLOBAL_PROPERTY(
         bool, useTwelveHourClock, QLocale().timeFormat(QLocale::ShortFormat).toLower().contains(u"a"_s))

--- a/plugin/src/Caelestia/Config/serviceconfig.hpp
+++ b/plugin/src/Caelestia/Config/serviceconfig.hpp
@@ -23,7 +23,7 @@ class ServiceConfig : public settings::ObjectNode {
                 QLocale().measurementSystem() == QLocale::ImperialUKSystem
             ? TemperatureUnit::Fahrenheit
             : TemperatureUnit::Celsius)
-    // This is always false by default cause apparently even imperial system users don't use it for perf temps?
+    // Always Celsius by default cause apparently even imperial system users don't use Fahrenheit for perf temps?
     CONFIG_GLOBAL_ENUM_PROPERTY(TemperatureUnit, sensorUnits, TemperatureUnit::Celsius)
     // Attempt to guess based on locale
     CONFIG_GLOBAL_PROPERTY(

--- a/plugin/src/Caelestia/I18n/CMakeLists.txt
+++ b/plugin/src/Caelestia/I18n/CMakeLists.txt
@@ -47,6 +47,7 @@ qml_module(caelestia-i18n
         pluralrules.cpp
     QML_SINGLETONS
         Tr.qml
+        Units.qml
     RESOURCES
         ${mo_files}
     LIBRARIES

--- a/plugin/src/Caelestia/I18n/Units.qml
+++ b/plugin/src/Caelestia/I18n/Units.qml
@@ -25,4 +25,10 @@ QtObject {
             return Tr.trCtx("%1 K", "temperature").arg(value);
         return Tr.trCtx("%1°C", "temperature").arg(value);
     }
+
+    // Converts and formats a sensor temperature in Celsius using the configured sensor units
+    function formatSensorTemp(celsius: real): string {
+        const unit = GlobalConfig.services.sensorUnits;
+        return formatTemp(Math.round(toTemperature(celsius, unit)), unit);
+    }
 }

--- a/plugin/src/Caelestia/I18n/Units.qml
+++ b/plugin/src/Caelestia/I18n/Units.qml
@@ -1,0 +1,28 @@
+pragma Singleton
+
+import QtQuick
+import Caelestia.Config
+import Caelestia.I18n
+
+QtObject {
+    // Converts a temperature in Celsius to the given TemperatureUnit
+    function toTemperature(celsius: real, unit: int): real {
+        if (Number(unit) === TemperatureUnit.Fahrenheit)
+            return celsius * 9 / 5 + 32;
+        if (Number(unit) === TemperatureUnit.Kelvin)
+            return celsius + 273.15;
+        return celsius;
+    }
+
+    // Formats an already converted temperature with the given TemperatureUnit's suffix
+    function formatTemp(value: var, unit: int, compact = false): string {
+        if (compact)
+            return Number(unit) === TemperatureUnit.Kelvin ? String(value) : Tr.trCtx("%1°", "temperature").arg(value);
+
+        if (Number(unit) === TemperatureUnit.Fahrenheit)
+            return Tr.trCtx("%1°F", "temperature").arg(value);
+        if (Number(unit) === TemperatureUnit.Kelvin)
+            return Tr.trCtx("%1 K", "temperature").arg(value);
+        return Tr.trCtx("%1°C", "temperature").arg(value);
+    }
+}

--- a/services/Weather.qml
+++ b/services/Weather.qml
@@ -33,10 +33,10 @@ Singleton {
 
     readonly property var cachedCities: new Map()
 
-    function formatTemp(temp: var): string {
-        const useF = GlobalConfig.services.useFahrenheit;
-        const value = temp !== undefined ? Math.round(useF ? toFahrenheit(temp) : temp) : "--";
-        return useF ? Tr.tr("%1°F").arg(value) : Tr.tr("%1°C").arg(value);
+    function formatTemp(temp: var, compact = false): string {
+        const unit = GlobalConfig.services.weatherUnits;
+        const value = temp !== undefined ? Math.round(Units.toTemperature(temp, unit)) : "--";
+        return Units.formatTemp(value, unit, compact);
     }
 
     function reload(): void {
@@ -278,10 +278,6 @@ Singleton {
             }
             hourlyForecast = hourlyList;
         });
-    }
-
-    function toFahrenheit(celsius: real): real {
-        return celsius * 9 / 5 + 32;
     }
 
     function getWeatherUrl(): string {


### PR DESCRIPTION
Allows for more units than just Celcius/Fahrenheit (adds Kelvin).

> [!IMPORTANT]
> The config options `services.useFahrenheit` and `services.useFahrenHeitPerformance` have been changed to `services.weatherUnits` and `services.sensorUnits` respectively.
> Their new values are one of (case insensitive):
> - Celcius
> - Fahrenheit
> - Kelvin

Also add a Units singleton for unified unit conversions.