### PR TITLE
chore(bar)!: remove perMonitorWorkspaces option

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ For example, to automatically hide the bar on the monitor named `DP-1`:
 >
 > - `appearance`: `anim.*`, `transparency.*`
 > - `bar.tray`: `hiddenIcons`, `iconSubs`
-> - `bar.workspaces`: `ignoredTags`, `perMonitorWorkspaces`, `specialWorkspaceIcons`, `windowIcons`
+> - `bar.workspaces`: `ignoredTags`, `specialWorkspaceIcons`, `windowIcons`
 > - `dashboard`: `mediaUpdateInterval`, `resourceUpdateInterval`
 > - `general`: `apps.*`, `battery.*`, `idle.*`, `logo`
 > - `launcher`: `actionPrefix`, `actions`, `enableDangerousActions`, `favouriteApps`, `hiddenApps`, `specialPrefix`, `useFuzzy.*`, `vimKeybinds`
@@ -430,7 +430,6 @@ For example, to automatically hide the bar on the monitor named `DP-1`:
             "showWindowsOnSpecialWorkspaces": true,
             "maxWindowIcons": 5,
             "activeTrail": false,
-            "perMonitorWorkspaces": true,
             "displayType": "shapes",
             "label": "  ",
             "occupiedLabel": "󰮯",

--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -79,11 +79,11 @@ ColumnLayout {
         const ch = childAt(width / 2, y) as EntryWrapper;
         if (ch?.entryId === "workspaces" && Config.bar.scrollActions.workspaces) {
             // Workspace scroll
-            const mon = (GlobalConfig.bar.workspaces.perMonitorWorkspaces ? Hypr.monitorFor(screen) : Hypr.focusedMonitor);
+            const mon = Hypr.monitorFor(screen);
             const specialWs = mon?.lastIpcObject.specialWorkspace.name;
             if (specialWs?.length > 0)
                 Hypr.dispatch(Hypr.usingLua ? `hl.dsp.workspace.toggle_special("${specialWs.slice(8)}")` : `togglespecialworkspace ${specialWs.slice(8)}`);
-            else if (angleDelta.y < 0 || (GlobalConfig.bar.workspaces.perMonitorWorkspaces ? mon.activeWorkspace?.id : Hypr.activeWsId) > 1)
+            else if (angleDelta.y < 0 || mon.activeWorkspace?.id > 1)
                 Hypr.dispatch(Hypr.usingLua ? `hl.dsp.focus({ workspace = "r${angleDelta.y > 0 ? "-" : "+"}1" })` : `workspace r${angleDelta.y > 0 ? "-" : "+"}1`);
         } else if (y < screen.height / 2 && Config.bar.scrollActions.volume) {
             // Volume scroll on top half

--- a/modules/bar/components/workspaces/SpecialWorkspaces.qml
+++ b/modules/bar/components/workspaces/SpecialWorkspaces.qml
@@ -15,7 +15,7 @@ Item {
 
     required property ShellScreen screen
     readonly property HyprlandMonitor monitor: Hypr.monitorFor(screen)
-    readonly property string activeSpecial: (GlobalConfig.bar.workspaces.perMonitorWorkspaces ? monitor : Hypr.focusedMonitor)?.lastIpcObject.specialWorkspace?.name ?? ""
+    readonly property string activeSpecial: monitor?.lastIpcObject.specialWorkspace?.name ?? ""
 
     layer.enabled: true
     layer.effect: Mask {
@@ -99,7 +99,7 @@ Item {
         onCurrentIndexChanged: currentIndex = Qt.binding(() => model.values.findIndex(w => w.name === root.activeSpecial))
 
         model: ScriptModel {
-            values: Hypr.workspaces.values.filter(w => w.name.startsWith("special:") && (!GlobalConfig.bar.workspaces.perMonitorWorkspaces || w.monitor === root.monitor))
+            values: Hypr.workspaces.values.filter(w => w.name.startsWith("special:") && w.monitor === root.monitor)
         }
 
         preferredHighlightBegin: 0

--- a/modules/bar/components/workspaces/Workspaces.qml
+++ b/modules/bar/components/workspaces/Workspaces.qml
@@ -14,13 +14,12 @@ StyledClippingRect {
     required property ShellScreen screen
     required property bool fullscreen
 
-    readonly property bool onSpecial: (GlobalConfig.bar.workspaces.perMonitorWorkspaces ? Hypr.monitorFor(screen) : Hypr.focusedMonitor)?.lastIpcObject.specialWorkspace?.name !== ""
-    readonly property int activeWsId: GlobalConfig.bar.workspaces.perMonitorWorkspaces ? (Hypr.monitorFor(screen).activeWorkspace?.id ?? 1) : Hypr.activeWsId
-    readonly property int monitorWsId: Hypr.monitorFor(screen)?.activeWorkspace?.id ?? -1
+    readonly property bool onSpecial: Hypr.monitorFor(screen)?.lastIpcObject.specialWorkspace?.name !== ""
+    readonly property int activeWsId: Hypr.monitorFor(screen).activeWorkspace?.id ?? 1
 
     readonly property var occupied: {
         // Other monitors' workspaces count as unoccupied when hiding unoccupied
-        const mon = GlobalConfig.bar.workspaces.perMonitorWorkspaces && !Config.bar.workspaces.showUnoccupied ? Hypr.monitorFor(screen) : null;
+        const mon = !Config.bar.workspaces.showUnoccupied ? Hypr.monitorFor(screen) : null;
         const occ = {};
         for (const ws of Hypr.workspaces.values)
             occ[ws.id] = ws.lastIpcObject.windows > 0 && (!mon || ws.monitor === mon);
@@ -97,7 +96,7 @@ StyledClippingRect {
                     activeWsId: root.activeWsId
                     occupied: root.occupied
                     groupOffset: root.groupOffset
-                    shouldShow: Config.bar.workspaces.showUnoccupied || isOccupied || ws === root.activeWsId || ws === root.monitorWsId
+                    shouldShow: Config.bar.workspaces.showUnoccupied || isOccupied || ws === root.activeWsId
 
                     workspaceRepeater: workspaces
                     layoutSpacing: root.workspaceSpacing

--- a/modules/nexus/pages/panels/taskbar/BarWorkspaces.qml
+++ b/modules/nexus/pages/panels/taskbar/BarWorkspaces.qml
@@ -76,13 +76,5 @@ PageBase {
             stepSize: 1
             onMoved: v => GlobalConfig.bar.workspaces.maxWindowIcons = v
         }
-
-        ToggleRow {
-            last: true
-            text: Tr.tr("Per-monitor workspaces")
-            subtext: Tr.tr("Show each monitor's workspaces independently")
-            checked: GlobalConfig.bar.workspaces.perMonitorWorkspaces
-            onToggled: GlobalConfig.bar.workspaces.perMonitorWorkspaces = checked
-        }
     }
 }

--- a/plugin/src/Caelestia/Config/barconfig.hpp
+++ b/plugin/src/Caelestia/Config/barconfig.hpp
@@ -40,7 +40,6 @@ class BarWorkspaces : public settings::ObjectNode {
     CONFIG_PROPERTY(bool, showWindowsOnSpecialWorkspaces, true)
     CONFIG_PROPERTY(int, maxWindowIcons, 5)
     CONFIG_PROPERTY(bool, activeTrail, false)
-    CONFIG_GLOBAL_PROPERTY(bool, perMonitorWorkspaces, true)
     CONFIG_ENUM_PROPERTY(BarWorkspaceDisplay, displayType, BarWorkspaceDisplay::Shapes)
     CONFIG_PROPERTY(QString, label, u"  "_s)
     CONFIG_PROPERTY(QString, occupiedLabel, u"󰮯"_s)


### PR DESCRIPTION
It originally existed due to a bug being turned into a feature, and adds a lot of complexity to things that could otherwise be much simpler. It is being removed as it is misleading and shouldn't be used.